### PR TITLE
attach finalizer to Arf/Arb/Acb

### DIFF
--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -3,29 +3,6 @@ mutable struct arf_struct
     size::UInt          # mp_size_t
     mantissa1::UInt     # mantissa_struct of length 128
     mantissa2::UInt
-
-    function arf_struct()
-        res = new()
-        init!(res)
-        finalizer(clear!, res)
-        return res
-    end
-
-    function arf_struct(si::Int)
-        res = new()
-        ccall(@libarb(arf_init_set_si), Cvoid, (Ref{arf_struct}, Int), res, si)
-        finalizer(clear!, res)
-        return res
-    end
-
-    function arf_struct(ui::UInt)
-        res = new()
-        ccall(@libarb(arf_init_set_ui), Cvoid, (Ref{arf_struct}, Int), res, ui)
-        finalizer(clear!, res)
-        return res
-    end
-
-    # read-only access: arf_init_**_shallow (no heap allocation)
 end
 
 mutable struct arb_struct
@@ -39,12 +16,6 @@ mutable struct arb_struct
     exponent_mag::UInt  # │ fmpz
     mantissa_mag::UInt  # │ mp_limb_t
                         # └
-    function arb_struct()
-        res = new()
-        init!(res)
-        finalizer(clear!, res)
-        return res
-    end
 end
 
 mutable struct acb_struct
@@ -56,7 +27,7 @@ mutable struct acb_struct
     exp_mag_r::Int        # │ fmpz
     mantissa_mag_r::UInt  # │ mp_limb_t
                           # └
-                          # ┌ arb_struct (real)
+                          # ┌ arb_struct (imag)
     exponent_i::Int       # │ fmpz
     size_i::UInt          # │ mp_size_t
     mantissa1_i::UInt     # │ mantissa_struct of length 128
@@ -64,51 +35,11 @@ mutable struct acb_struct
     exp_mag_i::Int        # │ fmpz
     mantissa_mag_i::UInt  # │ mp_limb_t
                           # └
-
-    function acb_struct()
-        res = new()
-        init!(res)
-        finalizer(clear!, res)
-        return res
-    end
 end
 
 mutable struct mag_struct
     exponent::UInt       # fmpz
     mantissa::UInt       # mp_limb_t
-
-    function mag_struct()
-        res = new()
-        init!(res)
-        finalizer(clear!, res)
-        return res
-    end
-
-    function mag_struct(m::mag_struct)
-        res = new()
-        ccall(
-            @libarb(mag_init_set),
-            Cvoid,
-            (Ref{mag_struct}, Ref{mag_struct}),
-            res,
-            m,
-        )
-        finalizer(clear!, res)
-        return res
-    end
-
-    function mag_struct(arf::arf_struct)
-        res = new()
-        ccall(
-            @libarb(mag_init_set_arf),
-            Cvoid,
-            (Ref{mag_struct}, Ref{arf_struct}),
-            res,
-            arf,
-        )
-        finalizer(clear!, res)
-        return res
-    end
 end
 
 for prefix in (:arf, :arb, :acb, :mag)
@@ -120,70 +51,5 @@ for prefix in (:arf, :arb, :acb, :mag)
             ccall(@libarb($arb_init), Cvoid, (Ref{$arbstruct},), t)
         clear!(t::$arbstruct) =
             ccall(@libarb($arb_clear), Cvoid, (Ref{$arbstruct},), t)
-    end
-end
-
-struct arf_struct_ref
-    exponent::UInt      # fmpz
-    size::UInt          # mp_size_t
-    mantissa1::UInt     # mantissa_struct of length 128
-    mantissa2::UInt
-
-    function arf_struct_ref(arf::arf_struct)
-        return new(arf.exponent, arf.size, arf.mantissa1, arf.mantissa2)
-    end
-end
-
-struct arb_struct_ref
-    exponent::UInt      # fmpz
-    size::UInt          # mp_size_t
-    mantissa1::UInt     # mantissa_struct of length 128
-    mantissa2::UInt
-    exponent_mag::UInt  # fmpz
-    mantissa_mag::UInt  #
-
-    function arf_struct_ref(arf::arf_struct)
-        return new(
-            arf.exponent,
-            arf.size,
-            arf.mantissa1,
-            arf.mantissa2,
-            arf.exponent_mag,
-            arf.mantissa_mag,
-        )
-    end
-end
-
-struct acb_struct_ref
-    exponent_r::UInt
-    size_r::UInt
-    mantissa1_r::UInt
-    mantissa2_r::UInt
-    exp_mag_r::Int
-    mantissa_mag_r::UInt
-
-    exponent_i::Int
-    size_i::UInt
-    mantissa1_i::UInt
-    mantissa2_i::UInt
-    exp_mag_i::Int
-    mantissa_mag_i::UInt
-
-    function acb_struct_ref(acb::acb_struct)
-        return new(
-            acb.exponent_r,
-            acb.size_r,
-            acb.mantissa1_r,
-            acb.mantissa2_r,
-            acb.exponent_mag_r,
-            acb.mantissa_mag_r,
-
-            acb.exponent_i,
-            acb.size_i,
-            acb.mantissa1_i,
-            acb.mantissa2_i,
-            acb.exponent_mag_i,
-            acb.mantissa_mag_i,
-        )
     end
 end

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -1,11 +1,11 @@
-mutable struct arf_struct
+struct arf_struct
     exponent::UInt      # fmpz
     size::UInt          # mp_size_t
     mantissa1::UInt     # mantissa_struct of length 128
     mantissa2::UInt
 end
 
-mutable struct arb_struct
+struct arb_struct
                         # ┌ arf_struct (midpoint)
     exponent::UInt      # │ fmpz
     size::UInt          # │ mp_size_t
@@ -18,7 +18,7 @@ mutable struct arb_struct
                         # └
 end
 
-mutable struct acb_struct
+struct acb_struct
                           # ┌ arb_struct (real)
     exponent_r::UInt      # │ fmpz
     size_r::UInt          # │ mp_size_t
@@ -37,7 +37,7 @@ mutable struct acb_struct
                           # └
 end
 
-mutable struct mag_struct
+struct mag_struct
     exponent::UInt       # fmpz
     mantissa::UInt       # mp_limb_t
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -88,9 +88,5 @@ for (T, prefix) in ((Arf, :arf), (Arb, :arb), (Acb, :acb), (Mag, :mag))
         clear!(a::$T) = clear!(a.$prefix)
         cprefix(::Type{$T}) = Symbol($spref) # useful for metaprogramming
         cstruct(t::$T) = getfield(t, cprefix($T))
-        Base.cconvert(::Type{Ref{$T}}, t::$T) =
-            Base.cconvert(Ref{$arbstruct}, cstruct(t))
-        Base.unsafe_convert(::Type{Ref{$T}}, t::Base.RefValue{$arbstruct}) =
-            Base.unsafe_convert(Ref{$arbstruct}, t)
     end
 end


### PR DESCRIPTION
unfortunately (?) `(arf|arb|arf)_struct`s need to be mutable, otherwise one can not change their value, even from the `c`-side??

julia 1.4 is able to elide all of allocations regardless of the design:

```julia
~/.julia/dev/Arblib on  new_design ⌚ 19:23:54
$ julia-1.3.0 --project=. --color=yes ./test/runtests.jl 
Activating environment at `~/.julia/dev/Arblib/Project.toml`
[ Info: Arf creation
  24.308 ns (2 allocations: 80 bytes)
[ Info: Arf set!
  128.500 ns (2 allocations: 32 bytes)
[ Info: Arf add!
  233.949 ns (3 allocations: 48 bytes)

~/.julia/dev/Arblib on  new_design ⌚ 19:24:10
$ julia-1.4.0-rc1 --project=. --color=yes ./test/runtests.jl 
 Activating environment at `~/.julia/dev/Arblib/Project.toml`
[ Info: Arf creation
  24.817 ns (2 allocations: 80 bytes)
[ Info: Arf set!
  11.136 ns (0 allocations: 0 bytes)
[ Info: Arf add!
  49.561 ns (0 allocations: 0 bytes)

~/.julia/dev/Arblib on  new_design ⌚ 19:24:28
$ git checkout master    
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

~/.julia/dev/Arblib on  master ⌚ 19:24:35
$ julia-1.3.0 --project=. --color=yes ./test/runtests.jl    
Activating environment at `~/.julia/dev/Arblib/Project.toml`
[ Info: Arf creation
  22.928 ns (2 allocations: 80 bytes)
[ Info: Arf set!
  121.800 ns (2 allocations: 32 bytes)
[ Info: Arf add!
  222.297 ns (3 allocations: 48 bytes)

~/.julia/dev/Arblib on  master ⌚ 19:24:49
$ julia-1.4.0-rc1 --project=. --color=yes ./test/runtests.jl
 Activating environment at `~/.julia/dev/Arblib/Project.toml`
[ Info: Arf creation
  22.849 ns (2 allocations: 80 bytes)
[ Info: Arf set!
  11.153 ns (0 allocations: 0 bytes)
[ Info: Arf add!
  49.764 ns (0 allocations: 0 bytes)
```