### PR TITLE
Arbcall signatures

### DIFF
--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -8,7 +8,8 @@ const Ctypes = Dict{String, DataType}(
     "arb_t"     => Arb,
     "acb_t"     => Acb,
     "mag_t"     => Mag,
-    "arf_rnd_t" => arb_rnd
+    "arf_rnd_t" => arb_rnd,
+    "mpfr_t"    => BigFloat,
 )
 
 struct Carg{ArgT}
@@ -27,7 +28,7 @@ name(ca::Carg) = ca.name
 isconst(ca::Carg) = ca.isconst
 jltype(::Carg{ArgT}) where ArgT = ArgT
 ctype(ca::Carg) = jltype(ca)
-ctype(::Carg{ArgT}) where ArgT <: Union{Arf, Arb, Acb, Mag}  = Ref{ArgT}
+ctype(::Carg{ArgT}) where ArgT <: Union{Arf, Arb, Acb, Mag, BigFloat}  = Ref{ArgT}
 
 struct Arbfunction{ReturnT}
     fname::String

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -165,17 +165,14 @@ function jlcode(af::Arbfunction, jl_fname=jlfname(af))
 
     jl_args = [:($a::$T) for (a, T) in zip(arg_names, jl_types)]
 
-    res = first(arg_names)
-
     return :(
-        function $jl_fname($(jl_args...); $(kwargs...))
-            ccall(Arblib.@libarb($(arbfname(af))),
-            $returnT,
-            $(Expr(:tuple, c_types...)),
-            $(Symbol.(name.(args))...))
-            return $res
+        function $jl_fname($(jl_args...); $(kwargs...))::$returnT
+        ccall(Arblib.@libarb($(arbfname(af))),
+              $returnT,
+              $(Expr(:tuple, c_types...)),
+              $(Symbol.(name.(args))...))
         end
-        )
+    )
 end
 
 macro arbcall_str(str)

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -71,6 +71,26 @@ function jlfname(af::Arbfunction,
     return jlfname(arbfname(af), prefixes, suffixes, inplace=inplace)
 end
 
+function arbsignature(af::Arbfunction)
+    jltoctype = Dict(value => key for (key, value) in Ctypes)
+
+    creturnT = jltoctype[returntype(af)]
+    args = arguments(af)
+
+    arg_consts = isconst.(args)
+    arg_ctypes = [jltoctype[jltype(arg)] for arg in args]
+    arg_names = name.(args)
+
+
+    c_args = join([ifelse(isconst, "const ", "")*"$type $name" for (isconst, type, name)
+                   in zip(arg_consts, arg_ctypes, arg_names)], ", ")
+
+    c_args = join([ifelse(isconst(arg), "const ", "") *
+                   "$(jltoctype[jltype(arg)]) $(name(arg))" for arg in args], ", ")
+
+    "$creturnT $(arbfname(af))($c_args)"
+end
+
 function jlcode(af::Arbfunction, jl_fname=jlfname(af))
     returnT = returntype(af)
     args = arguments(af)

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -13,6 +13,7 @@
                                               ("const arf_t x", "x", true, Arf, Ref{Arf}),
                                               ("const arb_t x", "x", true, Arb, Ref{Arb}),
                                               ("const acb_t x", "x", true, Acb, Ref{Acb}),
+                                              ("const char * inp", "inp", true, Cstring, Cstring),
                                     )
         arg = Arblib.Carg(str)
         @test Arblib.name(arg) == name
@@ -44,7 +45,9 @@
     end
 
     # Parsed incorrectly
-    for str in ("const char * inp",
+    for str in (
+                "mp_limb_t * error",
+                "mp_bitcnt_t * Qexp",
                 )
         @test_throws KeyError arg = Arblib.Carg(str)
     end
@@ -52,8 +55,6 @@
 
     # Parse errors
     for str in (# Internal types
-                "mp_limb_t * error",
-                "mp_bitcnt_t * Qexp",
                 )
         @test_throws ArgumentError arg = Arblib.Carg(str)
     end
@@ -124,7 +125,7 @@ end
     end
 
     # Return types with parse errors
-    for str in ("char * arb_get_str(const arb_t x, slong n, ulong flags)",)
+    for str in ()
         @test_throws ArgumentError Arblib.Arbfunction(str)
     end
 end
@@ -155,6 +156,8 @@ end
                 "void arb_sin(arb_t s, const arb_t x, slong prec)",
                 "void arb_cos(arb_t c, const arb_t x, slong prec)",
                 "void arb_sin_cos(arb_t s, arb_t c, const arb_t x, slong prec)",
+                # Pointer
+                "char * arb_get_str(const arb_t x, slong n, ulong flags)",
                 )
         @test Arblib.arbsignature(Arblib.Arbfunction(str)) == str
     end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -129,6 +129,21 @@ end
     end
 end
 
+@testset "jlsignature" begin
+    for (str, signature) in (("void arb_init(arb_t x)",
+                              :(init!(x::$Arb; )::$Nothing)),
+                             ("void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)",
+                              :(add!(z::$Arb, x::$Arb, y::$Arb;
+                                     prec::Integer = precision(z))::$Nothing)),
+                             ("int arf_add(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)",
+                              :(add!(res::$Arf, x::$Arf, y::$Arf;
+                                     prec::Integer = precision(res),
+                                     rnd::Union{arb_rnd, RoundingMode} = RoundNearest)::$Int32)),
+                             )
+        @test Arblib.jlsignature(Arblib.Arbfunction(str)) == signature
+    end
+end
+
 @testset "arbsignature" begin
     for str in ("void arb_init(arb_t x)",
                 "slong arb_rel_error_bits(const arb_t x)",

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -128,3 +128,19 @@ end
         @test_throws ArgumentError Arblib.Arbfunction(str)
     end
 end
+
+@testset "arbsignature" begin
+    for str in ("void arb_init(arb_t x)",
+                "slong arb_rel_error_bits(const arb_t x)",
+                "int arb_is_zero(const arb_t x)",
+                "void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)",
+                "void arb_add_arf(arb_t z, const arb_t x, const arf_t y, slong prec)",
+                "void arb_add_ui(arb_t z, const arb_t x, ulong y, slong prec)",
+                "void arb_add_si(arb_t z, const arb_t x, slong y, slong prec)",
+                "void arb_sin(arb_t s, const arb_t x, slong prec)",
+                "void arb_cos(arb_t c, const arb_t x, slong prec)",
+                "void arb_sin_cos(arb_t s, arb_t c, const arb_t x, slong prec)",
+                )
+        @test Arblib.arbsignature(Arblib.Arbfunction(str)) == str
+    end
+end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -159,3 +159,21 @@ end
         @test Arblib.arbsignature(Arblib.Arbfunction(str)) == str
     end
 end
+
+@testset "jlcode" begin
+    x = Arb(1)
+    y = Arb(2)
+    z = Arb(0)
+
+    Arblib.@arbcall_str "void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)"
+    @test typeof(Arblib.add!(z, x, y)) == Nothing
+
+    Arblib.@arbcall_str "slong arb_rel_error_bits(const arb_t x)"
+    @test typeof(Arblib.rel_error_bits(x)) == Int64
+
+    Arblib.@arbcall_str "int arb_is_zero(const arb_t x)"
+    @test typeof(Arblib.is_zero(x)) == Int32
+
+    Arblib.@arbcall_str "double arf_get_d(const arf_t x, arf_rnd_t rnd)"
+    @test typeof(Arblib.get(Arf(1))) == Float64
+end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -130,18 +130,21 @@ end
     end
 end
 
-@testset "jlsignature" begin
-    for (str, signature) in (("void arb_init(arb_t x)",
-                              :(init!(x::$Arb; )::$Nothing)),
-                             ("void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)",
-                              :(add!(z::$Arb, x::$Arb, y::$Arb;
-                                     prec::Integer = precision(z))::$Nothing)),
-                             ("int arf_add(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)",
-                              :(add!(res::$Arf, x::$Arf, y::$Arf;
-                                     prec::Integer = precision(res),
-                                     rnd::Union{arb_rnd, RoundingMode} = RoundNearest)::$Int32)),
-                             )
-        @test Arblib.jlsignature(Arblib.Arbfunction(str)) == signature
+@testset "jlargs" begin
+    for (str, args, kwargs) in (("void arb_init(arb_t x)",
+                                 [:(x::$Arb)],
+                                 Expr[]),
+                                ("void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)",
+                                 [:(z::$Arb), :(x::$Arb), :(y::$Arb)],
+                                 [Expr(:kw, :(prec::Integer), :(precision(z)))]),
+                                ("int arf_add(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)",
+                                 [:(res::$Arf), :(x::$Arf), :(y::$Arf)],
+                                 [Expr(:kw, :(prec::Integer), :(precision(res))),
+                                  Expr(:kw, :(rnd::Union{arb_rnd, RoundingMode}), :(RoundNearest))])
+                                )
+        (a, k) = Arblib.jlargs(Arblib.Arbfunction(str))
+        @test a == args
+        @test k == kwargs
     end
 end
 


### PR DESCRIPTION
This pull request contains two rather harmless commits and one more opinionated. The first two commits adds methods for computing the signatures of `Arbfunctions`, one for Julia signature and one for the arb signature. The Julia signature is not to interesting, it mainly makes it easier to test this part separately (it's slightly different from the previously used signature, more about that later).

The arb signature is more interesting, it allows partially automatic testing of `Arbfunction`. I have used this to do some testing. I began by extracting all the functions from the documentation of arb
```sh
grep function:: doc/source/*.rst | cut -f 3- -d " " > $SOMEPATH
```
I then wrote some Julia code to parse all of these functions and compare the arb signature of the result with the original string.
```julia
function parse_arb(filename)
    open(filename) do f
        methods = Arbfunction[]
        underscoremethods = Arbfunction[]
        type_error = String[]
        parse_error = String[]
        for line in readlines(f)
            try
                f = Arbfunction(line)

                if(line != arbsignature(f))
                    println(line)
                    println(arbsignature(f))
                end

                if startswith(string(jlfname(f)), "_")
                    push!(underscoremethods, f)

                else
                    push!(methods, f)
                end
            catch e
                if e isa KeyError
                    push!(type_error, line)
                elseif e isa ArgumentError
                    push!(parse_error, line)
                else
                    rethrow(e)
                end
            end
        end

        println("$(length(methods)) correctly parsed methods")
        println("$(length(underscoremethods)) correctly parsed underscore methods")

        println("$(length(type_error)) methods that were not parsed due to unsupported type")
        println("$(length(parse_error)) methods for which parsing failed")

        (methods, underscoremethods, type_error, parse_error)
    end
end
```
Running it on the above generated file give
```
julia> (m, u, t, p) = Arblib.parse_arb("allall.txt");
752 correctly parsed methods
6 correctly parsed underscore methods
1397 methods that were not parsed due to unsupported type
68 methods for which parsing failed
```
This was done using the master branch of arb (the last commit fixes a typo in the documentation). I have not included code for this in the commits, mainly because I was not sure how to handle the arb documentation files in a good way. Most of the fails are due to unsupported types, this will be fixed as more types are added (for example polynomials and matrices). The methods for which the parsing fails all contain pointers, for example `int acb_mat_lu_classical(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)`. There is one exception, but this is just a typo in the documentation (I'll probably submit a pull request to arb for this).

Finally to the opinionated commit. Previously the code generated by `jlcode` always returned the first argument. This follows the Julia default for in-place methods but doesn't work well for other types of methods. For example it doesn't make sense for predicates, where the return value is the important part. You could consider returning the first argument for void functions, however this will be inconsistent due to the fact that the `arf` functions return an `int` and the `arb` functions return `void`. You could also consider returning the first argument for all in-place methods, but it might be that some of them have return values which are important (I have not checked).

The change I made know makes the methods always return the return value from arb. I would say this is the safest choice, no information is lost, but it goes against the Julia default. It's also nice because the signature of the Julia and arb versions then match. I don't know what the best choice is.

