### PR TITLE
relax jltypes

### DIFF
--- a/src/arb.jl
+++ b/src/arb.jl
@@ -1,9 +1,9 @@
-@libcall arb_mul_2exp_si 2
-@libcall arb_one 1
-@libcall arb_pow_ui 2 prec=true
-@libcall arb_fac_ui 1 prec=true
-@libcall arb_div 3 prec=true
-@libcall arb_abs 2 prec=true
-@libcall arb_add_error 2
-@libcall arb_add 3 prec=true
-@libcall arb_sub 3 prec=true
+arbcall"void arb_mul_2exp_si(arb_t y, const arb_t x, slong e)"
+arbcall"void arb_one(arb_t f)"
+arbcall"void arb_pow_ui(arb_t y, const arb_t b, ulong e, slong prec)"
+arbcall"void arb_fac_ui(arb_t z, ulong n, slong prec)"
+arbcall"void arb_div(arb_t z, const arb_t x, const arb_t y, slong prec)"
+arbcall"void arb_abs(arb_t y, const arb_t x)"
+arbcall"void arb_add_error(arb_t x, const arb_t err)"
+arbcall"void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)"
+arbcall"void arb_sub(arb_t z, const arb_t x, const arb_t y, slong prec)"

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -28,9 +28,16 @@ end
 
 name(ca::Carg) = ca.name
 isconst(ca::Carg) = ca.isconst
-jltype(::Carg{ArgT}) where ArgT = ArgT
-ctype(ca::Carg) = jltype(ca)
-ctype(::Carg{ArgT}) where ArgT <: Union{Arf, Arb, Acb, Mag, BigFloat}  = Ref{ArgT}
+
+rawtype(::Carg{T}) where T = T
+
+jltype(ca::Carg) = rawtype(ca)
+jltype(::Carg{<:AbstractFloat}) = AbstractFloat
+jltype(::Carg{<:Integer}) = Integer
+jltype(::Carg{Cstring}) = AbstractString
+
+ctype(ca::Carg) = rawtype(ca)
+ctype(::Carg{T}) where T <: Union{Arf, Arb, Acb, Mag, BigFloat}  = Ref{T}
 ctype(::Carg{Vector{T}}) where T = Ref{T}
 
 struct Arbfunction{ReturnT}
@@ -84,7 +91,7 @@ function jlargs(af::Arbfunction)
 
     k = findfirst(==(:prec), arg_names)
     if !isnothing(k)
-        @assert jl_types[k] == Int64
+        @assert jl_types[k] == Integer
         p = :prec
         a = first(cargs)
         default = if jltype(a) ∈ (Arf, Arb, Acb)
@@ -118,15 +125,12 @@ function arbsignature(af::Arbfunction)
     args = arguments(af)
 
     arg_consts = isconst.(args)
-    arg_ctypes = [jltoctype[jltype(arg)] for arg in args]
+    arg_ctypes = [jltoctype[rawtype(arg)] for arg in args]
     arg_names = name.(args)
 
 
     c_args = join([ifelse(isconst, "const ", "")*"$type $name" for (isconst, type, name)
                    in zip(arg_consts, arg_ctypes, arg_names)], ", ")
-
-    c_args = join([ifelse(isconst(arg), "const ", "") *
-                   "$(jltoctype[jltype(arg)]) $(name(arg))" for arg in args], ", ")
 
     "$creturnT $(arbfname(af))($c_args)"
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -36,7 +36,7 @@ mutable struct Acb <: Number
     prec::Int
 
     function Acb(;prec::Integer=DEFAULT_PRECISION[])
-        res = new(arb_struct(0,0,0,0, 0,0,0,0), prec)
+        res = new(acb_struct(0,0,0,0,0,0, 0,0,0,0,0,0), prec)
         init!(res)
         finalizer(clear!, res)
         return res

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -1,20 +1,20 @@
 @testset "Carg" begin
     # Supported types
     for (str, name, isconst, jltype, ctype) in (("mag_t res", "res", false, Arblib.Mag, Ref{Arblib.Mag}),
-                                              ("arf_t res", "res", false, Arf, Ref{Arf}),
-                                              ("arb_t res", "res", false, Arb, Ref{Arb}),
-                                              ("acb_t res", "res", false, Acb, Ref{Acb}),
-                                              ("int flags", "flags", false, Integer, Cint),
-                                              ("slong x", "x", false, Integer, Clong),
-                                              ("ulong x", "x", false, Integer, Culong),
-                                              ("double x", "x", false, AbstractFloat, Cdouble),
-                                              ("arf_rnd_t rnd", "rnd", false, Arblib.arb_rnd, Arblib.arb_rnd),
-                                              ("const mag_t x", "x", true, Arblib.Mag, Ref{Arblib.Mag}),
-                                              ("const arf_t x", "x", true, Arf, Ref{Arf}),
-                                              ("const arb_t x", "x", true, Arb, Ref{Arb}),
-                                              ("const acb_t x", "x", true, Acb, Ref{Acb}),
-                                              ("const char * inp", "inp", true, AbstractString, Cstring),
-                                    )
+        ("arf_t res", "res", false, Arf, Ref{Arf}),
+        ("arb_t res", "res", false, Arb, Ref{Arb}),
+        ("acb_t res", "res", false, Acb, Ref{Acb}),
+        ("int flags", "flags", false, Integer, Cint),
+        ("slong x", "x", false, Integer, Clong),
+        ("ulong x", "x", false, Unsigned, Culong),
+        ("double x", "x", false, Base.GMP.CdoubleMax, Cdouble),
+        ("arf_rnd_t rnd", "rnd", false, Union{Arblib.arb_rnd, RoundingMode}, Arblib.arb_rnd),
+        ("const mag_t x", "x", true, Arblib.Mag, Ref{Arblib.Mag}),
+        ("const arf_t x", "x", true, Arf, Ref{Arf}),
+        ("const arb_t x", "x", true, Arb, Ref{Arb}),
+        ("const acb_t x", "x", true, Acb, Ref{Acb}),
+        ("const char * inp", "inp", true, Cstring, Cstring),
+    )
         arg = Arblib.Carg(str)
         @test Arblib.name(arg) == name
         @test Arblib.isconst(arg) == isconst

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -1,24 +1,24 @@
 @testset "Carg" begin
     # Supported types
-    for (str, name, isconst, type, ctype) in (("mag_t res", "res", false, Arblib.Mag, Ref{Arblib.Mag}),
+    for (str, name, isconst, jltype, ctype) in (("mag_t res", "res", false, Arblib.Mag, Ref{Arblib.Mag}),
                                               ("arf_t res", "res", false, Arf, Ref{Arf}),
                                               ("arb_t res", "res", false, Arb, Ref{Arb}),
                                               ("acb_t res", "res", false, Acb, Ref{Acb}),
-                                              ("int flags", "flags", false, Cint, Cint),
-                                              ("slong x", "x", false, Clong, Clong),
-                                              ("ulong x", "x", false, Culong, Culong),
-                                              ("double x", "x", false, Cdouble, Cdouble),
+                                              ("int flags", "flags", false, Integer, Cint),
+                                              ("slong x", "x", false, Integer, Clong),
+                                              ("ulong x", "x", false, Integer, Culong),
+                                              ("double x", "x", false, AbstractFloat, Cdouble),
                                               ("arf_rnd_t rnd", "rnd", false, Arblib.arb_rnd, Arblib.arb_rnd),
                                               ("const mag_t x", "x", true, Arblib.Mag, Ref{Arblib.Mag}),
                                               ("const arf_t x", "x", true, Arf, Ref{Arf}),
                                               ("const arb_t x", "x", true, Arb, Ref{Arb}),
                                               ("const acb_t x", "x", true, Acb, Ref{Acb}),
-                                              ("const char * inp", "inp", true, Cstring, Cstring),
+                                              ("const char * inp", "inp", true, AbstractString, Cstring),
                                     )
         arg = Arblib.Carg(str)
         @test Arblib.name(arg) == name
         @test Arblib.isconst(arg) == isconst
-        @test Arblib.jltype(arg) == type
+        @test Arblib.jltype(arg) == jltype
         @test Arblib.ctype(arg) == ctype
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ end
             # @show tol
             k = 0
             while true
-                Arblib.pow!(t, x, 2k + 1)
+                Arblib.pow!(t, x, UInt(2k + 1))
                 Arblib.fac!(u, UInt(2k + 1))
                 Arblib.div!(t, t, u)
                 Arblib.abs!(u, t)


### PR DESCRIPTION
consider (old behaviour)
```julia
julia> af = Arblib.Arbfunction("void arb_pow_ui(arb_t y, const arb_t b, ulong e, slong prec)")
Arblib.Arbfunction{Nothing}("arb_pow_ui", Arblib.Carg[Arblib.Carg{Arb}("y", false), Arblib.Carg{Arb}("b", true), Arblib.Carg{UInt64}("e", false), Arblib.Carg{Int64}("prec", false)])

julia> Arblib.jlcode(af)
:(function pow!(y::Arb, b::Arb, e::UInt64; prec::Integer = precision(y))
      #= /home/kalmar/.julia/dev/Arblib/src/arbcall.jl:141 =#
      ccall(#= /home/kalmar/.julia/dev/Arblib/src/arbcall.jl:141 =# Arblib.@libarb("arb_pow_ui"), Nothing, (Ref{Arb}, Ref{Arb}, UInt64, Int64), y, b, e, prec)
  end)
```
this defines `pow!` that needs `UInt64` exponent;
however `ccall` calls `Base.cconvert(UInt64, e)` internally, which will result with the correct thing for any `e` that converts to `UInt64`.

I suggest that we relax signatures in `jlargs` (new behaviour):
```julia
julia> af = Arblib.Arbfunction("void arb_pow_ui(arb_t y, const arb_t b, ulong e, slong prec)")
Arblib.Arbfunction{Nothing}("arb_pow_ui", Arblib.Carg[Arblib.Carg{Arb}("y", false), Arblib.Carg{Arb}("b", true), Arblib.Carg{UInt64}("e", false), Arblib.Carg{Int64}("prec", false)])

julia> Arblib.jlcode(af)
:(function pow!(y::Arb, b::Arb, e::Integer; prec::Integer = precision(y))
      #= /home/kalmar/.julia/dev/Arblib/src/arbcall.jl:144 =#
      ccall(#= /home/kalmar/.julia/dev/Arblib/src/arbcall.jl:144 =# Arblib.@libarb("arb_pow_ui"), Nothing, (Ref{Arb}, Ref{Arb}, UInt64, Int64), y, b, e, prec)
  end)

julia> x = Arb();

julia> Arblib.pow!(x, Arb(2.0), big(3))

julia> x
8.0000000000000000000000000000000000000000000000000000000000000000000000000000
```
