### PR TITLE
Arbcall structs

### DIFF
--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -1,16 +1,16 @@
-struct mag_struct
+mutable struct mag_struct
     exponent::UInt       # fmpz
     mantissa::UInt       # mp_limb_t
 end
 
-struct arf_struct
+mutable struct arf_struct
     exponent::UInt      # fmpz
     size::UInt          # mp_size_t
     mantissa1::UInt     # mantissa_struct of length 128
     mantissa2::UInt
 end
 
-struct arb_struct
+mutable struct arb_struct
                         # ┌ arf_struct (midpoint)
     exponent::UInt      # │ fmpz
     size::UInt          # │ mp_size_t
@@ -23,7 +23,7 @@ struct arb_struct
                         # └
 end
 
-struct acb_struct
+mutable struct acb_struct
                           # ┌ arb_struct (real)
     exponent_r::UInt      # │ fmpz
     size_r::UInt          # │ mp_size_t

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -1,13 +1,41 @@
-mutable struct mag_struct
-    exponent::UInt       # fmpz
-    mantissa::UInt       # mp_limb_t
-end
-
 mutable struct arf_struct
     exponent::UInt      # fmpz
     size::UInt          # mp_size_t
     mantissa1::UInt     # mantissa_struct of length 128
     mantissa2::UInt
+
+    function arf_struct()
+        res = new()
+        init!(res)
+        finalizer(clear!, res)
+        return res
+    end
+
+    function arf_struct(x::Union{UInt, Int})
+        res = new()
+        init_set!(res, x)
+        finalizer(clear!, res)
+        return res
+    end
+end
+
+mutable struct mag_struct
+    exponent::UInt       # fmpz
+    mantissa::UInt       # mp_limb_t
+
+    function mag_struct()
+        res = new()
+        init!(res)
+        finalizer(clear!, res)
+        return res
+    end
+
+    function mag_struct(x::Union{mag_struct, arf_struct})
+        res = new()
+        init_set!(res, x)
+        finalizer(clear!, res)
+        return res
+    end
 end
 
 mutable struct arb_struct
@@ -21,6 +49,13 @@ mutable struct arb_struct
     exponent_mag::UInt  # │ fmpz
     mantissa_mag::UInt  # │ mp_limb_t
                         # └
+
+    function arb_struct()
+        res = new()
+        init!(res)
+        finalizer(clear!, res)
+        return res
+    end
 end
 
 mutable struct acb_struct
@@ -40,4 +75,10 @@ mutable struct acb_struct
     exp_mag_i::Int        # │ fmpz
     mantissa_mag_i::UInt  # │ mp_limb_t
                           # └
+    function acb_struct()
+        res = new()
+        init!(res)
+        finalizer(clear!, res)
+        return res
+    end
 end

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -41,15 +41,3 @@ mutable struct acb_struct
     mantissa_mag_i::UInt  # │ mp_limb_t
                           # └
 end
-
-for prefix in (:arf, :arb, :acb, :mag)
-    arbstruct = Symbol(prefix, :_struct)
-    arb_init = Symbol(prefix, :_init)
-    arb_clear = Symbol(prefix, :_clear)
-    @eval begin
-        init!(t::$arbstruct) =
-            ccall(@libarb($arb_init), Cvoid, (Ref{$arbstruct},), t)
-        clear!(t::$arbstruct) =
-            ccall(@libarb($arb_clear), Cvoid, (Ref{$arbstruct},), t)
-    end
-end

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -79,7 +79,8 @@ jltype(ca::Carg{Vector{Clong}}) = Vector{<:Integer}
 jltype(ca::Carg{Vector{Culong}}) = Vector{<:Unsigned}
 
 ctype(ca::Carg) = rawtype(ca)
-ctype(::Carg{T}) where T <: Union{Arf, Arb, Acb, Mag, BigFloat, BigInt}  = Ref{T}
+ctype(::Carg{T}) where T <: Union{Mag, Arf, Arb, Acb}  = Ref{cstructtype(T)}
+ctype(::Carg{T}) where T <: Union{BigFloat, BigInt}  = Ref{T}
 ctype(::Carg{Vector{T}}) where T = Ref{T}
 
 struct Arbfunction{ReturnT}

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -77,6 +77,7 @@ jltype(ca::Carg{Base.MPFR.MPFRRoundingMode}) = Union{Base.MPFR.MPFRRoundingMode,
 jltype(ca::Carg{Cstring}) = AbstractString
 jltype(ca::Carg{Vector{Clong}}) = Vector{<:Integer}
 jltype(ca::Carg{Vector{Culong}}) = Vector{<:Unsigned}
+jltype(::Carg{T}) where {T <: Union{Mag, Arf, Arb, Acb}}  = Union{T, cstructtype(T), Ptr{cstructtype(T)}}
 
 ctype(ca::Carg) = rawtype(ca)
 ctype(::Carg{T}) where T <: Union{Mag, Arf, Arb, Acb}  = Ref{cstructtype(T)}
@@ -138,7 +139,11 @@ function jlargs(af::Arbfunction)
         @assert c_types[k] == Clong
         p = :prec
         a = first(cargs)
-        default = if jltype(a) ∈ (Arf, Arb, Acb)
+        default = if jltype(a) ∈ (
+            Union{Arf, arf_struct, Ptr{arf_struct}},
+            Union{Arb, arb_struct, Ptr{arb_struct}},
+            Union{Acb, acb_struct, Ptr{acb_struct}},
+        )
             :(precision($(Symbol(name(a)))))
         else
             :(DEFAULT_PRECISION[])

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -20,14 +20,16 @@ for T in (Unsigned, Integer, Base.GMP.CdoubleMax, Mag)
     end
 end
 
-for T in (BigFloat, Arf)
-    @eval begin
-        function Arf(x::$T; prec::Integer=precision(x))
-            res = Arf(prec=prec)
-            set!(res, x)
-            return res
-        end
-    end
+function Arf(x::BigFloat; prec::Integer=precision(x))
+    res = Arf(prec=prec)
+    set!(res, x)
+    return res
+end
+
+function Arf(x::Arf;
+             prec::Integer=precision(x),
+             shallow::Bool = false)
+    return Arf(x.arf, prec = prec, shallow = shallow)
 end
 
 ## Arb
@@ -41,14 +43,16 @@ for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
     end
 end
 
-for T in (Arf, Arb)
-    @eval begin
-        function Arb(x::$T; prec::Integer=precision(x))
-            res = Arb(prec=prec)
-            set!(res, x)
-            return res
-        end
-    end
+function Arb(x::Arf; prec::Integer=precision(x))
+    res = Arb(prec=prec)
+    set!(res, x)
+    return res
+end
+
+function Arb(x::Arb;
+             prec::Integer=precision(x),
+             shallow::Bool = false)
+    return Arb(x.arb, prec = prec, shallow = shallow)
 end
 
 function Arb(str::AbstractString; prec::Integer=DEFAULT_PRECISION[])
@@ -69,14 +73,16 @@ for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
     end
 end
 
-for T in (Arb, Acb)
-    @eval begin
-        function Acb(x::$T; prec::Integer=precision(x))
-            res = Acb(prec=prec)
-            set!(res, x)
-            return res
-        end
-    end
+function Acb(x::Arb; prec::Integer=precision(x))
+    res = Acb(prec=prec)
+    set!(res, x)
+    return res
+end
+
+function Acb(x::Acb;
+             prec::Integer=precision(x),
+             shallow::Bool = false)
+    return Acb(x.acb, prec = prec, shallow = shallow)
 end
 
 for T in (Integer, Base.GMP.CdoubleMax)

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -1,10 +1,16 @@
 const DEFAULT_PRECISION = Ref{Clong}(256)
 
 """
-    precision(<:Union{Arf,Arb,Acb})
+    precision(<:Union{Arf, Arb, Acb, arf_struct, arb_struct, acb_struct})
+    precision(<:Ptr{<:Union{arf_struct, arb_struct, acb_struct}})
+    precision(x::Union{arf_struct, arb_struct, acb_struct})
+    precision(x::Ptr{<:Union{arf_struct, arb_struct, acb_struct}})
 Get the default precision (in bits) currently used for `Arblib` arithmetic.
 """
-Base.precision(::Type{<:Union{Arf,Arb,Acb}}) = DEFAULT_PRECISION[]
+Base.precision(::Type{<:Union{Arf, Arb, Acb, arf_struct, arb_struct, acb_struct}}) = DEFAULT_PRECISION[]
+Base.precision(::Type{<:Ptr{<:Union{arf_struct, arb_struct, acb_struct}}}) = DEFAULT_PRECISION[]
+Base.precision(x::Union{arf_struct, arb_struct, acb_struct}) = DEFAULT_PRECISION[]
+Base.precision(x::Ptr{<:Union{arf_struct, arb_struct, acb_struct}}) = DEFAULT_PRECISION[]
 
 """
     setprecision(::Type{<:Union{Arf, Arb, Acb}}, precision::Int)

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -9,8 +9,11 @@ Get the default precision (in bits) currently used for `Arblib` arithmetic.
 """
 Base.precision(::Type{<:Union{Arf, Arb, Acb, arf_struct, arb_struct, acb_struct}}) = DEFAULT_PRECISION[]
 Base.precision(::Type{<:Ptr{<:Union{arf_struct, arb_struct, acb_struct}}}) = DEFAULT_PRECISION[]
+
 Base.precision(x::Union{arf_struct, arb_struct, acb_struct}) = DEFAULT_PRECISION[]
 Base.precision(x::Ptr{<:Union{arf_struct, arb_struct, acb_struct}}) = DEFAULT_PRECISION[]
+
+Base.precision(x::Union{Arf, Arb, Acb}) = x.prec
 
 """
     setprecision(::Type{<:Union{Arf, Arb, Acb}}, precision::Int)
@@ -26,4 +29,10 @@ function Base.setprecision(::Type{<:Union{Arf,Arb,Acb}}, precision::Integer)
     end
     DEFAULT_PRECISION[] = precision
     return precision
+end
+
+function Base.setprecision(x::T,
+                           precision::Integer;
+                           shallow = false) where {T <: Union{Arf, Arb, Acb}}
+    return T(x, prec = precision, shallow = shallow)
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -13,7 +13,7 @@ for ArbT in (Mag, Arf, Arb, Acb)
             original_stdout = stdout
             out_rd, out_wr = redirect_stdout()
             try
-                ccall(@libarb($arbf), Cvoid, (Ref{$ArbT},), x)
+                ccall(@libarb($arbf), Cvoid, (Ref{$(cstructtype(ArbT))},), x)
                 Libc.flush_cstdio()
             finally
                 redirect_stdout(original_stdout)

--- a/src/types.jl
+++ b/src/types.jl
@@ -73,11 +73,6 @@ mutable struct Acb <: Number
     end
 end
 
-cprefix(::Type{Mag}) = :mag
-cprefix(::Type{Arf}) = :arf
-cprefix(::Type{Arb}) = :arb
-cprefix(::Type{Acb}) = :acb
-
 for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
     arbstruct = Symbol(prefix, :_struct)
     spref = "$prefix"
@@ -85,6 +80,7 @@ for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
         cstructtype(::Type{$T}) = $arbstruct
     end
     @eval begin
+        cprefix(::Type{$T}) = $(QuoteNode(Symbol(prefix)))
         cstruct(x::$T) = getfield(x, cprefix($T))
         Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,23 +3,12 @@ mutable struct Arf <: Real
     prec::Int
 
     function Arf(;prec::Integer=DEFAULT_PRECISION[])
-        res = new(arf_struct(0,0,0,0), prec)
-        init!(res)
-        finalizer(clear!, res)
+        res = new(arf_struct(), prec)
         return res
     end
 
-    function Arf(ui::UInt64; prec::Integer=DEFAULT_PRECISION[])
-        res = new(arf_struct(0,0,0,0), prec)
-        init_set!(res, ui)
-        finalizer(clear!, res)
-        return res
-    end
-
-    function Arf(si::Int64; prec::Integer=DEFAULT_PRECISION[])
-        res = new(arf_struct(0,0,0,0), prec)
-        init_set!(res, si)
-        finalizer(clear!, res)
+    function Arf(x::Union{UInt, Int}; prec::Integer=DEFAULT_PRECISION[])
+        res = new(arf_struct(x), prec)
         return res
     end
 end
@@ -28,23 +17,12 @@ mutable struct Mag <: Real
     mag::mag_struct
 
     function Mag()
-        res = new(mag_struct(0,0))
-        init!(res)
-        finalizer(clear!, res)
+        res = new(mag_struct())
         return res
     end
 
-    function Mag(m::Mag)
-        res = new(mag_struct(0,0))
-        init_set!(res, m)
-        finalizer(clear!, res)
-        return res
-    end
-
-    function Mag(arf::Arf)
-        res = new(mag_struct(0,0))
-        init_set!(res, arf)
-        finalizer(clear!, res)
+    function Mag(x::Union{Mag, Arf})
+        res = new(mag_struct(cstruct(x)))
         return res
     end
 end
@@ -54,9 +32,7 @@ mutable struct Arb <: Real
     prec::Int
 
     function Arb(;prec::Integer=DEFAULT_PRECISION[])
-        res = new(arb_struct(0,0,0,0, 0,0), prec)
-        init!(res)
-        finalizer(clear!, res)
+        res = new(arb_struct(), prec)
         return res
     end
 end
@@ -66,9 +42,7 @@ mutable struct Acb <: Number
     prec::Int
 
     function Acb(;prec::Integer=DEFAULT_PRECISION[])
-        res = new(acb_struct(0,0,0,0,0,0, 0,0,0,0,0,0), prec)
-        init!(res)
-        finalizer(clear!, res)
+        res = new(acb_struct(), prec)
         return res
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -73,6 +73,11 @@ mutable struct Acb <: Number
     end
 end
 
+cprefix(::Type{Mag}) = :mag
+cprefix(::Type{Arf}) = :arf
+cprefix(::Type{Arb}) = :arb
+cprefix(::Type{Acb}) = :acb
+
 for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
     arbstruct = Symbol(prefix, :_struct)
     spref = "$prefix"
@@ -80,7 +85,6 @@ for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
         cstructtype(::Type{$T}) = $arbstruct
     end
     @eval begin
-        cprefix(::Type{$T}) = Symbol($spref)
         cstruct(x::$T) = getfield(x, cprefix($T))
         Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,6 +7,19 @@ mutable struct Arf <: Real
         return res
     end
 
+    function Arf(x::arf_struct;
+                 prec::Integer=DEFAULT_PRECISION[],
+                 shallow::Bool = false)
+        if shallow
+            res = new(x, prec)
+        else
+            res = Arf(prec = prec)
+            set!(res, x)
+        end
+
+        return res
+    end
+
     function Arf(x::Union{UInt, Int}; prec::Integer=DEFAULT_PRECISION[])
         res = new(arf_struct(x), prec)
         return res
@@ -18,6 +31,17 @@ mutable struct Mag <: Real
 
     function Mag()
         res = new(mag_struct())
+        return res
+    end
+
+    function Mag(x::mag_struct;
+                 shallow::Bool = false)
+        if shallow
+            res = new(x)
+        else
+            res = new(mag_struct(x))
+        end
+
         return res
     end
 
@@ -35,6 +59,19 @@ mutable struct Arb <: Real
         res = new(arb_struct(), prec)
         return res
     end
+
+    function Arb(x::arb_struct;
+                 prec::Integer=DEFAULT_PRECISION[],
+                 shallow::Bool = false)
+        if shallow
+            res = new(x, prec)
+        else
+            res = Arb(prec = prec)
+            set!(res, x)
+        end
+
+        return res
+    end
 end
 
 mutable struct Acb <: Number
@@ -43,6 +80,19 @@ mutable struct Acb <: Number
 
     function Acb(;prec::Integer=DEFAULT_PRECISION[])
         res = new(acb_struct(), prec)
+        return res
+    end
+
+    function Acb(x::acb_struct;
+                 prec::Integer=DEFAULT_PRECISION[],
+                 shallow::Bool = false)
+        if shallow
+            res = new(x, prec)
+        else
+            res = Acb(prec = prec)
+            set!(res, x)
+        end
+
         return res
     end
 end
@@ -57,9 +107,5 @@ for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
         cprefix(::Type{$T}) = $(QuoteNode(Symbol(prefix)))
         cstruct(x::$T) = getfield(x, cprefix($T))
         Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
-    end
-    T == Mag && continue
-    @eval begin
-        Base.precision(x::$T) = x.prec
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-mutable struct Arf <: Real
+struct Arf <: Real
     arf::arf_struct
     prec::Int
 
@@ -26,7 +26,7 @@ mutable struct Arf <: Real
     end
 end
 
-mutable struct Mag <: Real
+struct Mag <: Real
     mag::mag_struct
 
     function Mag()
@@ -51,7 +51,7 @@ mutable struct Mag <: Real
     end
 end
 
-mutable struct Arb <: Real
+struct Arb <: Real
     arb::arb_struct
     prec::Int
 
@@ -74,7 +74,7 @@ mutable struct Arb <: Real
     end
 end
 
-mutable struct Acb <: Number
+struct Acb <: Number
     acb::acb_struct
     prec::Int
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -77,8 +77,12 @@ for (T, prefix) in ((Mag, :mag), (Arf, :arf), (Arb, :arb), (Acb, :acb))
     arbstruct = Symbol(prefix, :_struct)
     spref = "$prefix"
     @eval begin
-        cprefix(::Type{$T}) = Symbol($spref) # useful for metaprogramming
-        cstruct(t::$T) = getfield(t, cprefix($T))
+        cstructtype(::Type{$T}) = $arbstruct
+    end
+    @eval begin
+        cprefix(::Type{$T}) = Symbol($spref)
+        cstruct(x::$T) = getfield(x, cprefix($T))
+        Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
     end
     T == Mag && continue
     @eval begin

--- a/test/arb_types-test.jl
+++ b/test/arb_types-test.jl
@@ -1,16 +1,8 @@
 @testset "arb_types" begin
-    mag = Arblib.mag_struct(0,0)
-    arf = Arblib.arf_struct(0,0,0,0)
-    arb = Arblib.arb_struct(0,0,0,0,0,0)
-    acb = Arblib.acb_struct(0,0,0,0,0,0, 0,0,0,0,0,0)
-
-    for x in (mag, arf, arb, acb)
-        @test begin
-            Arblib.init!(x)
-            Arblib.clear!(x)
-            true
-        end
-    end
+    mag = Arblib.mag_struct()
+    arf = Arblib.arf_struct()
+    arb = Arblib.arb_struct()
+    acb = Arblib.acb_struct()
 
     prec = 256
     for x in (arf, arb, acb)

--- a/test/arb_types-test.jl
+++ b/test/arb_types-test.jl
@@ -3,10 +3,6 @@
     arf = Arblib.arf_struct(0,0,0,0)
     arb = Arblib.arb_struct(0,0,0,0,0,0)
     acb = Arblib.acb_struct(0,0,0,0,0,0, 0,0,0,0,0,0)
-    @test typeof(mag) == Arblib.mag_struct
-    @test typeof(arf) == Arblib.arf_struct
-    @test typeof(arb) == Arblib.arb_struct
-    @test typeof(acb) == Arblib.acb_struct
 
     for x in (mag, arf, arb, acb)
         @test begin
@@ -14,5 +10,13 @@
             Arblib.clear!(x)
             true
         end
+    end
+
+    prec = 256
+    for x in (arf, arb, acb)
+        @test precision(x) == prec
+        @test precision(Ptr{typeof(x)}()) == prec
+        @test precision(typeof(x)) == prec
+        @test precision(Ptr{typeof(x)}) == prec
     end
 end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -1,15 +1,20 @@
 @testset "arbcall" begin
+    mag_struct = Arblib.mag_struct
+    arf_struct = Arblib.arf_struct
+    arb_struct = Arblib.arb_struct
+    acb_struct = Arblib.acb_struct
+
     @testset "Carg" begin
         # Supported types
         for (str, name, isconst, jltype, ctype) in (
-            ("mag_t res", "res", false, Arblib.Mag, Ref{Arblib.Mag}),
-            ("arf_t res", "res", false, Arf, Ref{Arf}),
-            ("arb_t res", "res", false, Arb, Ref{Arb}),
-            ("acb_t res", "res", false, Acb, Ref{Acb}),
-            ("const mag_t x", "x", true, Arblib.Mag, Ref{Arblib.Mag}),
-            ("const arf_t x", "x", true, Arf, Ref{Arf}),
-            ("const arb_t x", "x", true, Arb, Ref{Arb}),
-            ("const acb_t x", "x", true, Acb, Ref{Acb}),
+            ("mag_t res", "res", false, Arblib.Mag, Ref{mag_struct}),
+            ("arf_t res", "res", false, Arf, Ref{arf_struct}),
+            ("arb_t res", "res", false, Arb, Ref{arb_struct}),
+            ("acb_t res", "res", false, Acb, Ref{acb_struct}),
+            ("const mag_t x", "x", true, Arblib.Mag, Ref{mag_struct}),
+            ("const arf_t x", "x", true, Arf, Ref{arf_struct}),
+            ("const arb_t x", "x", true, Arb, Ref{arb_struct}),
+            ("const acb_t x", "x", true, Acb, Ref{acb_struct}),
             ("arf_rnd_t rnd", "rnd", false, Union{Arblib.arb_rnd, RoundingMode}, Arblib.arb_rnd),
             ("mpfr_t x", "x", false, BigFloat, Ref{BigFloat}),
             ("mpfr_rnd_t rnd", "rnd", false, Union{Base.MPFR.MPFRRoundingMode, RoundingMode},

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -199,14 +199,21 @@ end
 
     Arblib.@arbcall_str "void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)"
     @test Arblib.add!(z, x, y) isa Nothing
+    @test Arblib.add!(
+        Ptr{arb_struct}(pointer_from_objref(z.arb)),
+        Ptr{arb_struct}(pointer_from_objref(x.arb)),
+        Ptr{arb_struct}(pointer_from_objref(y.arb)),
+    ) isa Nothing
     @test Arblib.add!(z.arb, x.arb, y.arb) isa Nothing
 
     Arblib.@arbcall_str "slong arb_rel_error_bits(const arb_t x)"
     @test Arblib.rel_error_bits(x) isa Int64
+    @test Arblib.rel_error_bits(Ptr{arb_struct}(pointer_from_objref(x.arb))) isa Int64
     @test Arblib.rel_error_bits(x.arb) isa Int64
 
     Arblib.@arbcall_str "int arb_is_zero(const arb_t x)"
     @test Arblib.is_zero(x) isa Int32
+    @test Arblib.is_zero(Ptr{arb_struct}(pointer_from_objref(x.arb))) isa Int32
     @test Arblib.is_zero(x.arb) isa Int32
 
     Arblib.@arbcall_str "double arf_get_d(const arf_t x, arf_rnd_t rnd)"

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -9,6 +9,8 @@
         @test typeof(zero(Mag())) == Mag
         @test typeof(one(Mag())) == Mag
         @test typeof(Mag(π)) == Mag
+        @test typeof(Mag(Mag().mag), shallow = false) == Mag
+        @test typeof(Mag(Mag().mag), shallow = true) == Mag
     end
 
     @testset "Arf" begin

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -9,8 +9,8 @@
         @test typeof(zero(Mag())) == Mag
         @test typeof(one(Mag())) == Mag
         @test typeof(Mag(π)) == Mag
-        @test typeof(Mag(Mag().mag), shallow = false) == Mag
-        @test typeof(Mag(Mag().mag), shallow = true) == Mag
+        @test typeof(Mag(Mag().mag, shallow = false)) == Mag
+        @test typeof(Mag(Mag().mag, shallow = true)) == Mag
     end
 
     @testset "Arf" begin

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -92,9 +92,9 @@
                 end
 
                 prec *= 2
-                x.prec = prec
-                r.prec = prec
-                t.prec = prec
+                x = setprecision(x, prec, shallow = true)
+                r = setprecision(r, prec, shallow = true)
+                t = setprecision(t, prec, shallow = true)
             end
 
             return x

--- a/test/precision-test.jl
+++ b/test/precision-test.jl
@@ -1,0 +1,36 @@
+@testset "precision" begin
+    precdefault = 256
+    prec = 64
+
+    @testset "precision" begin
+        for T in (Arf, Arb, Acb)
+            @test precision(T()) == precdefault
+            @test precision(T(prec = prec)) == prec
+
+            @test precision(Arblib.cstruct(T())) == precdefault
+            @test precision(Arblib.cstruct(T(prec = prec))) == precdefault
+
+            @test precision(T) == precdefault
+            @test precision(Arblib.cstructtype(T)) == precdefault
+            @test precision(Ptr{Arblib.cstructtype(T)}) == precdefault
+        end
+    end
+
+    @testset "setprecision" begin
+        for T in (Arf, Arb, Acb)
+            x = T()
+            @test precision(x) == precdefault
+
+            y = setprecision(x, prec, shallow = false)
+            z = setprecision(x, prec, shallow = true)
+            @test precision(y) == prec
+            @test precision(z) == prec
+
+            # Test that y is a normal copy and z a shallow copy
+            Arblib.set!(y, 2)
+            @test !isequal(x, y)
+            Arblib.set!(z, 2)
+            @test isequal(x, z)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Arblib, Test
 include("arb_types-test.jl")
 include("types-test.jl")
 include("arbcall-test.jl")
+include("precision-test.jl")
 include("constructors-test.jl")
 include("predicates-test.jl")
 include("show-test.jl")


### PR DESCRIPTION
I have changed the methods generated by `arbcall` to not only accept the Julia wrapper of the Arb-type but also the corresponding struct as well as pointers to such structs. So for example an argument which would previously take an `Arb` now takes `Union{Arb, arb_struct, Ptr{arb_struct}}`. If the argument is a struct or a pointer the default precision is the current global precision.

The main reason for this is to make it easier to implement non-allocating and inplace operations on vectors and matrices, but also on the radius and midpoint, in the future.

Some more comments:

The last commit fixes a performance issue with `cprefix` that I noticed when comparing the performance after the two commits before that. I believe the problem was that the symbol had to be parsed every time. I tried to figure out how to precompute it in the macro but was not able to get anywhere... So I moved it out and defined it manually instead.

There are not many tests for the new code, in particular for calling the methods with pointers. This will probably be added in a later stage when we add support for `ArbVectors` which will naturally have to use a lot of the pointer methods.