### PR TITLE
Grab bag

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -2,6 +2,7 @@ module Arblib
 
 using LoadFlint
 const libflint = LoadFlint.libflint
+import LinearAlgebra
 
 using Arb_jll
 
@@ -28,6 +29,7 @@ include("acb_matrix.jl")
 include("predicates.jl")
 include("show.jl")
 include("arithmetic.jl")
+include("linear_algebra.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -27,6 +27,7 @@ include("acb_matrix.jl")
 
 include("predicates.jl")
 include("show.jl")
+include("arithmetic.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -6,7 +6,7 @@ import LinearAlgebra
 
 using Arb_jll
 
-export Arf, Arb, Acb, AcbRef, ArbVector, AcbVector, ArbMatrix, AcbMatrix
+export Arf, Arb, ArbRef, Acb, AcbRef, ArbVector, AcbVector, ArbMatrix, AcbMatrix
 
 macro libarb(function_name)
     return (:($function_name), libarb)

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -6,7 +6,7 @@ import LinearAlgebra
 
 using Arb_jll
 
-export Arf, Arb, Acb, ArbVector, AcbVector, ArbMatrix, AcbMatrix
+export Arf, Arb, Acb, AcbRef, ArbVector, AcbVector, ArbMatrix, AcbMatrix
 
 macro libarb(function_name)
     return (:($function_name), libarb)

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -1,11 +1,11 @@
-function AcbMatrix(v::AbstractVector; prec::Integer = precision(first(v)))
+function AcbMatrix(v::AbstractVector; prec::Integer = _precision(first(v)))
     M = AcbMatrix(length(v), 1; prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         M[i, 1] = vᵢ
     end
     return M
 end
-function AcbMatrix(A::AbstractMatrix; prec::Integer = precision(first(A)))
+function AcbMatrix(A::AbstractMatrix; prec::Integer = _precision(first(A)))
     M = AcbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
         M[i, j] = A[i, j]

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -1,3 +1,10 @@
+function AcbMatrix(v::AbstractVector{Acb}; prec::Integer = precision(first(v)))
+    M = AcbMatrix(length(v), 1; prec = prec)
+    @inbounds for (i, vᵢ) in enumerate(v)
+        M[i, 1] = vᵢ
+    end
+    return M
+end
 function AcbMatrix(A::AbstractMatrix{Acb}; prec::Integer = precision(first(A)))
     M = AcbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
@@ -8,6 +15,10 @@ end
 
 Base.size(A::AcbMatrix) = size(A.acb_mat)
 Base.size(A::acb_mat_struct) = (A.r, A.c)
+
+Base.copy(A::AcbMatrix) = copy!(AcbMatrix(size(A)...; prec=precision(A)), A)
+Base.copy!(A::AcbMatrix, B::AcbMatrix) = (set!(A, B); A)
+Base.copyto!(A::AcbMatrix, B::AcbMatrix)  = (set!(A, B); A)
 
 function Base.getindex(A::acb_mat_struct, i::Integer, j::Integer)
     return ccall(

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -37,24 +37,14 @@ Base.@propagate_inbounds function Base.getindex(
     shallow::Bool = false,
 )
     @boundscheck checkbounds(A, i, j)
-    return Acb(unsafe_load(A.acb_mat[i, j]); prec = precision(A), shallow = shallow)
+    return AcbRef(A.acb_mat[i, j], precision(A), cstruct(A))
 end
 
-function Base.setindex!(
-    A::acb_mat_struct,
-    x::Union{Acb,acb_struct,Ref{acb_struct}},
-    i::Integer,
-    j::Integer,
-)
+function Base.setindex!(A::acb_mat_struct, x, i::Integer, j::Integer)
     set!(A[i, j], x)
     return x
 end
-Base.@propagate_inbounds function Base.setindex!(
-    A::AcbMatrix,
-    x::Union{Acb,acb_struct,Ref{acb_struct}},
-    i::Integer,
-    j::Integer,
-)
+Base.@propagate_inbounds function Base.setindex!(A::AcbMatrix, x, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     A.acb_mat[i, j] = x
     return x

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -16,9 +16,9 @@ end
 Base.size(A::AcbMatrix) = size(A.acb_mat)
 Base.size(A::acb_mat_struct) = (A.r, A.c)
 
-Base.copy(A::AcbMatrix) = copy!(AcbMatrix(size(A)...; prec=precision(A)), A)
+Base.copy(A::AcbMatrix) = copy!(AcbMatrix(size(A)...; prec = precision(A)), A)
 Base.copy!(A::AcbMatrix, B::AcbMatrix) = (set!(A, B); A)
-Base.copyto!(A::AcbMatrix, B::AcbMatrix)  = (set!(A, B); A)
+Base.copyto!(A::AcbMatrix, B::AcbMatrix) = (set!(A, B); A)
 
 function Base.getindex(A::acb_mat_struct, i::Integer, j::Integer)
     return ccall(

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -1,11 +1,11 @@
-function AcbMatrix(v::AbstractVector{Acb}; prec::Integer = precision(first(v)))
+function AcbMatrix(v::AbstractVector; prec::Integer = precision(first(v)))
     M = AcbMatrix(length(v), 1; prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         M[i, 1] = vᵢ
     end
     return M
 end
-function AcbMatrix(A::AbstractMatrix{Acb}; prec::Integer = precision(first(A)))
+function AcbMatrix(A::AbstractMatrix; prec::Integer = precision(first(A)))
     M = AcbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
         M[i, j] = A[i, j]

--- a/src/acb_matrix.jl
+++ b/src/acb_matrix.jl
@@ -30,12 +30,7 @@ function Base.getindex(A::acb_mat_struct, i::Integer, j::Integer)
         j - 1,
     )
 end
-Base.@propagate_inbounds function Base.getindex(
-    A::AcbMatrix,
-    i::Integer,
-    j::Integer;
-    shallow::Bool = false,
-)
+Base.@propagate_inbounds function Base.getindex(A::AcbMatrix, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     return AcbRef(A.acb_mat[i, j], precision(A), cstruct(A))
 end

--- a/src/acb_vector.jl
+++ b/src/acb_vector.jl
@@ -26,7 +26,7 @@ Base.@propagate_inbounds function Base.getindex(
     shallow::Bool = false,
 )
     @boundscheck checkbounds(v, i)
-    return Acb(unsafe_load(v.acb_vec[i]); prec = precision(v), shallow = shallow)
+    return AcbRef(v.acb_vec[i], precision(v), cstruct(v))
 end
 
 Base.@propagate_inbounds function Base.setindex!(v::AcbVector, x, i::Integer)

--- a/src/acb_vector.jl
+++ b/src/acb_vector.jl
@@ -20,11 +20,7 @@ function AcbVector(v::AbstractVector{Acb}, prec::Integer = precision(first(v)))
     return V
 end
 
-Base.@propagate_inbounds function Base.getindex(
-    v::AcbVector,
-    i::Integer;
-    shallow::Bool = false,
-)
+Base.@propagate_inbounds function Base.getindex(v::AcbVector, i::Integer)
     @boundscheck checkbounds(v, i)
     return AcbRef(v.acb_vec[i], precision(v), cstruct(v))
 end

--- a/src/acb_vector.jl
+++ b/src/acb_vector.jl
@@ -12,7 +12,7 @@ Base.size(v::AcbVector) = size(v.acb_vec)
 Base.cconvert(::Type{Ptr{acb_struct}}, v::AcbVector) = v.acb_vec
 Base.unsafe_convert(::Type{Ptr{acb_struct}}, v::acb_vec_struct) = v.entries
 
-function AcbVector(v::AbstractVector{Acb}, prec::Integer = precision(first(v)))
+function AcbVector(v::AbstractVector, prec::Integer = precision(first(v)))
     V = AcbVector(length(v); prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         V[i] = vᵢ

--- a/src/acb_vector.jl
+++ b/src/acb_vector.jl
@@ -12,7 +12,7 @@ Base.size(v::AcbVector) = size(v.acb_vec)
 Base.cconvert(::Type{Ptr{acb_struct}}, v::AcbVector) = v.acb_vec
 Base.unsafe_convert(::Type{Ptr{acb_struct}}, v::acb_vec_struct) = v.entries
 
-function AcbVector(v::AbstractVector, prec::Integer = precision(first(v)))
+function AcbVector(v::AbstractVector, prec::Integer = _precision(first(v)))
     V = AcbVector(length(v); prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         V[i] = vᵢ

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -17,9 +17,9 @@ end
 Base.size(A::ArbMatrix) = size(A.arb_mat)
 Base.size(A::arb_mat_struct) = (A.r, A.c)
 
-Base.copy(A::ArbMatrix) = copy!(ArbMatrix(size(A)...; prec=precision(A)), A)
+Base.copy(A::ArbMatrix) = copy!(ArbMatrix(size(A)...; prec = precision(A)), A)
 Base.copy!(A::ArbMatrix, B::ArbMatrix) = (set!(A, B); A)
-Base.copyto!(A::ArbMatrix, B::ArbMatrix)  = (set!(A, B); A)
+Base.copyto!(A::ArbMatrix, B::ArbMatrix) = (set!(A, B); A)
 
 function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
     return ccall(

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -1,4 +1,4 @@
-function ArbMatrix(v::AbstractVector{Arb}; prec::Integer = precision(first(v)))
+function ArbMatrix(v::AbstractVector; prec::Integer = precision(first(v)))
     M = ArbMatrix(length(v), 1; prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         M[i, 1] = vᵢ
@@ -6,7 +6,7 @@ function ArbMatrix(v::AbstractVector{Arb}; prec::Integer = precision(first(v)))
     return M
 end
 
-function ArbMatrix(A::AbstractMatrix{Arb}; prec::Integer = precision(first(A)))
+function ArbMatrix(A::AbstractMatrix; prec::Integer = precision(first(A)))
     M = ArbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
         M[i, j] = A[i, j]

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -38,7 +38,7 @@ end
 
 function Base.setindex!(
     A::arb_mat_struct,
-    x::Union{Arb,arb_struct,Ref{arb_struct}},
+    x,
     i::Integer,
     j::Integer,
 )
@@ -47,7 +47,7 @@ function Base.setindex!(
 end
 Base.@propagate_inbounds function Base.setindex!(
     A::ArbMatrix,
-    x::Union{Arb,arb_struct,Ref{arb_struct}},
+    x,
     i::Integer,
     j::Integer,
 )

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -1,3 +1,11 @@
+function ArbMatrix(v::AbstractVector{Arb}; prec::Integer = precision(first(v)))
+    M = ArbMatrix(length(v), 1; prec = prec)
+    @inbounds for (i, vᵢ) in enumerate(v)
+        M[i, 1] = vᵢ
+    end
+    return M
+end
+
 function ArbMatrix(A::AbstractMatrix{Arb}; prec::Integer = precision(first(A)))
     M = ArbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
@@ -8,6 +16,10 @@ end
 
 Base.size(A::ArbMatrix) = size(A.arb_mat)
 Base.size(A::arb_mat_struct) = (A.r, A.c)
+
+Base.copy(A::ArbMatrix) = copy!(ArbMatrix(size(A)...; prec=precision(A)), A)
+Base.copy!(A::ArbMatrix, B::ArbMatrix) = (set!(A, B); A)
+Base.copyto!(A::ArbMatrix, B::ArbMatrix)  = (set!(A, B); A)
 
 function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
     return ccall(

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -31,14 +31,9 @@ function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
         j - 1,
     )
 end
-Base.@propagate_inbounds function Base.getindex(
-    A::ArbMatrix,
-    i::Integer,
-    j::Integer;
-    shallow::Bool = false,
-)
+Base.@propagate_inbounds function Base.getindex(A::ArbMatrix, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
-    return Arb(unsafe_load(A.arb_mat[i, j]); prec = precision(A), shallow = shallow)
+    return ArbRef(A.arb_mat[i, j], precision(A), cstruct(A))
 end
 
 function Base.setindex!(

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -36,21 +36,11 @@ Base.@propagate_inbounds function Base.getindex(A::ArbMatrix, i::Integer, j::Int
     return ArbRef(A.arb_mat[i, j], precision(A), cstruct(A))
 end
 
-function Base.setindex!(
-    A::arb_mat_struct,
-    x,
-    i::Integer,
-    j::Integer,
-)
+function Base.setindex!(A::arb_mat_struct, x, i::Integer, j::Integer)
     set!(A[i, j], x)
     return x
 end
-Base.@propagate_inbounds function Base.setindex!(
-    A::ArbMatrix,
-    x,
-    i::Integer,
-    j::Integer,
-)
+Base.@propagate_inbounds function Base.setindex!(A::ArbMatrix, x, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     A.arb_mat[i, j] = x
     return x

--- a/src/arb_matrix.jl
+++ b/src/arb_matrix.jl
@@ -1,4 +1,4 @@
-function ArbMatrix(v::AbstractVector; prec::Integer = precision(first(v)))
+function ArbMatrix(v::AbstractVector; prec::Integer = _precision(first(v)))
     M = ArbMatrix(length(v), 1; prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         M[i, 1] = vᵢ
@@ -6,7 +6,7 @@ function ArbMatrix(v::AbstractVector; prec::Integer = precision(first(v)))
     return M
 end
 
-function ArbMatrix(A::AbstractMatrix; prec::Integer = precision(first(A)))
+function ArbMatrix(A::AbstractMatrix; prec::Integer = _precision(first(A)))
     M = ArbMatrix(size(A)...; prec = prec)
     @inbounds for j = 1:size(A, 2), i = 1:size(A, 1)
         M[i, j] = A[i, j]

--- a/src/arb_vector.jl
+++ b/src/arb_vector.jl
@@ -13,7 +13,7 @@ Base.size(v::ArbVector) = size(v.arb_vec)
 Base.cconvert(::Type{Ptr{arb_struct}}, v::ArbVector) = v.arb_vec
 Base.unsafe_convert(::Type{Ptr{arb_struct}}, v::arb_vec_struct) = v.entries
 
-function ArbVector(v::AbstractVector{Arb}, prec::Integer = precision(first(v)))
+function ArbVector(v::AbstractVector, prec::Integer = precision(first(v)))
     V = ArbVector(length(v); prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         V[i] = vᵢ

--- a/src/arb_vector.jl
+++ b/src/arb_vector.jl
@@ -21,13 +21,9 @@ function ArbVector(v::AbstractVector{Arb}, prec::Integer = precision(first(v)))
     return V
 end
 
-Base.@propagate_inbounds function Base.getindex(
-    v::ArbVector,
-    i::Integer;
-    shallow::Bool = false,
-)
+Base.@propagate_inbounds function Base.getindex(v::ArbVector, i::Integer)
     @boundscheck checkbounds(v, i)
-    return Arb(unsafe_load(v.arb_vec[i]); prec = precision(v), shallow = shallow)
+    return ArbRef(v.arb_vec[i], precision(v), cstruct(v))
 end
 
 Base.@propagate_inbounds function Base.setindex!(v::ArbVector, x, i::Integer)

--- a/src/arb_vector.jl
+++ b/src/arb_vector.jl
@@ -13,7 +13,7 @@ Base.size(v::ArbVector) = size(v.arb_vec)
 Base.cconvert(::Type{Ptr{arb_struct}}, v::ArbVector) = v.arb_vec
 Base.unsafe_convert(::Type{Ptr{arb_struct}}, v::arb_vec_struct) = v.entries
 
-function ArbVector(v::AbstractVector, prec::Integer = precision(first(v)))
+function ArbVector(v::AbstractVector, prec::Integer = _precision(first(v)))
     V = ArbVector(length(v); prec = prec)
     @inbounds for (i, vᵢ) in enumerate(v)
         V[i] = vᵢ

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -101,7 +101,9 @@ jltype(ca::Carg{Vector{Clong}}) = Vector{<:Integer}
 jltype(ca::Carg{Vector{Culong}}) = Vector{<:Unsigned}
 jltype(ca::Carg{ArbVector}) = Union{ArbVector,cstructtype(ArbVector)}
 jltype(ca::Carg{AcbVector}) = Union{AcbVector,cstructtype(AcbVector)}
-jltype(::Carg{T}) where {T<:Union{Mag,Arf,Arb,Acb,ArbMatrix,AcbMatrix}} =
+jltype(::Carg{Acb}) =
+    Union{Acb,cstructtype(Acb),Ptr{cstructtype(Acb)},AcbRef}
+jltype(::Carg{T}) where {T<:Union{Mag,Arf,Arb,ArbMatrix,AcbMatrix}} =
     Union{T,cstructtype(T),Ptr{cstructtype(T)}}
 
 ctype(ca::Carg) = rawtype(ca)
@@ -175,7 +177,7 @@ function jlargs(af::Arbfunction)
             if jltype(a) ∈ (
                 Union{Arf,arf_struct,Ptr{arf_struct}},
                 Union{Arb,arb_struct,Ptr{arb_struct}},
-                Union{Acb,acb_struct,Ptr{acb_struct}},
+                Union{Acb,acb_struct,Ptr{acb_struct},AcbRef},
             )
                 :(precision($(Symbol(name(a)))))
             else

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -101,8 +101,7 @@ jltype(ca::Carg{Vector{Clong}}) = Vector{<:Integer}
 jltype(ca::Carg{Vector{Culong}}) = Vector{<:Unsigned}
 jltype(ca::Carg{ArbVector}) = Union{ArbVector,cstructtype(ArbVector)}
 jltype(ca::Carg{AcbVector}) = Union{AcbVector,cstructtype(AcbVector)}
-jltype(::Carg{Acb}) =
-    Union{Acb,cstructtype(Acb),Ptr{cstructtype(Acb)},AcbRef}
+jltype(::Carg{Acb}) = Union{Acb,cstructtype(Acb),Ptr{cstructtype(Acb)},AcbRef}
 jltype(::Carg{T}) where {T<:Union{Mag,Arf,Arb,ArbMatrix,AcbMatrix}} =
     Union{T,cstructtype(T),Ptr{cstructtype(T)}}
 

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -102,7 +102,8 @@ jltype(ca::Carg{Vector{Culong}}) = Vector{<:Unsigned}
 jltype(ca::Carg{ArbVector}) = Union{ArbVector,cstructtype(ArbVector)}
 jltype(ca::Carg{AcbVector}) = Union{AcbVector,cstructtype(AcbVector)}
 jltype(::Carg{Acb}) = Union{Acb,cstructtype(Acb),Ptr{cstructtype(Acb)},AcbRef}
-jltype(::Carg{T}) where {T<:Union{Mag,Arf,Arb,ArbMatrix,AcbMatrix}} =
+jltype(::Carg{Arb}) = Union{Arb,cstructtype(Arb),Ptr{cstructtype(Arb)},ArbRef}
+jltype(::Carg{T}) where {T<:Union{Mag,Arf,ArbMatrix,AcbMatrix}} =
     Union{T,cstructtype(T),Ptr{cstructtype(T)}}
 
 ctype(ca::Carg) = rawtype(ca)
@@ -175,7 +176,7 @@ function jlargs(af::Arbfunction)
         default =
             if jltype(a) ∈ (
                 Union{Arf,arf_struct,Ptr{arf_struct}},
-                Union{Arb,arb_struct,Ptr{arb_struct}},
+                Union{Arb,arb_struct,Ptr{arb_struct},ArbRef},
                 Union{Acb,acb_struct,Ptr{acb_struct},AcbRef},
             )
                 :(precision($(Symbol(name(a)))))

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,23 +1,26 @@
 Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
 Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Arf}}) = Arb
-Base.promote_rule(::Type{Acb}, ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb}}) = Acb
+Base.promote_rule(
+    ::Type{Acb},
+    ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb,AcbRef}},
+) = Acb
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
     @eval function $(Expr(:., :Base, QuoteNode(jf)))(
         x::T,
         y::T,
-    ) where {T<:Union{Arf,Arb,Acb}}
+    ) where {T<:Union{Arf,Arb,Acb,AcbRef}}
         z = T(prec = max(precision(x), precision(y)))
         $af(z, x, y)
         z
     end
 end
-function Base.:(-)(x::T) where {T<:Union{Arf,Arb,Acb}}
+function Base.:(-)(x::T) where {T<:Union{Arf,Arb,Acb,AcbRef}}
     z = T(prec = precision(x))
     neg!(z, x)
     z
 end
-function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,Acb}}
+function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,Acb,AcbRef}}
     z = T(prec = precision(x))
     pow!(z, x, convert(UInt, k))
     z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -17,7 +17,7 @@ function Base.:(-)(x::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
     neg!(z, x)
     z
 end
-function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+function Base.:(^)(x::T, k::Integer) where {T<:Union{Arb,ArbRef,Acb,AcbRef}}
     z = T(prec = precision(x))
     pow!(z, x, convert(UInt, k))
     z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -48,7 +48,7 @@ for f in [
     :sech,
     :asech,
 ]
-    @eval function Base.$f(x::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+    @eval function Base.$f(x::T) where {T<:Union{Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x)))
         $(Symbol(f, :!))(z, x)
         z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,5 +1,6 @@
 Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
-Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Rational,Arf,ArbRef}}) = Arb
+Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Rational,Arf,ArbRef}}) =
+    Arb
 Base.promote_rule(
     ::Type{Acb},
     ::Type{

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,8 +1,19 @@
 Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
-Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Arf,ArbRef}}) = Arb
+Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Rational,Arf,ArbRef}}) = Arb
 Base.promote_rule(
     ::Type{Acb},
-    ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb,ArbRef,AcbRef}},
+    ::Type{
+        <:Union{
+            AbstractFloat,
+            Integer,
+            Rational,
+            Complex{<:Union{AbstractFloat,Integer,Rational}},
+            Arf,
+            Arb,
+            ArbRef,
+            AcbRef,
+        },
+    },
 ) = Acb
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,26 +1,26 @@
 Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
-Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Arf}}) = Arb
+Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Arf,ArbRef}}) = Arb
 Base.promote_rule(
     ::Type{Acb},
-    ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb,AcbRef}},
+    ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb,ArbRef,AcbRef}},
 ) = Acb
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
     @eval function $(Expr(:., :Base, QuoteNode(jf)))(
         x::T,
         y::T,
-    ) where {T<:Union{Arf,Arb,Acb,AcbRef}}
+    ) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x), precision(y)))
         $af(z, x, y)
         z
     end
 end
-function Base.:(-)(x::T) where {T<:Union{Arf,Arb,Acb,AcbRef}}
+function Base.:(-)(x::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
     z = T(prec = precision(x))
     neg!(z, x)
     z
 end
-function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,Acb,AcbRef}}
+function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
     z = T(prec = precision(x))
     pow!(z, x, convert(UInt, k))
     z
@@ -51,7 +51,9 @@ for f in [
     :sech,
     :asech,
 ]
-    @eval function $(Expr(:., :Base, QuoteNode(f)))(x::T) where {T<:Union{Arf,Arb,Acb}}
+    @eval function $(Expr(:., :Base, QuoteNode(f)))(
+        x::T,
+    ) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x)))
         $(Symbol(f, :!))(z, x)
         z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -6,10 +6,7 @@ Base.promote_rule(
 ) = Acb
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
-    @eval function $(Expr(:., :Base, QuoteNode(jf)))(
-        x::T,
-        y::T,
-    ) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+    @eval function Base.$jf(x::T, y::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x), precision(y)))
         $af(z, x, y)
         z
@@ -51,9 +48,7 @@ for f in [
     :sech,
     :asech,
 ]
-    @eval function $(Expr(:., :Base, QuoteNode(f)))(
-        x::T,
-    ) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+    @eval function Base.$f(x::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x)))
         $(Symbol(f, :!))(z, x)
         z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,0 +1,56 @@
+Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
+Base.promote_rule(::Type{Arb}, ::Type{<:Union{AbstractFloat,Integer,Arf}}) = Arb
+Base.promote_rule(::Type{Acb}, ::Type{<:Union{AbstractFloat,Integer,Complex,Arf,Arb}}) = Acb
+
+for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
+    @eval function $(Expr(:., :Base, QuoteNode(jf)))(
+        x::T,
+        y::T,
+    ) where {T<:Union{Arf,Arb,Acb}}
+        z = T(prec = max(precision(x), precision(y)))
+        $af(z, x, y)
+        z
+    end
+end
+function Base.:(-)(x::T) where {T<:Union{Arf,Arb,Acb}}
+    z = T(prec = precision(x))
+    neg!(z, x)
+    z
+end
+function Base.:(^)(x::T, k::Integer) where {T<:Union{Arf,Arb,Acb}}
+    z = T(prec = precision(x))
+    pow!(z, x, convert(UInt, k))
+    z
+end
+
+for f in [
+    :sqrt,
+    :exp,
+    :log,
+    :log1p,
+    :sin,
+    :cos,
+    :tan,
+    :cot,
+    :asin,
+    :acos,
+    :atan,
+    :acot,
+    :sinc,
+    :sinh,
+    :cosh,
+    :tanh,
+    :asinh,
+    :acosh,
+    :atanh,
+    :sec,
+    :asec,
+    :sech,
+    :asech,
+]
+    @eval function $(Expr(:., :Base, QuoteNode(f)))(x::T) where {T<:Union{Arf,Arb,Acb}}
+        z = T(prec = max(precision(x)))
+        $(Symbol(f, :!))(z, x)
+        z
+    end
+end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -131,10 +131,10 @@ Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))
 Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
 # Define these since the base implementation would create `n` copies of the same element
 # I.e. only allocating **one** Arf/Arb/Acb.
-Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} =[zero(x) for _ in 1:n]
-Base.ones(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(x) for _ in 1:n]
-Base.zeros(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} =[zero(T) for _ in 1:n]
-Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ in 1:n]
+Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]
+Base.ones(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(x) for _ = 1:n]
+Base.zeros(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(T) for _ = 1:n]
+Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ = 1:n]
 
 # Irrationals
 function Mag(::Irrational{:π})

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -58,6 +58,13 @@ function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     return res
 end
 
+function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
+    num = Arb(numerator(x); prec = prec)
+    denom = Arb(denominator(x); prec = prec)
+    div!(num, num, denom)
+    return num
+end
+
 ## Acb
 for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
     @eval begin
@@ -71,7 +78,7 @@ end
 function Acb(x::Arf; prec::Integer = precision(x))
     res = Acb(prec = prec)
     # There is not set! with Acb and Arf. So create intermediate Arb :shrug:
-    set!(res, Arb(x, prec=prec))
+    set!(res, Arb(x, prec = prec))
     return res
 end
 
@@ -100,6 +107,11 @@ for T in (Integer, Base.GMP.CdoubleMax)
         end
     end
 end
+
+function Acb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
+    Acb(Arb(x; prec = prec); prec = prec)
+end
+
 
 function Acb(re::Arb, im::Arb; prec::Integer = max(precision(re), precision(im)))
     res = Acb(prec = prec)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -26,8 +26,8 @@ function Arf(x::BigFloat; prec::Integer = precision(x))
     return res
 end
 
-function Arf(x::Arf; prec::Integer = precision(x), shallow::Bool = false)
-    return Arf(x.arf, prec = prec, shallow = shallow)
+function Arf(x::Arf; prec::Integer = precision(x))
+    return Arf(x.arf, prec = prec)
 end
 
 ## Arb
@@ -47,8 +47,8 @@ function Arb(x::Arf; prec::Integer = precision(x))
     return res
 end
 
-function Arb(x::Arb; prec::Integer = precision(x), shallow::Bool = false)
-    return Arb(x.arb, prec = prec, shallow = shallow)
+function Arb(x::Arb; prec::Integer = precision(x))
+    return Arb(x.arb, prec = prec)
 end
 
 function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
@@ -88,8 +88,8 @@ function Acb(x::Arb; prec::Integer = precision(x))
     return res
 end
 
-function Acb(x::Acb; prec::Integer = precision(x), shallow::Bool = false)
-    return Acb(x.acb, prec = prec, shallow = shallow)
+function Acb(x::Acb; prec::Integer = precision(x))
+    return Acb(x.acb, prec = prec)
 end
 
 for T in (Integer, Base.GMP.CdoubleMax)
@@ -131,6 +131,8 @@ Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))
 Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
 Base.zero(x::AcbRef) = Acb(0, prec = precision(x))
 Base.one(x::AcbRef) = Acb(1, prec = precision(x))
+Base.zero(x::ArbRef) = Arb(0, prec = precision(x))
+Base.one(x::ArbRef) = Arb(1, prec = precision(x))
 # Define these since the base implementation would create `n` copies of the same element
 # I.e. only allocating **one** Arf/Arb/Acb.
 Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -129,6 +129,8 @@ Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))
 Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))
 Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
+Base.zero(x::AcbRef) = Acb(0, prec = precision(x))
+Base.one(x::AcbRef) = Acb(1, prec = precision(x))
 # Define these since the base implementation would create `n` copies of the same element
 # I.e. only allocating **one** Arf/Arb/Acb.
 Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -129,6 +129,12 @@ Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))
 Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))
 Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
+# Define these since the base implementation would create `n` copies of the same element
+# I.e. only allocating **one** Arf/Arb/Acb.
+Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} =[zero(x) for _ in 1:n]
+Base.ones(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(x) for _ in 1:n]
+Base.zeros(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} =[zero(T) for _ in 1:n]
+Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ in 1:n]
 
 # Irrationals
 function Mag(::Irrational{:π})

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -68,6 +68,12 @@ for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
         end
     end
 end
+function Acb(x::Arf; prec::Integer = precision(x))
+    res = Acb(prec = prec)
+    # There is not set! with Acb and Arf. So create intermediate Arb :shrug:
+    set!(res, Arb(x, prec=prec))
+    return res
+end
 
 function Acb(x::Arb; prec::Integer = precision(x))
     res = Acb(prec = prec)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -36,7 +36,11 @@ LinearAlgebra.ldiv!(Y::AcbMatrix, A::AcbMatrix, B::AcbMatrix) =
     LinearAlgebra.ldiv!(Y, LinearAlgebra.lu(A), B)
 LinearAlgebra.ldiv!(A::AcbMatrix, B::AcbMatrix) =
     LinearAlgebra.ldiv!(B, LinearAlgebra.lu(A), B)
-function LinearAlgebra.ldiv!(Y::AcbMatrix, A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix)
+function LinearAlgebra.ldiv!(
+    Y::AcbMatrix,
+    A::LinearAlgebra.LU{AcbRef,AcbMatrix},
+    B::AcbMatrix,
+)
     Arblib.solve_lu_precomp!(Y, A.ipiv, A.factors, B)
     Y
 end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -1,8 +1,5 @@
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!)]
-    @eval function $(Expr(:., :Base, QuoteNode(jf)))(
-        A::T,
-        B::T,
-    ) where {T<:Union{ArbMatrix,AcbMatrix}}
+    @eval function Base.$jf(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
         C = T(size(A, 1), size(B, 2); prec = max(precision(A), precision(B)))
         $af(C, A, B)
         C

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -1,14 +1,33 @@
-for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!)]
+for (jf, af) in [(:+, :add!), (:-, :sub!)]
     @eval function Base.$jf(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+        @boundscheck (
+            size(A) == size(B) ||
+            throw(DimensionMismatch("Matrix sizes are not compatible."))
+        )
         C = T(size(A, 1), size(B, 2); prec = max(precision(A), precision(B)))
         $af(C, A, B)
         C
     end
 end
+
 function Base.:(-)(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
     C = T(size(A)...; prec = precision(A))
     neg!(C, A)
     C
+end
+
+function LinearAlgebra.mul!(C::T, A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    @boundscheck (
+        (size(C) == (size(A, 1), size(B, 2)) && size(A, 2) == size(B, 1)) ||
+        throw(DimensionMismatch("Matrix sizes are not compatible."))
+    )
+    Arblib.mul!(C, A, B)
+    C
+end
+
+function Base.:(*)(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    C = T(size(A, 1), size(B, 2); prec = max(precision(A), precision(B)))
+    LinearAlgebra.mul!(C, A, B)
 end
 
 function LinearAlgebra.lu!(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
@@ -29,15 +48,31 @@ function LinearAlgebra.inv(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
     B
 end
 
-LinearAlgebra.ldiv!(Y::T, A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}} =
+function LinearAlgebra.ldiv!(Y::T, A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    @boundscheck (
+        (size(Y) == size(B) && size(A, 1) == size(A, 2) && size(A, 1) == size(B, 1)) ||
+        throw(DimensionMismatch("Matrix sizes are not compatible."))
+    )
     LinearAlgebra.ldiv!(Y, LinearAlgebra.lu(A), B)
-LinearAlgebra.ldiv!(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}} =
+end
+
+function LinearAlgebra.ldiv!(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    @boundscheck (
+        (size(A, 1) == size(A, 2)) ||
+        throw(DimensionMismatch("Expected a square matrix as the left hand side."))
+    )
     LinearAlgebra.ldiv!(B, LinearAlgebra.lu(A), B)
+end
+
 function LinearAlgebra.ldiv!(
     Y::T,
     A::LinearAlgebra.LU{<:Any,T},
     B::T,
 ) where {T<:Union{ArbMatrix,AcbMatrix}}
+    @boundscheck (
+        (size(Y) == size(B) && size(A, 1) == size(A, 2) && size(A, 1) == size(B, 1)) ||
+        throw(DimensionMismatch("Matrix sizes are not compatible."))
+    )
     Arblib.solve_lu_precomp!(Y, A.ipiv, A.factors, B)
     Y
 end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -1,0 +1,53 @@
+for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!)]
+    @eval function $(Expr(:., :Base, QuoteNode(jf)))(
+        A::T,
+        B::T,
+    ) where {T<:Union{ArbMatrix,AcbMatrix}}
+        C = T(size(A, 1), size(B, 2); prec = max(precision(A), precision(B)))
+        $af(C, A, B)
+        C
+    end
+end
+function Base.:(-)(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    C = T(size(A)...; prec = precision(A))
+    neg!(C, A)
+    C
+end
+
+function LinearAlgebra.lu!(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    ipiv = zeros(Int, size(A, 2))
+    retcode = lu!(ipiv, A, A)
+    LinearAlgebra.LU(A, ipiv, retcode > 0 ? 0 : 1)
+end
+function LinearAlgebra.lu(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    lu = T(size(A)...; prec = precision(A))
+    ipiv = zeros(Int, size(A, 2))
+    retcode = lu!(ipiv, lu, A)
+    LinearAlgebra.LU(lu, ipiv, retcode > 0 ? 0 : 1)
+end
+
+function LinearAlgebra.inv(A::AcbMatrix)
+    B = AcbMatrix(size(A)...; prec = precision(A))
+    Arblib.inv!(B, A)
+    B
+end
+
+LinearAlgebra.ldiv!(Y::AcbMatrix, A::AcbMatrix, B::AcbMatrix) =
+    LinearAlgebra.ldiv!(Y, LinearAlgebra.lu(A), B)
+LinearAlgebra.ldiv!(A::AcbMatrix, B::AcbMatrix) =
+    LinearAlgebra.ldiv!(B, LinearAlgebra.lu(A), B)
+function LinearAlgebra.ldiv!(Y::AcbMatrix, A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix)
+    Arblib.solve_lu_precomp!(Y, A.ipiv, A.factors, B)
+    Y
+end
+LinearAlgebra.ldiv!(A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix) =
+    LinearAlgebra.ldiv!(B, A, B)
+
+function Base.:(\)(A::AcbMatrix, B::AcbMatrix)
+    Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A), precision(B)))
+    LinearAlgebra.ldiv!(Y, A, B)
+end
+function Base.:(\)(A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix)
+    Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A.factors), precision(B)))
+    LinearAlgebra.ldiv!(Y, A, B)
+end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -36,18 +36,18 @@ LinearAlgebra.ldiv!(Y::AcbMatrix, A::AcbMatrix, B::AcbMatrix) =
     LinearAlgebra.ldiv!(Y, LinearAlgebra.lu(A), B)
 LinearAlgebra.ldiv!(A::AcbMatrix, B::AcbMatrix) =
     LinearAlgebra.ldiv!(B, LinearAlgebra.lu(A), B)
-function LinearAlgebra.ldiv!(Y::AcbMatrix, A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix)
+function LinearAlgebra.ldiv!(Y::AcbMatrix, A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix)
     Arblib.solve_lu_precomp!(Y, A.ipiv, A.factors, B)
     Y
 end
-LinearAlgebra.ldiv!(A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix) =
+LinearAlgebra.ldiv!(A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix) =
     LinearAlgebra.ldiv!(B, A, B)
 
 function Base.:(\)(A::AcbMatrix, B::AcbMatrix)
     Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A), precision(B)))
     LinearAlgebra.ldiv!(Y, A, B)
 end
-function Base.:(\)(A::LinearAlgebra.LU{Acb,AcbMatrix}, B::AcbMatrix)
+function Base.:(\)(A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix)
     Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A.factors), precision(B)))
     LinearAlgebra.ldiv!(Y, A, B)
 end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -26,32 +26,34 @@ function LinearAlgebra.lu(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
     LinearAlgebra.LU(lu, ipiv, retcode > 0 ? 0 : 1)
 end
 
-function LinearAlgebra.inv(A::AcbMatrix)
-    B = AcbMatrix(size(A)...; prec = precision(A))
+function LinearAlgebra.inv(A::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    B = T(size(A)...; prec = precision(A))
     Arblib.inv!(B, A)
     B
 end
 
-LinearAlgebra.ldiv!(Y::AcbMatrix, A::AcbMatrix, B::AcbMatrix) =
+LinearAlgebra.ldiv!(Y::T, A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}} =
     LinearAlgebra.ldiv!(Y, LinearAlgebra.lu(A), B)
-LinearAlgebra.ldiv!(A::AcbMatrix, B::AcbMatrix) =
+LinearAlgebra.ldiv!(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}} =
     LinearAlgebra.ldiv!(B, LinearAlgebra.lu(A), B)
 function LinearAlgebra.ldiv!(
-    Y::AcbMatrix,
-    A::LinearAlgebra.LU{AcbRef,AcbMatrix},
-    B::AcbMatrix,
-)
+    Y::T,
+    A::LinearAlgebra.LU{<:Any,T},
+    B::T,
+) where {T<:Union{ArbMatrix,AcbMatrix}}
     Arblib.solve_lu_precomp!(Y, A.ipiv, A.factors, B)
     Y
 end
-LinearAlgebra.ldiv!(A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix) =
-    LinearAlgebra.ldiv!(B, A, B)
+LinearAlgebra.ldiv!(
+    A::LinearAlgebra.LU{<:Any,T},
+    B::T,
+) where {T<:Union{ArbMatrix,AcbMatrix}} = LinearAlgebra.ldiv!(B, A, B)
 
-function Base.:(\)(A::AcbMatrix, B::AcbMatrix)
-    Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A), precision(B)))
+function Base.:(\)(A::T, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    Y = T(size(A, 2), size(B, 2); prec = max(precision(A), precision(B)))
     LinearAlgebra.ldiv!(Y, A, B)
 end
-function Base.:(\)(A::LinearAlgebra.LU{AcbRef,AcbMatrix}, B::AcbMatrix)
-    Y = AcbMatrix(size(A, 2), size(B, 2); prec = max(precision(A.factors), precision(B)))
+function Base.:(\)(A::LinearAlgebra.LU{<:Any,T}, B::T) where {T<:Union{ArbMatrix,AcbMatrix}}
+    Y = T(size(A, 2), size(B, 2); prec = max(precision(A.factors), precision(B)))
     LinearAlgebra.ldiv!(Y, A, B)
 end

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -30,12 +30,8 @@ function Base.setprecision(::Type{<:ArbTypes}, precision::Integer)
     return precision
 end
 
-function Base.setprecision(
-    x::T,
-    precision::Integer;
-    shallow = false,
-) where {T<:Union{Arf,Arb,Acb}}
-    return T(x, prec = precision, shallow = shallow)
+function Base.setprecision(x::T, precision::Integer) where {T<:Union{Arf,Arb,Acb}}
+    return T(x, prec = precision)
 end
 Base.setprecision(v::ArbVector, precision::Integer) = ArbVector(v.arb_vec, precision)
 Base.setprecision(v::AcbVector, precision::Integer) = AcbVector(v.acb_vec, precision)

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -14,6 +14,9 @@ Base.precision(x::ArbStructTypes) = DEFAULT_PRECISION[]
 Base.precision(x::Ptr{<:ArbStructTypes}) = DEFAULT_PRECISION[]
 Base.precision(x::ArbTypes) = x.prec
 
+@inline _precision(x::ArbTypes) = precision(x)
+@inline _precision(_) = DEFAULT_PRECISION[]
+
 """
     setprecision(::Type{<:Union{Arf, Arb, Acb}}, precision::Int)
 Set the precision (in bits) to be used for `Arblib` arithmetic.

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -24,7 +24,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        Arb,
+        Union{Arb,ArbRef},
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -119,7 +119,7 @@ end
 
 for (ArbT, args) in (
     (
-        Arb,
+        Union{Arb,ArbRef},
         ((:(==), :eq), (:(!=), :ne), (:(<), :lt), (:(<=), :le), (:(>), :gt), (:(>=), :ge)),
     ),
     (Union{Acb,AcbRef}, ((:(==), :eq), (:(!=), :ne))),

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -39,7 +39,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        Acb,
+        Union{Acb,AcbRef},
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -122,7 +122,7 @@ for (ArbT, args) in (
         Arb,
         ((:(==), :eq), (:(!=), :ne), (:(<), :lt), (:(<=), :le), (:(>), :gt), (:(>=), :ge)),
     ),
-    (Acb, ((:(==), :eq), (:(!=), :ne))),
+    (Union{Acb,AcbRef}, ((:(==), :eq), (:(!=), :ne))),
     (ArbMatrix, ((:(==), :eq), (:(!=), :ne))),
     (AcbMatrix, ((:(==), :eq), (:(!=), :ne))),
 )

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,10 +1,10 @@
 digits_prec(prec::Integer) = floor(Int, prec * log(2) / log(10))
 
 Base.show(io::IO, x::Mag) = print(io, _string(x))
-Base.show(io::IO, x::Union{Arb,Acb}) = print(io, string_nice(x))
+Base.show(io::IO, x::Union{Arb,Acb,AcbRef}) = print(io, string_nice(x))
 Base.show(io::IO, x::Arf) = print(io, string_decimal(x))
 
-for ArbT in (Mag, Arf, Arb, Acb)
+for ArbT in (Mag, Arf, Arb, Acb, AcbRef)
     arbf = Symbol(cprefix(ArbT), :_, :print)
     @eval begin
         function _string(x::$ArbT)

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,10 +1,10 @@
 digits_prec(prec::Integer) = floor(Int, prec * log(2) / log(10))
 
 Base.show(io::IO, x::Mag) = print(io, _string(x))
-Base.show(io::IO, x::Union{Arb,Acb,AcbRef}) = print(io, string_nice(x))
+Base.show(io::IO, x::Union{Arb,ArbRef,Acb,AcbRef}) = print(io, string_nice(x))
 Base.show(io::IO, x::Arf) = print(io, string_decimal(x))
 
-for ArbT in (Mag, Arf, Arb, Acb, AcbRef)
+for ArbT in (Mag, Arf, Arb, ArbRef, Acb, AcbRef)
     arbf = Symbol(cprefix(ArbT), :_, :print)
     @eval begin
         function _string(x::$ArbT)

--- a/src/types.jl
+++ b/src/types.jl
@@ -74,10 +74,14 @@ struct AcbRef <: Number
     prec::Int
     parent::Union{acb_vec_struct,acb_mat_struct}
 end
-function AcbRef(ptr::Ptr{acb_struct}, parent::Union{acb_vec_struct,acb_mat_struct}; prec::Int)
+function AcbRef(
+    ptr::Ptr{acb_struct},
+    parent::Union{acb_vec_struct,acb_mat_struct};
+    prec::Int,
+)
     AcbRef(ptr, prec, parent)
 end
-AcbRef(;prec::Int = DEFAULT_PRECISION[]) = Acb(;prec=prec)
+AcbRef(; prec::Int = DEFAULT_PRECISION[]) = Acb(; prec = prec)
 
 
 struct Acb <: Number

--- a/src/types.jl
+++ b/src/types.jl
@@ -90,7 +90,7 @@ struct Acb <: Number
     end
 end
 
-struct ArbVector <: AbstractVector{Arb}
+struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct
     prec::Int
 
@@ -98,7 +98,7 @@ struct ArbVector <: AbstractVector{Arb}
         new(arb_vec_struct(n), prec)
 end
 
-struct AcbVector <: AbstractVector{Acb}
+struct AcbVector <: DenseVector{Acb}
     acb_vec::acb_vec_struct
     prec::Int
 
@@ -106,7 +106,7 @@ struct AcbVector <: AbstractVector{Acb}
         new(acb_vec_struct(n), prec)
 end
 
-struct ArbMatrix <: AbstractMatrix{Arb}
+struct ArbMatrix <: DenseMatrix{Arb}
     arb_mat::arb_mat_struct
     prec::Int
 
@@ -116,7 +116,7 @@ struct ArbMatrix <: AbstractMatrix{Arb}
     end
 end
 
-struct AcbMatrix <: AbstractMatrix{Acb}
+struct AcbMatrix <: DenseMatrix{Acb}
     acb_mat::acb_mat_struct
     prec::Int
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,14 +7,9 @@ struct Arf <: Real
         return res
     end
 
-    function Arf(x::arf_struct; prec::Integer = DEFAULT_PRECISION[], shallow::Bool = false)
-        if shallow
-            res = new(x, prec)
-        else
-            res = Arf(prec = prec)
-            set!(res, x)
-        end
-
+    function Arf(x::arf_struct; prec::Integer = DEFAULT_PRECISION[])
+        res = Arf(prec = prec)
+        set!(res, x)
         return res
     end
 
@@ -32,13 +27,8 @@ struct Mag <: Real
         return res
     end
 
-    function Mag(x::mag_struct; shallow::Bool = false)
-        if shallow
-            res = new(x)
-        else
-            res = new(mag_struct(x))
-        end
-
+    function Mag(x::mag_struct)
+        res = new(mag_struct(x))
         return res
     end
 
@@ -57,31 +47,34 @@ struct Arb <: Real
         return res
     end
 
-    function Arb(x::arb_struct; prec::Integer = DEFAULT_PRECISION[], shallow::Bool = false)
-        if shallow
-            res = new(x, prec)
-        else
-            res = Arb(prec = prec)
-            set!(res, x)
-        end
-
+    function Arb(x::arb_struct; prec::Integer = DEFAULT_PRECISION[])
+        res = Arb(prec = prec)
+        set!(res, x)
         return res
     end
 end
 
-struct AcbRef <: Number
-    acb_ptr::Ptr{acb_struct}
+
+struct ArbRef <: Number
+    arb_ptr::Ptr{arb_struct}
     prec::Int
-    parent::Union{acb_vec_struct,acb_mat_struct}
+    parent::Union{arb_vec_struct,arb_mat_struct}
 end
-function AcbRef(
-    ptr::Ptr{acb_struct},
-    parent::Union{acb_vec_struct,acb_mat_struct};
+function ArbRef(
+    ptr::Ptr{arb_struct},
+    parent::Union{arb_vec_struct,arb_mat_struct};
     prec::Int,
 )
-    AcbRef(ptr, prec, parent)
+    ArbRef(ptr, prec, parent)
 end
-AcbRef(; prec::Int = DEFAULT_PRECISION[]) = Acb(; prec = prec)
+
+ArbRef(; prec::Int = DEFAULT_PRECISION[]) = Arb(; prec = prec)
+function Arb(x::ArbRef; prec::Integer = precision(x))
+    res = Arb(prec = prec)
+    set!(res, x)
+    return res
+end
+Base.getindex(x::ArbRef) = Arb(x)
 
 
 struct Acb <: Number
@@ -100,6 +93,21 @@ struct Acb <: Number
     end
 end
 
+
+struct AcbRef <: Number
+    acb_ptr::Ptr{acb_struct}
+    prec::Int
+    parent::Union{acb_vec_struct,acb_mat_struct}
+end
+function AcbRef(
+    ptr::Ptr{acb_struct},
+    parent::Union{acb_vec_struct,acb_mat_struct};
+    prec::Int,
+)
+    AcbRef(ptr, prec, parent)
+end
+
+AcbRef(; prec::Int = DEFAULT_PRECISION[]) = Acb(; prec = prec)
 function Acb(x::AcbRef; prec::Integer = precision(x))
     res = Acb(prec = prec)
     set!(res, x)
@@ -107,7 +115,7 @@ function Acb(x::AcbRef; prec::Integer = precision(x))
 end
 Base.getindex(x::AcbRef) = Acb(x)
 
-struct ArbVector <: DenseVector{Arb}
+struct ArbVector <: DenseVector{ArbRef}
     arb_vec::arb_vec_struct
     prec::Int
 
@@ -123,7 +131,7 @@ struct AcbVector <: DenseVector{AcbRef}
         new(acb_vec_struct(n), prec)
 end
 
-struct ArbMatrix <: DenseMatrix{Arb}
+struct ArbMatrix <: DenseMatrix{ArbRef}
     arb_mat::arb_mat_struct
     prec::Int
 
@@ -143,7 +151,7 @@ struct AcbMatrix <: DenseMatrix{AcbRef}
     end
 end
 
-const ArbTypes = Union{Arf,Arb,Acb,AcbRef,ArbVector,AcbVector,ArbMatrix,AcbMatrix}
+const ArbTypes = Union{Arf,Arb,ArbRef,Acb,AcbRef,ArbVector,AcbVector,ArbMatrix,AcbMatrix}
 
 for (T, prefix) in (
     (Mag, :mag),
@@ -167,13 +175,20 @@ for (T, prefix) in (
     end
 end
 
+
+cprefix(::Type{ArbRef}) = :arb_struct
+cstructtype(::Type{ArbRef}) = Ptr{arb_struct}
+cstruct(x::ArbRef) = x.arb_ptr
+Base.convert(::Type{Ptr{arb_struct}}, x::ArbRef) = cstruct(x)
+Base.cconvert(::Type{Ref{arb_struct}}, x::ArbRef) = cstruct(x)
+
 cprefix(::Type{AcbRef}) = :acb_struct
 cstructtype(::Type{AcbRef}) = Ptr{acb_struct}
 cstruct(x::AcbRef) = x.acb_ptr
 Base.convert(::Type{Ptr{acb_struct}}, x::AcbRef) = cstruct(x)
 Base.cconvert(::Type{Ref{acb_struct}}, x::AcbRef) = cstruct(x)
 
-function Base.setindex!(x::Union{Mag,Arf,Arb,Acb}, z::Number)
+function Base.setindex!(x::Union{Mag,Arf,Arb,ArbRef,Acb,AcbRef}, z::Number)
     set!(x, z)
     x
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -149,3 +149,8 @@ for (T, prefix) in (
         Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
     end
 end
+
+function Base.setindex!(x::Union{Mag,Arf,Arb,Acb}, z::Number)
+    set!(x, z)
+    x
+end

--- a/test/acb_matrix.jl
+++ b/test/acb_matrix.jl
@@ -16,4 +16,7 @@
 
     A = AcbMatrix([Acb(i + j) for i = 1:4, j = 1:4])
     @test A[4, 4] == Acb(8)
+    A = AcbMatrix([i + j for i = 1:4, j = 1:4])
+    @test A[4, 4] == Acb(8)
+    @test precision(A) == precision(Acb(8))
 end

--- a/test/acb_matrix.jl
+++ b/test/acb_matrix.jl
@@ -6,7 +6,7 @@
     x = Acb(1.5)
     M[2, 2] = x
     @test M[2, 2] == x
-    @test M[2, 2] isa Acb
+    @test M[2, 2] isa AcbRef
     @test precision(M[2, 2]) == 128
 
     Arblib.add!(M, M, M)

--- a/test/acb_vector.jl
+++ b/test/acb_vector.jl
@@ -6,8 +6,9 @@
     x = Acb(1.5)
     V[3] = x
     @test V[3] == x
-    @test V[3] isa Acb
+    @test V[3] isa AcbRef
     @test precision(V[3]) == 128
+    @test !isempty(sprint(show, V[3]))
 
     Arblib.add!(V, V, V, length(V))
     V2 = Arblib.AcbVector(4, prec = 128)

--- a/test/acb_vector.jl
+++ b/test/acb_vector.jl
@@ -17,4 +17,7 @@
 
     A = AcbVector([Acb(i + 1) for i = 2:5])
     @test A[end] == Acb(6)
+
+    A = AcbVector([i + j for i = 1:4 for j = 1:4])
+    @test A[16] == Acb(8)
 end

--- a/test/arb_matrix.jl
+++ b/test/arb_matrix.jl
@@ -6,8 +6,9 @@
     x = Arb(1.5)
     M[2, 2] = x
     @test M[2, 2] == x
-    @test M[2, 2] isa Arb
+    @test M[2, 2] isa ArbRef
     @test precision(M[2, 2]) == 128
+    @test !isempty(sprint(show, M[2, 2]))
 
     Arblib.add!(M, M, M)
     M2 = Arblib.ArbMatrix(4, 4, prec = 128)

--- a/test/arb_matrix.jl
+++ b/test/arb_matrix.jl
@@ -17,4 +17,7 @@
 
     A = ArbMatrix([Arb(i + j) for i = 1:4, j = 1:4])
     @test A[4, 4] == Arb(8)
+
+    A = ArbMatrix([i + j for i = 1:4, j = 1:4])
+    @test A[4, 4] == Arb(8)
 end

--- a/test/arb_vector.jl
+++ b/test/arb_vector.jl
@@ -6,7 +6,8 @@
     x = Arb(1.5)
     V[3] = x
     @test V[3] == x
-    @test V[3] isa Arb
+    @test V[3] isa ArbRef
+    @test !isempty(sprint(show, V[3]))
     @test precision(V[3]) == 128
 
     Arblib.add!(V, V, V, length(V))

--- a/test/arb_vector.jl
+++ b/test/arb_vector.jl
@@ -17,4 +17,7 @@
 
     A = ArbVector([Arb(i + 1) for i = 2:5])
     @test A[end] == Arb(6)
+
+    A = ArbVector([i + j for i = 1:4 for j = 1:4])
+    @test A[16] == Arb(8)
 end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -26,14 +26,14 @@
                 "arb_t res",
                 "res",
                 false,
-                Union{Arb,arb_struct,Ptr{arb_struct}},
+                Union{Arb,ArbRef,arb_struct,Ptr{arb_struct}},
                 Ref{arb_struct},
             ),
             (
                 "acb_t res",
                 "res",
                 false,
-                Union{Acb,acb_struct,Ptr{acb_struct}},
+                Union{Acb,AcbRef,acb_struct,Ptr{acb_struct}},
                 Ref{acb_struct},
             ),
             (
@@ -54,14 +54,14 @@
                 "const arb_t x",
                 "x",
                 true,
-                Union{Arb,arb_struct,Ptr{arb_struct}},
+                Union{Arb,ArbRef,arb_struct,Ptr{arb_struct}},
                 Ref{arb_struct},
             ),
             (
                 "const acb_t x",
                 "x",
                 true,
-                Union{Acb,acb_struct,Ptr{acb_struct}},
+                Union{Acb,AcbRef,acb_struct,Ptr{acb_struct}},
                 Ref{acb_struct},
             ),
             (
@@ -234,15 +234,15 @@
         for (str, args, kwargs) in (
             (
                 "void arb_init(arb_t x)",
-                [:(x::$(Union{Arb,arb_struct,Ptr{arb_struct}}))],
+                [:(x::$(Union{Arb,ArbRef,arb_struct,Ptr{arb_struct}}))],
                 Expr[],
             ),
             (
                 "void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)",
                 [
-                    :(z::$(Union{arb_struct,Ptr{arb_struct},Arb})),
-                    :(x::$(Union{arb_struct,Ptr{arb_struct},Arb})),
-                    :(y::$(Union{arb_struct,Ptr{arb_struct},Arb})),
+                    :(z::$(Union{arb_struct,Ptr{arb_struct},Arb,ArbRef})),
+                    :(x::$(Union{arb_struct,Ptr{arb_struct},Arb,ArbRef})),
+                    :(y::$(Union{arb_struct,Ptr{arb_struct},Arb,ArbRef})),
                 ],
                 [Expr(:kw, :(prec::Integer), :(precision(z)))],
             ),

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -9,8 +9,8 @@
         @test typeof(zero(Mag())) == Mag
         @test typeof(one(Mag())) == Mag
         @test typeof(Mag(π)) == Mag
-        @test typeof(Mag(Mag().mag, shallow = false)) == Mag
-        @test typeof(Mag(Mag().mag, shallow = true)) == Mag
+        @test typeof(Mag(Mag().mag)) == Mag
+        @test typeof(Mag(Mag().mag)) == Mag
     end
 
     @testset "Arf" begin

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -92,9 +92,9 @@
                 end
 
                 prec *= 2
-                x = setprecision(x, prec, shallow = true)
-                r = setprecision(r, prec, shallow = true)
-                t = setprecision(t, prec, shallow = true)
+                x = setprecision(x, prec)
+                r = setprecision(r, prec)
+                t = setprecision(t, prec)
             end
 
             return x

--- a/test/linear_algebra.jl
+++ b/test/linear_algebra.jl
@@ -1,0 +1,24 @@
+@testset "LinearAlgebra" begin
+    Af = rand(ComplexF64, 3, 3)
+    bf = rand(ComplexF64, 3)
+    A = AcbMatrix(Acb.(Af))
+    b = AcbMatrix(Acb.(bf))
+    c = AcbMatrix(3, 1)
+
+    # lu factorization
+    ldiv!(c, A, b)
+    c′ = A \ b
+    @test Arblib.overlaps(c, c′) == 1
+    ldiv!(c, lu(A), b)
+    @test Arblib.overlaps(c, c′) == 1
+    ldiv!(c, lu!(copy(A)), b)
+    @test Arblib.overlaps(c, c′) == 1
+    d = copy(b)
+    ldiv!(lu(A), d)
+    @test Arblib.overlaps(d, c′) == 1
+
+    # inv
+    id = copy(A)
+    Arblib.one!(id)
+    @test Bool(Arblib.contains(inv(A) * A, id))
+end

--- a/test/linear_algebra.jl
+++ b/test/linear_algebra.jl
@@ -23,10 +23,10 @@
     @test Bool(Arblib.contains(inv(A) * A, id))
 
     # mul
-    A = ArbMatrix(rand(3,2))
-    B = ArbMatrix(rand(2,4))
-    B_wrong = ArbMatrix(rand(3,4))
-    C = ArbMatrix(3,4)
+    A = ArbMatrix(rand(3, 2))
+    B = ArbMatrix(rand(2, 4))
+    B_wrong = ArbMatrix(rand(3, 4))
+    C = ArbMatrix(3, 4)
     @test_throws DimensionMismatch("Matrix sizes are not compatible.") A * B_wrong
     LinearAlgebra.mul!(C, A, B)
     @test C == A * B

--- a/test/linear_algebra.jl
+++ b/test/linear_algebra.jl
@@ -21,4 +21,13 @@
     id = copy(A)
     Arblib.one!(id)
     @test Bool(Arblib.contains(inv(A) * A, id))
+
+    # mul
+    A = ArbMatrix(rand(3,2))
+    B = ArbMatrix(rand(2,4))
+    B_wrong = ArbMatrix(rand(3,4))
+    C = ArbMatrix(3,4)
+    @test_throws DimensionMismatch("Matrix sizes are not compatible.") A * B_wrong
+    LinearAlgebra.mul!(C, A, B)
+    @test C == A * B
 end

--- a/test/precision-test.jl
+++ b/test/precision-test.jl
@@ -21,16 +21,28 @@
             x = T()
             @test precision(x) == precdefault
 
-            y = setprecision(x, prec, shallow = false)
-            z = setprecision(x, prec, shallow = true)
+            y = setprecision(x, prec)
             @test precision(y) == prec
-            @test precision(z) == prec
-
-            # Test that y is a normal copy and z a shallow copy
             Arblib.set!(y, 2)
             @test !isequal(x, y)
-            Arblib.set!(z, 2)
-            @test isequal(x, z)
         end
     end
+
+    @testset "setprecision 2" begin
+        x = Arb("0.1")
+        @test precision(x) == 256
+        @test precision(Arb) == 256
+        @test string(x) ==
+              "[0.1000000000000000000000000000000000000000000000000000000000000000000000000000 +/- 1.95e-78]"
+
+        setprecision(Arb, 64)
+        @test precision(x) == 256
+        @test precision(Arb) == 64
+        y = Arb("0.1")
+        @test precision(y) == 64
+        @test string(y) == "[0.100000000000000000 +/- 1.22e-20]"
+
+        setprecision(Arb, 256)
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Arblib, Test
+using Arblib, Test, LinearAlgebra
 
 include("arb_types-test.jl")
 include("types-test.jl")
@@ -12,6 +12,7 @@ include("arb_vector.jl")
 include("acb_vector.jl")
 include("arb_matrix.jl")
 include("acb_matrix.jl")
+include("linear_algebra.jl")
 
 @testset "Arblib" begin
     @test isa(Arb(π), Arb)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,36 +1,17 @@
 using Arblib, Test, LinearAlgebra
 
-include("arb_types-test.jl")
-include("types-test.jl")
-include("arbcall-test.jl")
-include("precision-test.jl")
-include("constructors-test.jl")
-include("predicates-test.jl")
-include("show-test.jl")
-include("examples.jl")
-include("arb_vector.jl")
-include("acb_vector.jl")
-include("arb_matrix.jl")
-include("acb_matrix.jl")
-include("linear_algebra.jl")
-
 @testset "Arblib" begin
-    @test isa(Arb(π), Arb)
-end
-
-@testset "setprecision" begin
-    x = Arb("0.1")
-    @test precision(x) == 256
-    @test precision(Arb) == 256
-    @test string(x) ==
-          "[0.1000000000000000000000000000000000000000000000000000000000000000000000000000 +/- 1.95e-78]"
-
-    setprecision(Arb, 64)
-    @test precision(x) == 256
-    @test precision(Arb) == 64
-    y = Arb("0.1")
-    @test precision(y) == 64
-    @test string(y) == "[0.100000000000000000 +/- 1.22e-20]"
-
-    setprecision(Arb, 256)
+    include("arb_types-test.jl")
+    include("types-test.jl")
+    include("arbcall-test.jl")
+    include("precision-test.jl")
+    include("constructors-test.jl")
+    include("predicates-test.jl")
+    include("show-test.jl")
+    include("examples.jl")
+    include("arb_vector.jl")
+    include("acb_vector.jl")
+    include("arb_matrix.jl")
+    include("acb_matrix.jl")
+    include("linear_algebra.jl")
 end


### PR DESCRIPTION
As the title suggests this is a grab bag of things I stumbled over / needed.
* Adding non-inplace versions for basic arithmetic, exp, log and trig functions 
* Support for square linear system solving
* Constructor from `Rational`
* Fix `zeros(Acb, n)` and `ones(Acb, n)` (previously this would just allocate one element, i.e., all entries shared the same memory)
* Overload `setindex!(a,b)` to call `set!` where `a` is `Union{Mag, Arf, Arb,Acb}` and `b` a number. This allows the syntax
```julia
x = zero(Acb)
y = Acb(2)
x[] = y # identical to set!(x, y)
```
which is consistent with how, e.g. , `Ref`s are updated.