### PR TITLE
Allow only linear indexing of matrices of size n x 1

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -52,6 +52,23 @@ end
 
 ## Common methods
 
+# linear indexing
+Base.@propagate_inbounds function Base.getindex(A::Union{ArbMatrix,AcbMatrix}, k::Integer)
+    @boundscheck (1 ≤ k ≤ length(A) || throw(BoundsError(A, k)))
+    j, i = divrem(k - 1, size(A, 1))
+    A[i+1, j+1]
+end
+Base.@propagate_inbounds function Base.setindex!(
+    A::Union{ArbMatrix,AcbMatrix},
+    x,
+    k::Integer,
+)
+    @boundscheck (1 ≤ k ≤ length(A) || throw(BoundsError(A, k)))
+    j, i = divrem(k - 1, size(A, 1))
+    A[i+1, j+1] = x
+    x
+end
+
 # General constructor
 for T in [:ArbMatrix, :AcbMatrix]
     @eval function $T(A::AbstractMatrix, prec::Integer = _precision(first(A)))

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -53,4 +53,14 @@
         LinearAlgebra.mul!(C, A, B)
         @test C == A * B
     end
+
+    @testset "indexing" begin
+        A = ArbMatrix(3, 1)
+        A[3, 1][] = 4
+        @test A[3] == A[3, 1]
+        B = ArbMatrix(reshape(1:15, 3, 5))
+        @test B[1:15] == 1:15
+        C = ArbMatrix(reshape(1:15, 5, 3))
+        @test C[1:15] == 1:15
+    end
 end


### PR DESCRIPTION
Linear indexing of matrices can be handy if you need to manipulate a vector but also perform matrix-vector multiplication, since this is in Arb only defined between matrices. I also want to make the multiplication working, but I think this is good first step.
Otherwise, the linear indexing of matrices can be confusing since Arb has a row-major memory layout.