### PR TITLE
Add realref, imagref, real, imag of Acb

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -68,3 +68,15 @@ for f in [
         z
     end
 end
+
+function realref(z::AcbLike; prec = _precision(z))
+    real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, cstruct(z))
+end
+function imagref(z::AcbLike; prec = _precision(z))
+    real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, cstruct(z))
+end
+Base.real(z::AcbLike; prec = _precision(z)) = get_real!(Arb(prec = prec), z)
+Base.imag(z::AcbLike; prec = _precision(z)) = get_imag!(Arb(prec = prec), z)
+Base.conj(z::AcbLike) = conj!(Acb(prec = _precision(z)), z)

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,11 +58,11 @@ end
 struct ArbRef <: Number
     arb_ptr::Ptr{arb_struct}
     prec::Int
-    parent::Union{arb_vec_struct,arb_mat_struct}
+    parent::Union{acb_struct,arb_vec_struct,arb_mat_struct}
 end
 function ArbRef(
     ptr::Ptr{arb_struct},
-    parent::Union{arb_vec_struct,arb_mat_struct};
+    parent::Union{acb_struct,arb_vec_struct,arb_mat_struct};
     prec::Int,
 )
     ArbRef(ptr, prec, parent)
@@ -143,6 +143,8 @@ end
 AcbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     AcbMatrix(acb_mat_struct(r, c), prec)
 
+const ArbLike = Union{Arb,ArbRef,Ptr{arb_struct},arb_struct}
+const AcbLike = Union{Acb,AcbRef,Ptr{acb_struct},acb_struct}
 const ArbTypes = Union{Arf,Arb,ArbRef,Acb,AcbRef,ArbVector,AcbVector,ArbMatrix,AcbMatrix}
 
 for (T, prefix) in (
@@ -163,6 +165,7 @@ for (T, prefix) in (
     @eval begin
         cprefix(::Type{$T}) = $(QuoteNode(Symbol(prefix)))
         cstruct(x::$T) = getfield(x, cprefix($T))
+        cstruct(x::$arbstruct) = x
         Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
     end
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -25,4 +25,17 @@
         @test a + 3 == 3
         @test a + 3 isa T
     end
+
+    @testset "real/imag" begin
+        x, y = Arb(rand()), Arb(rand())
+        z = Acb(x, y)
+
+        Arblib.realref(z) isa ArbRef
+        Arblib.realref(z) == x
+        real(z) == x
+        Arblib.imagref(z) isa ArbRef
+        Arblib.imagref(z) == y
+        imag(z) == y
+
+    end
 end


### PR DESCRIPTION
Extends the parent field of `ArbRef` to also allow `Acb`. The `realref` 
and `imagref` methods are recommended in the Arb manual as a fallback if 
a method is not implemented for `Acb`.