### PR TITLE
Convert Mag, Arf to Float64

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -14,8 +14,8 @@ macro libflint(function_name)
 end
 
 include("arb_types.jl")
-include("types.jl")
 include("rounding.jl")
+include("types.jl")
 include("arbcall.jl")
 
 include("precision.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -187,3 +187,17 @@ function Base.setindex!(x::Union{Mag,Arf,Arb,ArbRef,Acb,AcbRef}, z::Number)
     set!(x, z)
     x
 end
+
+Base.Float64(x::Mag) = get(x)
+function Base.Float64(
+    x::Union{Arf,Ptr{arf_struct}};
+    rnd::Union{arb_rnd,RoundingMode} = RoundNearest,
+)
+    ccall(@libarb(arf_get_d), Cdouble, (Ref{arf_struct}, arb_rnd), x, rnd)
+end
+function Base.Int(
+    x::Union{Arf,Ptr{arf_struct}};
+    rnd::Union{arb_rnd,RoundingMode} = RoundNearest,
+)
+    ccall(@libarb(arf_get_si), Clong, (Ref{arf_struct}, arb_rnd), x, rnd)
+end

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -11,6 +11,9 @@
         @test typeof(Mag(π)) == Mag
         @test typeof(Mag(Mag().mag)) == Mag
         @test typeof(Mag(Mag().mag)) == Mag
+        @test Float64(Mag(2.0)) isa Float64
+        # Mag doesn't guarantee exact conversions, just upper bounds
+        @test Float64(Mag(2.0)) ≥ 2.0
     end
 
     @testset "Arf" begin
@@ -31,6 +34,18 @@
         @test precision(Arf(Arf(prec = 64))) == 64
         @test precision(zero(Arf(prec = 64))) == 64
         @test precision(one(Arf(prec = 64))) == 64
+
+        @test Float64(Arf(2.0)) isa Float64
+        @test Float64(Arf(2.0)) == 2.0
+        @test convert(Float64, Arf(2.0)) isa Float64
+        @test convert(Float64, Arf(2.0)) == 2.0
+        @test Int(Arf(2.0)) isa Int
+        @test Int(Arf(2.0)) == 2
+        @test convert(Int, Arf(2.0)) isa Int
+        @test convert(Int, Arf(2.0)) == 2
+        @test Int(Arf(2.0)) == 2
+        @test Int(Arf(0.5)) == 0
+        @test Int(Arf(0.5); rnd = Arblib.ArbRoundFromZero) == 1
     end
 
     @testset "Arb" begin


### PR DESCRIPTION
This allows to convert a `Mag` or `Arf` to a `Float64` using the syntax 
`m[]` which is quite neat. The other types don't have a simple `get` 
function.