### PR TITLE
add similar

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -34,7 +34,6 @@ include("arbcall.jl")
 include("precision.jl")
 
 include("constructors.jl")
-
 include("predicates.jl")
 include("show.jl")
 include("arithmetic.jl")

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -41,6 +41,7 @@ include("arithmetic.jl")
 
 include("vector.jl")
 include("matrix.jl")
+include("array_common.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/array_common.jl
+++ b/src/array_common.jl
@@ -1,0 +1,28 @@
+for (ElT, n, T) in (
+    (Acb, 2, :AcbMatrix),
+    (AcbRef, 2, :AcbRefMatrix),
+    (Arb, 2, :ArbMatrix),
+    (ArbRef, 2, :ArbRefMatrix),
+
+    (Acb, 1, :AcbVector),
+    (AcbRef, 1, :AcbRefVector),
+    (Arb, 1, :ArbVector),
+    (ArbRef, 1, :ArbRefVector),
+)
+    @eval begin
+        function Base.similar(
+            A::Matrices,
+            ::Type{<:$ElT},
+            dims::Dims{$n},
+        )
+            return $T(dims..., prec = precision(A))
+        end
+        function Base.similar(
+            A::Vectors,
+            ::Type{<:$ElT},
+            dims::Dims{$n},
+        )
+            return $T(dims..., prec = precision(A))
+        end
+    end
+end

--- a/src/array_common.jl
+++ b/src/array_common.jl
@@ -3,25 +3,16 @@ for (ElT, n, T) in (
     (AcbRef, 2, :AcbRefMatrix),
     (Arb, 2, :ArbMatrix),
     (ArbRef, 2, :ArbRefMatrix),
-
     (Acb, 1, :AcbVector),
     (AcbRef, 1, :AcbRefVector),
     (Arb, 1, :ArbVector),
     (ArbRef, 1, :ArbRefVector),
 )
     @eval begin
-        function Base.similar(
-            A::Matrices,
-            ::Type{<:$ElT},
-            dims::Dims{$n},
-        )
+        function Base.similar(A::Matrices, ::Type{<:$ElT}, dims::Dims{$n})
             return $T(dims..., prec = precision(A))
         end
-        function Base.similar(
-            A::Vectors,
-            ::Type{<:$ElT},
-            dims::Dims{$n},
-        )
+        function Base.similar(A::Vectors, ::Type{<:$ElT}, dims::Dims{$n})
             return $T(dims..., prec = precision(A))
         end
     end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -125,8 +125,6 @@ for T in [:ArbMatrix, :ArbRefMatrix, :AcbMatrix, :AcbRefMatrix]
     end
 end
 
-## Common methods
-
 const Matrices = Union{ArbMatrix,ArbRefMatrix,AcbMatrix,AcbRefMatrix}
 
 Base.copy(A::T) where {T<:Matrices} = copy!(T(size(A)...; prec = precision(A)), A)
@@ -154,11 +152,7 @@ for (jf, af) in [(:+, :add!), (:-, :sub!)]
     end
 end
 
-function Base.:(-)(A::T) where {T<:Matrices}
-    C = T(size(A)...; prec = precision(A))
-    neg!(C, A)
-    C
-end
+Base.:(-)(A::Matrices) = neg!(similar(A), A)
 
 function LinearAlgebra.mul!(C::T, A::T, B::T) where {T<:Matrices}
     @boundscheck (
@@ -180,8 +174,8 @@ function LinearAlgebra.lu!(A::T) where {T<:Matrices}
     retcode = lu!(ipiv, A, A)
     LinearAlgebra.LU(A, ipiv, retcode > 0 ? 0 : 1)
 end
-function LinearAlgebra.lu(A::T) where {T<:Matrices}
-    lu = T(size(A)...; prec = precision(A))
+function LinearAlgebra.lu(A::Matrices)
+    lu = similar(A)
     ipiv = zeros(Int, size(A, 2))
     retcode = lu!(ipiv, lu, A)
     LinearAlgebra.LU(lu, ipiv, retcode > 0 ? 0 : 1)
@@ -225,8 +219,4 @@ function Base.:(\)(A::LinearAlgebra.LU{<:Any,T}, B::T) where {T<:Matrices}
 end
 
 # inverse
-function LinearAlgebra.inv(A::T) where {T<:Matrices}
-    B = T(size(A)...; prec = precision(A))
-    Arblib.inv!(B, A)
-    B
-end
+LinearAlgebra.inv(A::Matrices) = (B = similar(A); inv!(B, A); B)

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -115,13 +115,8 @@ for (jf, af) in [(:+, :add!), (:-, :sub!)]
         u
     end
 end
-function Base.:(-)(v::T) where {T<:Vectors}
-    n = length(v)
-    w = T(length(v); prec = precision(v))
-    neg!(w, v)
-    w
-end
+Base.:(-)(v::Vectors) = neg!(similar(v), v)
 
-Base.copy(v::T) where {T<:Vectors} = copy!(T(length(v); prec = precision(v)), v)
+Base.copy(v::Vectors) = copy!(similar(v), v)
 Base.copy!(w::T, v::T) where {T<:Vectors} = set!(w, v)
 Base.copyto!(w::T, v::T) where {T<:Vectors} = set!(w, v)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -100,8 +100,8 @@
 
         for (ElT, VT, MT) in (
             (Arb, ArbVector, ArbMatrix),
-            # (Acb, AcbVector, AcbMatrix),
-            # (ArbRef, ArbRefVector, ArbRefMatrix),
+            (Acb, AcbVector, AcbMatrix),
+            (ArbRef, ArbRefVector, ArbRefMatrix),
             (AcbRef, AcbRefVector, AcbRefMatrix),
         )
             a = similar(A, ElT, 3)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -78,14 +78,42 @@
     end
 
     @testset "indexing" begin
-        A = ArbMatrix(3, 1)
+        A = TMat(3, 1)
         A[3, 1][] = 4
         @test A[3] == A[3, 1]
-        B = ArbMatrix(reshape(1:15, 3, 5))
+        B = TMat(reshape(1:15, 3, 5))
         @test B[1:15] == 1:15
-        C = ArbMatrix(reshape(1:15, 5, 3))
+        C = TMat(reshape(1:15, 5, 3))
         @test C[1:15] == 1:15
     end
+
+    @testset "similar:" begin
+        A = TMat(3,5; prec = 96)
+
+        a = similar(A)
+        @test a isa TMat
+        @test precision(a) == precision(A)
+
+        a = similar(A, TRef, (2,3))
+        @test a isa TMat
+        @test precision(a) == precision(A)
+
+        for (ElT, VT, MT) in (
+            (Arb, ArbVector, ArbMatrix),
+            # (Acb, AcbVector, AcbMatrix),
+            # (ArbRef, ArbRefVector, ArbRefMatrix),
+            (AcbRef, AcbRefVector, AcbRefMatrix),
+        )
+            a = similar(A, ElT, 3)
+            @test a isa VT
+            @test precision(a) == precision(A)
+
+            a = similar(A, ElT, (3,2))
+            @test a isa MT
+            @test precision(a) == precision(A)
+        end
+    end
+
 end
 
 

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -88,13 +88,13 @@
     end
 
     @testset "similar:" begin
-        A = TMat(3,5; prec = 96)
+        A = TMat(3, 5; prec = 96)
 
         a = similar(A)
         @test a isa TMat
         @test precision(a) == precision(A)
 
-        a = similar(A, TRef, (2,3))
+        a = similar(A, TRef, (2, 3))
         @test a isa TMat
         @test precision(a) == precision(A)
 
@@ -108,7 +108,7 @@
             @test a isa VT
             @test precision(a) == precision(A)
 
-            a = similar(A, ElT, (3,2))
+            a = similar(A, ElT, (3, 2))
             @test a isa MT
             @test precision(a) == precision(A)
         end

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -72,7 +72,7 @@
             @test a isa VT
             @test precision(a) == precision(A)
 
-            a = similar(A, ElT, (3,2))
+            a = similar(A, ElT, (3, 2))
             @test a isa MT
             @test precision(a) == precision(A)
         end
@@ -94,4 +94,3 @@ end
     @test C == A
     @test C[4] == 4
 end
-

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -50,6 +50,33 @@
     D = TVec(length(A); prec = 96)
     Arblib.add!(D, A, B, length(AInt), 96)
     @test D == AInt + BInt
+
+    @testset "similar" begin
+        A = TVec(5; prec = 96)
+
+        a = similar(A)
+        @test a isa TVec
+        @test precision(a) == precision(A)
+
+        a = similar(A, TRef, 3)
+        @test a isa TVec
+        @test precision(a) == precision(A)
+
+        for (ElT, VT, MT) in (
+            (Arb, ArbVector, ArbMatrix),
+            # (Acb, AcbVector, AcbMatrix),
+            # (ArbRef, ArbRefVector, ArbRefMatrix),
+            (AcbRef, AcbRefVector, AcbRefMatrix),
+        )
+            a = similar(A, ElT, 3)
+            @test a isa VT
+            @test precision(a) == precision(A)
+
+            a = similar(A, ElT, (3,2))
+            @test a isa MT
+            @test precision(a) == precision(A)
+        end
+    end
 end
 
 @testset "VectorRef: $T" for (T, TRef) in
@@ -67,3 +94,4 @@ end
     @test C == A
     @test C[4] == 4
 end
+

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -64,8 +64,8 @@
 
         for (ElT, VT, MT) in (
             (Arb, ArbVector, ArbMatrix),
-            # (Acb, AcbVector, AcbMatrix),
-            # (ArbRef, ArbRefVector, ArbRefMatrix),
+            (Acb, AcbVector, AcbMatrix),
+            (ArbRef, ArbRefVector, ArbRefMatrix),
             (AcbRef, AcbRefVector, AcbRefMatrix),
         )
             a = similar(A, ElT, 3)


### PR DESCRIPTION
As in the title, preserves `precision`;

Depending on the order of merges, the `A::Union{...}` would need to be adjusted to contain ref vectors/matrices as well
