### PR TITLE
use ispredicate(::Arbfunction) to return Bool from arbcall

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -3,6 +3,8 @@ module Arblib
 using Arb_jll
 import LinearAlgebra
 
+import Base: contains
+
 export Arf,
     Arb,
     ArbRef,

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -3,7 +3,10 @@ module Arblib
 using Arb_jll
 import LinearAlgebra
 
-import Base: contains
+
+if VERSION >= v"1.5.0-DEV.639"
+    import Base: contains
+end
 
 export Arf,
     Arb,

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -184,7 +184,7 @@ function ispredicate(af::Arbfunction)
            (
                any(s -> startswith(string(jlfname(af)), s), ("is_",)) ||
                any(
-                   s -> contains(string(jlfname(af)), s),
+                   s -> occursin(s, string(jlfname(af))),
                    ("_is_", "contains", "can_", "check_", "validate_"),
                ) ||
                any(==(jlfname(af)), (:eq, :ne, :lt, :le, :gt, :ge, :overlaps, :equal))

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -178,6 +178,15 @@ function extract_length_argument!(kwargs, len_keywords, carg, prev_carg)
     push!(kwargs, Expr(:kw, :($(name(carg))::Integer), :(length($vec_name))))
     push!(len_keywords, name(carg))
 end
+function ispredicate(af::Arbfunction)
+    return isconst(first(arguments(af))) &&
+           returntype(af) == Cint &&
+           (
+               any(s -> startswith(string(jlfname(af)), s), ("is_", )) ||
+               any(s ->   contains(string(jlfname(af)), s), ("_is_", "contains", "can_", "check_", "validate_")) ||
+               any(==(jlfname(af)), (:eq, :ne, :lt, :le, :gt, :ge, :overlaps))
+           )
+end
 
 function jlargs(af::Arbfunction; argument_detection::Bool = true)
     cargs = arguments(af)
@@ -273,7 +282,15 @@ function jlcode(af::Arbfunction, jl_fname = jlfname(af))
                 $(Expr(:tuple, ctype.(cargs)...)),
                 $(name.(cargs)...),
             )
-            $(returnT == Nothing && inplace(af) ? name(first(arguments(af))) : :__ret)
+            $(
+                if returnT === Nothing && inplace(af)
+                    name(first(arguments(af)))
+                elseif ispredicate(af)
+                    :(!iszero(__ret))
+                else
+                    :__ret
+                end
+            )
         end
     )
 

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -184,7 +184,7 @@ function ispredicate(af::Arbfunction)
            (
                any(s -> startswith(string(jlfname(af)), s), ("is_", )) ||
                any(s ->   contains(string(jlfname(af)), s), ("_is_", "contains", "can_", "check_", "validate_")) ||
-               any(==(jlfname(af)), (:eq, :ne, :lt, :le, :gt, :ge, :overlaps))
+               any(==(jlfname(af)), (:eq, :ne, :lt, :le, :gt, :ge, :overlaps, :equal))
            )
 end
 

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -182,8 +182,11 @@ function ispredicate(af::Arbfunction)
     return isconst(first(arguments(af))) &&
            returntype(af) == Cint &&
            (
-               any(s -> startswith(string(jlfname(af)), s), ("is_", )) ||
-               any(s ->   contains(string(jlfname(af)), s), ("_is_", "contains", "can_", "check_", "validate_")) ||
+               any(s -> startswith(string(jlfname(af)), s), ("is_",)) ||
+               any(
+                   s -> contains(string(jlfname(af)), s),
+                   ("_is_", "contains", "can_", "check_", "validate_"),
+               ) ||
                any(==(jlfname(af)), (:eq, :ne, :lt, :le, :gt, :ge, :overlaps, :equal))
            )
 end

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -183,6 +183,34 @@
         @test !Arblib.is_length_argument(carg1, prev_carg, len_keywords)
     end
 
+    @testset "Predicate detection" begin
+        for sig in (
+            "int acb_is_zero(const acb_t z)",
+            "int acb_is_int_2exp_si(const acb_t x, slong e)",
+            "int acb_equal_si(const acb_t x, slong y)",
+            "int arb_ne(const arb_t x, const arb_t y)",
+            "int acb_overlaps(const acb_t x, const acb_t y)",
+            "int acb_contains(const acb_t x, const acb_t y)",
+            "int acb_is_real(const acb_t x)",
+            "int _acb_vec_is_zero(acb_srcptr vec, slong len)",
+            "int _arb_vec_is_finite(arb_srcptr x, slong len)",
+        )
+            @test Arblib.ispredicate(Arblib.Arbfunction(sig))
+        end
+
+        for sig in (
+            "int acb_mat_lu_classical(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)",
+            "int acb_mat_lu_recursive(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)",
+            "int acb_mat_lu(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)",
+            "int acb_mat_inv(acb_mat_t X, const acb_mat_t A, slong prec)",
+            "int arb_sgn_nonzero(const arb_t x)",
+            "int arf_set_round(arf_t res, const arf_t x, slong prec, arf_rnd_t rnd)",
+            "int arf_cmp(const arf_t x, const arf_t y)",
+        )
+            @test !Arblib.ispredicate(Arblib.Arbfunction(sig))
+        end
+    end
+
     @testset "jlargs" begin
         for (str, args, kwargs) in (
             ("void arb_init(arb_t x)", [:(x::$(Arblib.ArbLike))], Expr[]),


### PR DESCRIPTION
This adds just predicate detection and uses it to turn the returned `int` to `Bool`. Arblib returns "success", hence non-zero output can be interpreted as `true` 