### PR TITLE
Add MagRef and ArfRef

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -3,12 +3,14 @@ module Arblib
 using Arb_jll
 import LinearAlgebra
 
-
 if VERSION >= v"1.5.0-DEV.639"
     import Base: contains
 end
 
-export Arf,
+export Mag,
+    MagRef,
+    Arf,
+    ArfRef,
     Arb,
     ArbRef,
     Acb,

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -213,8 +213,13 @@ function jlargs(af::Arbfunction; argument_detection::Bool = true)
             @assert !prec_kwarg
             prec_kwarg = true
 
-            c₁ = first(cargs)
-            push!(kwargs, Expr(:kw, :(prec::Integer), :(_precision($(name(c₁))))))
+            # If the first argument has a precision,
+            # then use this otherwise make it a mandatory kwarg
+            if rawtype(cargs[1]) <: ArbTypes && rawtype(cargs[1]) != Mag
+                push!(kwargs, Expr(:kw, :(prec::Integer), :(_precision($(name(cargs[1]))))))
+            else
+                push!(kwargs, :(prec::Integer))
+            end
 
             # Automatic detection of rounding mode argument
         elseif carg == Carg{arb_rnd}(:rnd, false)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,20 +1,19 @@
-Base.promote_rule(::Type{Mag}, ::Type{Float64}) = Mag
-Base.promote_rule(::Type{Arf}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
+Base.promote_rule(::Type{<:MagLike}, ::Type{Float64}) = Mag
+Base.promote_rule(::Type{<:ArfLike}, ::Type{<:Union{AbstractFloat,Integer}}) = Arf
 Base.promote_rule(
-    ::Type{<:Union{Arb,ArbRef}},
-    ::Type{<:Union{AbstractFloat,Integer,Rational,Arf,ArbRef}},
+    ::Type{<:ArbLike},
+    ::Type{<:Union{AbstractFloat,Integer,Rational,ArfLike,ArbRef}},
 ) = Arb
 Base.promote_rule(
-    ::Type{<:Union{Acb,AcbRef}},
+    ::Type{<:AcbLike},
     ::Type{
         <:Union{
             AbstractFloat,
             Integer,
             Rational,
             Complex{<:Union{AbstractFloat,Integer,Rational}},
-            Arf,
-            Arb,
-            ArbRef,
+            ArfLike,
+            ArbLike,
             AcbRef,
         },
     },

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -70,14 +70,6 @@ for f in [
     end
 end
 
-function realref(z::AcbLike; prec = _precision(z))
-    real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
-    ArbRef(real_ptr, prec, cstruct(z))
-end
-function imagref(z::AcbLike; prec = _precision(z))
-    real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
-    ArbRef(real_ptr, prec, cstruct(z))
-end
 Base.real(z::AcbLike; prec = _precision(z)) = get_real!(Arb(prec = prec), z)
 Base.imag(z::AcbLike; prec = _precision(z)) = get_imag!(Arb(prec = prec), z)
 Base.conj(z::AcbLike) = conj!(Acb(prec = _precision(z)), z)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -171,13 +171,13 @@ end
 # lu factorization
 function LinearAlgebra.lu!(A::T) where {T<:Matrices}
     ipiv = zeros(Int, size(A, 2))
-    retcode = lu!(ipiv, A, A)
+    retcode = lu!(ipiv, A, A; prec = precision(A))
     LinearAlgebra.LU(A, ipiv, retcode > 0 ? 0 : 1)
 end
 function LinearAlgebra.lu(A::Matrices)
     lu = similar(A)
     ipiv = zeros(Int, size(A, 2))
-    retcode = lu!(ipiv, lu, A)
+    retcode = lu!(ipiv, lu, A; prec = precision(lu))
     LinearAlgebra.LU(lu, ipiv, retcode > 0 ? 0 : 1)
 end
 

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -13,6 +13,8 @@ Base.precision(::Type{<:Ptr{<:ArbStructTypes}}) = DEFAULT_PRECISION[]
 Base.precision(x::ArbStructTypes) = DEFAULT_PRECISION[]
 Base.precision(x::Ptr{<:ArbStructTypes}) = DEFAULT_PRECISION[]
 Base.precision(x::ArbTypes) = x.prec
+# MagLike <: ArbTypes
+Base.precision(x::MagLike) = DEFAULT_PRECISION[]
 
 @inline _precision(x::ArbTypes) = precision(x)
 @inline _precision(_) = DEFAULT_PRECISION[]

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -33,7 +33,10 @@ function Base.setprecision(::Type{<:ArbTypes}, precision::Integer)
     return precision
 end
 
-function Base.setprecision(x::T, precision::Integer) where {T<:Union{Arf,Arb,Acb}}
+function Base.setprecision(
+    x::T,
+    precision::Integer,
+) where {T<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
     return T(x, prec = precision)
 end
 Base.setprecision(v::ArbVector, precision::Integer) = ArbVector(v.arb_vec, precision)

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -94,20 +94,15 @@ end
 #Base.:(<=)(x::Arf, y::Arf) = !isnan(x) && !isnan(y) && cmp(x, y) <= 0
 #Base.isequal(x::Arf, y::Arf) = !iszero(is_equal(x, y))
 
-for ArbT in (MagLike, ArfLike, ArbLike, AcbLike)
+for ArbT in (ArfLike, ArbLike, AcbLike)
     @eval begin
         Base.isequal(y::$ArbT, x::$ArbT) = !iszero(equal(x, y))
-    end
-
-    ArbT == MagLike && continue
-
-    # Comparison of non-floating point values should use ==
-    @eval begin
+        # Comparison of non-floating point values should use ==
         Base.:(==)(y::Integer, x::$ArbT) = !iszero(equal(x, y))
         Base.:(==)(x::$ArbT, y::Integer) = !iszero(equal(x, y))
     end
 end
-
+Base.:(==)(x::MagLike, y::MagLike) = !iszero(equal(x, y))
 Base.isless(x::MagLike, y::MagLike) = cmp(x, y) < 0
 Base.:(<)(x::MagLike, y::MagLike) = cmp(x, y) < 0
 Base.:(<=)(x::MagLike, y::MagLike) = cmp(x, y) <= 0
@@ -121,6 +116,7 @@ for jltype in (Arf, Integer, Unsigned, Base.GMP.CdoubleMax)
 end
 
 for (ArbT, args) in (
+    (ArfLike, ((:(==), :equal),)),
     (
         ArbLike,
         ((:(==), :eq), (:(!=), :ne), (:(<), :lt), (:(<=), :le), (:(>), :gt), (:(>=), :ge)),

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -1,6 +1,6 @@
 for (T, funcpairs) in (
     (
-        Mag,
+        MagLike,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isinf), :is_inf),
@@ -9,7 +9,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        Arf,
+        ArfLike,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isinf), :is_inf),
@@ -24,7 +24,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        Union{Arb,ArbRef},
+        ArbLike,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -39,7 +39,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        Union{Acb,AcbRef},
+        AcbLike,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -51,9 +51,9 @@ for (T, funcpairs) in (
             (:containsint, :contains_int),
         ),
     ),
-    (ArbVector, ((:(Base.isfinite), :is_finite), (:(Base.iszero), :is_zero))),
+    (ArbVectorLike, ((:(Base.isfinite), :is_finite), (:(Base.iszero), :is_zero))),
     (
-        AcbVector,
+        AcbVectorLike,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isreal), :is_real),
@@ -61,7 +61,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        ArbMatrix,
+        ArbMatrixLike,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -70,7 +70,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        AcbMatrix,
+        AcbMatrixLike,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -94,12 +94,12 @@ end
 #Base.:(<=)(x::Arf, y::Arf) = !isnan(x) && !isnan(y) && cmp(x, y) <= 0
 #Base.isequal(x::Arf, y::Arf) = !iszero(is_equal(x, y))
 
-for ArbT in (Mag, Arf, Union{Arb,ArbRef}, Union{Acb,AcbRef})
+for ArbT in (MagLike, ArfLike, ArbLike, AcbLike)
     @eval begin
         Base.isequal(y::$ArbT, x::$ArbT) = !iszero(equal(x, y))
     end
 
-    ArbT == Mag && continue
+    ArbT == MagLike && continue
 
     # Comparison of non-floating point values should use ==
     @eval begin
@@ -108,26 +108,26 @@ for ArbT in (Mag, Arf, Union{Arb,ArbRef}, Union{Acb,AcbRef})
     end
 end
 
-Base.isless(x::Mag, y::Mag) = cmp(x, y) < 0
-Base.:(<)(x::Mag, y::Mag) = cmp(x, y) < 0
-Base.:(<=)(x::Mag, y::Mag) = cmp(x, y) <= 0
+Base.isless(x::MagLike, y::MagLike) = cmp(x, y) < 0
+Base.:(<)(x::MagLike, y::MagLike) = cmp(x, y) < 0
+Base.:(<=)(x::MagLike, y::MagLike) = cmp(x, y) <= 0
 
 for jltype in (Arf, Integer, Unsigned, Base.GMP.CdoubleMax)
     @eval begin
-        Base.isless(x::Arf, y::$jltype) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
-        Base.:(<)(x::Arf, y::$jltype) = !isnan(x) && !isnan(y) && cmp(x, y) < 0
-        Base.:(<=)(x::Arf, y::$jltype) = (x < y) || isequal(x, y)
+        Base.isless(x::ArfLike, y::$jltype) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
+        Base.:(<)(x::ArfLike, y::$jltype) = !isnan(x) && !isnan(y) && cmp(x, y) < 0
+        Base.:(<=)(x::ArfLike, y::$jltype) = (x < y) || isequal(x, y)
     end
 end
 
 for (ArbT, args) in (
     (
-        Union{Arb,ArbRef},
+        ArbLike,
         ((:(==), :eq), (:(!=), :ne), (:(<), :lt), (:(<=), :le), (:(>), :gt), (:(>=), :ge)),
     ),
-    (Union{Acb,AcbRef}, ((:(==), :eq), (:(!=), :ne))),
-    (ArbMatrix, ((:(==), :eq), (:(!=), :ne))),
-    (AcbMatrix, ((:(==), :eq), (:(!=), :ne))),
+    (AcbLike, ((:(==), :eq), (:(!=), :ne))),
+    (ArbMatrixLike, ((:(==), :eq), (:(!=), :ne))),
+    (AcbMatrixLike, ((:(==), :eq), (:(!=), :ne))),
 )
     for (jlf, arbf) in args
         @eval begin

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -85,15 +85,6 @@ for (T, funcpairs) in (
     end
 end
 
-#Base.isless(x::Mag, y::Mag) = cmp(x, y) < 0
-#Base.:(==)(x::Mag, y::Mag) = !iszero(is_equal(x, y))
-#
-#Base.isless(x::Arf, y::Arf) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
-#Base.:(==)(x::Arf, y::Arf) = !isnan(x) && !iszero(equal(x, y))
-#Base.:(<)(x::Arf, y::Arf) = !isnan(x) && !isnan(y) && cmp(x, y) < 0
-#Base.:(<=)(x::Arf, y::Arf) = !isnan(x) && !isnan(y) && cmp(x, y) <= 0
-#Base.isequal(x::Arf, y::Arf) = !iszero(is_equal(x, y))
-
 for ArbT in (ArfLike, ArbLike, AcbLike)
     @eval begin
         Base.isequal(y::$ArbT, x::$ArbT) = !iszero(equal(x, y))

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,10 +1,10 @@
 digits_prec(prec::Integer) = floor(Int, prec * log(2) / log(10))
 
-Base.show(io::IO, x::Mag) = print(io, _string(x))
+Base.show(io::IO, x::Union{Mag,MagRef}) = print(io, _string(x))
 Base.show(io::IO, x::Union{Arb,ArbRef,Acb,AcbRef}) = print(io, string_nice(x))
-Base.show(io::IO, x::Arf) = print(io, string_decimal(x))
+Base.show(io::IO, x::Union{Arf,ArfRef}) = print(io, string_decimal(x))
 
-for ArbT in (Mag, Arf, Arb, ArbRef, Acb, AcbRef)
+for ArbT in (Mag, MagRef, Arf, ArfRef, Arb, ArbRef, Acb, AcbRef)
     arbf = Symbol(cprefix(ArbT), :_, :print)
     @eval begin
         function _string(x::$ArbT)
@@ -23,7 +23,7 @@ for ArbT in (Mag, Arf, Arb, ArbRef, Acb, AcbRef)
         end
     end
 
-    ArbT == Mag && continue # no mag_printd and mag_printn
+    (ArbT == Mag || ArbT == MagRef) && continue # no mag_printd and mag_printn
 
     @eval begin
         function string_decimal(x::$ArbT, digits::Integer = digits_prec(precision(x)))
@@ -42,7 +42,7 @@ for ArbT in (Mag, Arf, Arb, ArbRef, Acb, AcbRef)
         end
     end
 
-    ArbT == Arf && continue #no arf_printn
+    (ArbT == Arf || ArbT == ArfRef) && continue #no arf_printn
 
     @eval begin
         function string_nice(
@@ -66,7 +66,7 @@ for ArbT in (Mag, Arf, Arb, ArbRef, Acb, AcbRef)
     end
 end
 
-for ArbT in (Mag, Arf, Arb)
+for ArbT in (Mag, MagRef, Arf, ArfRef, Arb, ArbRef)
     @eval begin
         function load_string!(x::$ArbT, str::AbstractString)
             res = load!(x, str)

--- a/src/types.jl
+++ b/src/types.jl
@@ -281,7 +281,7 @@ Base.setindex!(x::Union{Arf,ArfRef}, z::Ptr{arf_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arb,ArbRef}, z::Ptr{arb_struct}) = set!(x, z)
 Base.setindex!(x::Union{Acb,AcbRef}, z::Ptr{acb_struct}) = set!(x, z)
 
-function midref(x::Union{Arb,ArbRef}, prec = _precision(x))
+function midref(x::Union{Arb,ArbRef}, prec = precision(x))
     mid_ptr = ccall(@libarb(arb_mid_ptr), Ptr{arf_struct}, (Ref{arb_struct},), x)
     ArfRef(mid_ptr, prec, parentstruct(x))
 end
@@ -290,11 +290,11 @@ function radref(x::Union{Arb,ArbRef})
     MagRef(rad_ptr, parentstruct(x))
 end
 
-function realref(z::Union{Acb,AcbRef}; prec = _precision(z))
+function realref(z::Union{Acb,AcbRef}; prec = precision(z))
     real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
     ArbRef(real_ptr, prec, parentstruct(z))
 end
-function imagref(z::Union{Acb,AcbRef}; prec = _precision(z))
+function imagref(z::Union{Acb,AcbRef}; prec = precision(z))
     real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
     ArbRef(real_ptr, prec, parentstruct(z))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,6 +38,7 @@ struct Mag <: Real
     end
 end
 
+
 struct Arb <: Real
     arb::arb_struct
     prec::Int
@@ -55,7 +56,7 @@ struct Arb <: Real
 end
 
 
-struct ArbRef <: Number
+struct ArbRef <: Real
     arb_ptr::Ptr{arb_struct}
     prec::Int
     parent::Union{acb_struct,arb_vec_struct,arb_mat_struct}
@@ -76,6 +77,25 @@ function Arb(x::ArbRef; prec::Integer = precision(x))
 end
 Base.getindex(x::ArbRef) = Arb(x)
 
+struct MagRef <: Real
+    mag_ptr::Ptr{mag_struct}
+    parent::Union{arb_struct,ArbRef}
+end
+Mag(x::MagRef) = set!(Mag(), x)
+Base.getindex(x::MagRef) = Mag(x)
+
+struct ArfRef <: Real
+    arf_ptr::Ptr{arf_struct}
+    prec::Int
+    parent::Union{arb_struct,ArbRef}
+end
+function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Int)
+    ArfRef(ptr, prec, parent)
+end
+
+ArfRef(; prec::Int = DEFAULT_PRECISION[]) = Arf(; prec = prec)
+Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
+Base.getindex(x::ArfRef) = Arf(x)
 
 struct Acb <: Number
     acb::acb_struct
@@ -208,20 +228,26 @@ for (T, prefix) in (
     end
 end
 
-cprefix(::Type{ArbRef}) = :arb_struct
-cstructtype(::Type{ArbRef}) = Ptr{arb_struct}
-cstruct(x::ArbRef) = x.arb_ptr
-Base.convert(::Type{Ptr{arb_struct}}, x::ArbRef) = cstruct(x)
-Base.cconvert(::Type{Ref{arb_struct}}, x::ArbRef) = cstruct(x)
+# handle Ref types
+for prefix in [:mag, :arf, :arb, :acb]
+    T = Symbol(uppercasefirst(string(prefix)))
+    TRef = Symbol(T, :Ref)
+    TStruct = Symbol(prefix, :_struct)
+    TPtr = Symbol(prefix, :_ptr)
+    @eval begin
+        cprefix(::Type{$TRef}) = $(QuoteNode(prefix))
+        cstructtype(::Type{$TRef}) = $TStruct
+        cstruct(x::$TRef) = x.$TPtr
+        Base.convert(::Type{Ptr{$TStruct}}, x::$TRef) = cstruct(x)
+        Base.cconvert(::Type{Ref{$TStruct}}, x::$TRef) = cstruct(x)
 
-cprefix(::Type{AcbRef}) = :acb_struct
-cstructtype(::Type{AcbRef}) = Ptr{acb_struct}
-cstruct(x::AcbRef) = x.acb_ptr
-Base.convert(::Type{Ptr{acb_struct}}, x::AcbRef) = cstruct(x)
-Base.cconvert(::Type{Ref{acb_struct}}, x::AcbRef) = cstruct(x)
+        parentstruct(x::$T) = cstruct(x)
+        parentstruct(x::$TRef) = x
+    end
+end
 
-const MagLike = Union{Mag,cstructtype(Mag),Ptr{cstructtype(Mag)}}
-const ArfLike = Union{Arf,cstructtype(Arf),Ptr{cstructtype(Arf)}}
+const MagLike = Union{Mag,MagRef,cstructtype(Mag),Ptr{cstructtype(Mag)}}
+const ArfLike = Union{Arf,ArfRef,cstructtype(Arf),Ptr{cstructtype(Arf)}}
 const ArbLike = Union{Arb,ArbRef,cstructtype(Arb),Ptr{cstructtype(Arb)}}
 const AcbLike = Union{Acb,AcbRef,cstructtype(Acb),Ptr{cstructtype(Acb)}}
 const ArbVectorLike = Union{ArbVector,ArbRefVector,cstructtype(ArbVector)}
@@ -229,7 +255,10 @@ const AcbVectorLike = Union{AcbVector,AcbRefVector,cstructtype(AcbVector)}
 const ArbMatrixLike = Union{ArbMatrix,ArbRefMatrix,cstructtype(ArbMatrix)}
 const AcbMatrixLike = Union{AcbMatrix,AcbRefMatrix,cstructtype(AcbMatrix)}
 const ArbTypes = Union{
+    Mag,
+    MagRef,
     Arf,
+    ArfRef,
     Arb,
     ArbRef,
     Acb,
@@ -244,20 +273,37 @@ const ArbTypes = Union{
     AcbRefMatrix,
 }
 
-Base.setindex!(x::Union{Mag,Arf,Arb,ArbRef,Acb,AcbRef}, z::Number) = set!(x, z)
+Base.setindex!(x::Union{Mag,MagRef,Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}, z::Number) =
+    set!(x, z)
+Base.setindex!(x::Union{Mag,MagRef}, z::Ptr{mag_struct}) = set!(x, z)
+Base.setindex!(x::Union{Arf,ArfRef}, z::Ptr{arf_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arb,ArbRef}, z::Ptr{arb_struct}) = set!(x, z)
 Base.setindex!(x::Union{Acb,AcbRef}, z::Ptr{acb_struct}) = set!(x, z)
 
-Base.Float64(x::Mag) = get(x)
-function Base.Float64(
-    x::Union{Arf,Ptr{arf_struct}};
-    rnd::Union{arb_rnd,RoundingMode} = RoundNearest,
-)
+function midref(x::Union{Arb,ArbRef}, prec = _precision(x))
+    mid_ptr = ccall(@libarb(arb_mid_ptr), Ptr{arf_struct}, (Ref{arb_struct},), x)
+    ArfRef(mid_ptr, prec, parentstruct(x))
+end
+function radref(x::Union{Arb,ArbRef})
+    rad_ptr = ccall(@libarb(arb_rad_ptr), Ptr{mag_struct}, (Ref{arb_struct},), x)
+    MagRef(rad_ptr, parentstruct(x))
+end
+
+function realref(z::Union{Acb,AcbRef}; prec = _precision(z))
+    real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, parentstruct(z))
+end
+function imagref(z::Union{Acb,AcbRef}; prec = _precision(z))
+    real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, parentstruct(z))
+end
+
+Base.Float64(x::MagLike) = get(x)
+function Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest)
     ccall(@libarb(arf_get_d), Cdouble, (Ref{arf_struct}, arb_rnd), x, rnd)
 end
-function Base.Int(
-    x::Union{Arf,Ptr{arf_struct}};
-    rnd::Union{arb_rnd,RoundingMode} = RoundNearest,
-)
+function Base.Int(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest)
     ccall(@libarb(arf_get_si), Clong, (Ref{arf_struct}, arb_rnd), x, rnd)
 end
+Base.Float64(x::ArbLike) = Float64(midref(x))
+Base.ComplexF64(z::AcbLike) = Complex(Float64(realref(z)), Float64(imagref(z)))

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,47 +56,6 @@ struct Arb <: Real
 end
 
 
-struct ArbRef <: Real
-    arb_ptr::Ptr{arb_struct}
-    prec::Int
-    parent::Union{acb_struct,arb_vec_struct,arb_mat_struct}
-end
-function ArbRef(
-    ptr::Ptr{arb_struct},
-    parent::Union{acb_struct,arb_vec_struct,arb_mat_struct};
-    prec::Int,
-)
-    ArbRef(ptr, prec, parent)
-end
-
-ArbRef(; prec::Int = DEFAULT_PRECISION[]) = Arb(; prec = prec)
-function Arb(x::ArbRef; prec::Integer = precision(x))
-    res = Arb(prec = prec)
-    set!(res, x)
-    return res
-end
-Base.getindex(x::ArbRef) = Arb(x)
-
-struct MagRef <: Real
-    mag_ptr::Ptr{mag_struct}
-    parent::Union{arb_struct,ArbRef}
-end
-Mag(x::MagRef) = set!(Mag(), x)
-Base.getindex(x::MagRef) = Mag(x)
-
-struct ArfRef <: Real
-    arf_ptr::Ptr{arf_struct}
-    prec::Int
-    parent::Union{arb_struct,ArbRef}
-end
-function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Int)
-    ArfRef(ptr, prec, parent)
-end
-
-ArfRef(; prec::Int = DEFAULT_PRECISION[]) = Arf(; prec = prec)
-Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
-Base.getindex(x::ArfRef) = Arf(x)
-
 struct Acb <: Number
     acb::acb_struct
     prec::Int
@@ -113,7 +72,7 @@ struct Acb <: Number
     end
 end
 
-
+# Refs are in reverse order to model their possible depencies
 struct AcbRef <: Number
     acb_ptr::Ptr{acb_struct}
     prec::Int
@@ -134,6 +93,48 @@ function Acb(x::AcbRef; prec::Integer = precision(x))
     return res
 end
 Base.getindex(x::AcbRef) = Acb(x)
+
+struct ArbRef <: Real
+    arb_ptr::Ptr{arb_struct}
+    prec::Int
+    parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct}
+end
+function ArbRef(
+    ptr::Ptr{arb_struct},
+    parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct};
+    prec::Int,
+)
+    ArbRef(ptr, prec, parent)
+end
+
+ArbRef(; prec::Int = DEFAULT_PRECISION[]) = Arb(; prec = prec)
+function Arb(x::ArbRef; prec::Integer = precision(x))
+    res = Arb(prec = prec)
+    set!(res, x)
+    return res
+end
+Base.getindex(x::ArbRef) = Arb(x)
+
+struct ArfRef <: Real
+    arf_ptr::Ptr{arf_struct}
+    prec::Int
+    parent::Union{arb_struct,ArbRef}
+end
+function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Int)
+    ArfRef(ptr, prec, parent)
+end
+
+ArfRef(; prec::Int = DEFAULT_PRECISION[]) = Arf(; prec = prec)
+Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
+Base.getindex(x::ArfRef) = Arf(x)
+
+struct MagRef <: Real
+    mag_ptr::Ptr{mag_struct}
+    parent::Union{arb_struct,ArbRef}
+end
+Mag(x::MagRef) = set!(Mag(), x)
+Base.getindex(x::MagRef) = Mag(x)
+
 
 struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct

--- a/test/arf_ref-test.jl
+++ b/test/arf_ref-test.jl
@@ -1,0 +1,12 @@
+@testset "ArfRef from ArbRef" begin
+    v = ArbRefVector([1.0, 2.0, 3.0])
+    @test v[3] isa ArbRef
+    x = Arblib.midref(v[3])
+    @test x isa ArfRef
+    @test startswith(sprint(show, x), "3")
+    y = typeof(x)()
+    @test y isa Arf
+    y[] = x
+    @test startswith(sprint(show, y), "3")
+    @test y == x
+end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -30,12 +30,39 @@
         x, y = Arb(rand()), Arb(rand())
         z = Acb(x, y)
 
-        Arblib.realref(z) isa ArbRef
-        Arblib.realref(z) == x
-        real(z) == x
-        Arblib.imagref(z) isa ArbRef
-        Arblib.imagref(z) == y
-        imag(z) == y
+        @test Arblib.realref(z) isa ArbRef
+        @test Arblib.realref(z) == x
+        @test real(z) == x
+        @test Arblib.imagref(z) isa ArbRef
+        @test Arblib.imagref(z) == y
+        @test imag(z) == y
+    end
 
+    @testset "midref" begin
+        x = Arb(0.25)
+        @test Arblib.midref(x) isa ArfRef
+        @test startswith(sprint(show, x), "0.250")
+        @test Float64(Arblib.midref(x)) isa Float64
+        @test Float64(Arblib.midref(x)) == 0.25
+        @test Float64(x) == 0.25
+        @test sprint(show, x) == sprint(show, x[])
+    end
+
+    @testset "radref" begin
+        x = Arb(0.25)
+        m = Arblib.radref(x)
+        @test m isa MagRef
+        m[] = 1.0
+        @test Float64(m) ≥ 1.0
+        @test sprint(show, m) == sprint(show, m[])
+    end
+
+    @testset "convert to Float64/ComplexF64" begin
+        x = Arb(0.25)
+        @test Float64(x) isa Float64
+        @test Float64(x) == 0.25
+        z = Acb(2.0 + 0.125im)
+        @test ComplexF64(z) isa ComplexF64
+        @test ComplexF64(z) == 2.0 + 0.125im
     end
 end

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -1,6 +1,4 @@
 @testset "constructors" begin
-    Mag = Arblib.Mag
-
     @testset "Mag" begin
         @test typeof(Mag(UInt64(1))) == Mag
         @test typeof(Mag(1.0)) == Mag
@@ -105,5 +103,18 @@
         x = Acb()
         x[] = (1.0 + 2.0im)
         @test x == Acb(1, 2)
+    end
+
+    @testset "MagRef/ArfRef" begin
+        x = Arb(2.0)
+        m = Arblib.radref(x)
+        @test m isa MagRef
+        @test m[] isa Mag
+        @test m == m[]
+
+        d = Arblib.midref(x)
+        @test d isa ArfRef
+        @test d[] isa Arf
+        @test d == d[]
     end
 end

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -71,7 +71,13 @@
         tol = 1e-12
         λ_approx, R_approx = Arblib.approx_eig_qr(M, tol = tol)
 
-        @test Arblib.eig_global_enclosure!(ε, M, λ_approx, R_approx) isa Arblib.Mag
+        @test Arblib.eig_global_enclosure!(
+            ε,
+            M,
+            λ_approx,
+            R_approx;
+            prec = precision(M),
+        ) isa Arblib.Mag
 
         @info Arblib.get(ε)
         @test ε <= tol

--- a/test/ref-test.jl
+++ b/test/ref-test.jl
@@ -10,3 +10,12 @@
     @test startswith(sprint(show, y), "3")
     @test y == x
 end
+
+@testset "Refs from AcbRef" begin
+    v = AcbRefVector([1, 2, 3])
+    @test v[1] isa AcbRef
+    @test Arblib.realref(v[1]) isa ArbRef
+    @test Arblib.midref(Arblib.realref(v[1])) isa ArfRef
+    @test Arblib.imagref(v[1]) isa ArbRef
+    @test ComplexF64(v[1]) == 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,5 +13,5 @@ using Arblib, Test, LinearAlgebra
     include("vector.jl")
     include("matrix.jl")
     include("eigen.jl")
-    include("arf_ref-test.jl")
+    include("ref-test.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ using Arblib, Test, LinearAlgebra
     include("vector.jl")
     include("matrix.jl")
     include("eigen.jl")
+    include("arf_ref-test.jl")
 end


### PR DESCRIPTION
This superseeds #52 since the rebasing of #52 onto master was basically not possible. I decided to also directly add a `MagRef` type since we need it anyways. With this PR is not now possible to convert an `Acb` to a `ComplexF64` (by using the midpoint of `Acb`) without any allocations.