### PR TITLE
add initial version of integration

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -58,6 +58,7 @@ include("matrix.jl")
 include("array_common.jl")
 include("eigen.jl")
 include("poly.jl")
+include("calc_integrate.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -199,4 +199,3 @@ mutable struct calc_integrate_opt_struct
         return opts
     end
 end
-

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -170,3 +170,33 @@ const ArbStructTypes = Union{
     arb_mat_struct,
     acb_mat_struct,
 }
+
+mutable struct calc_integrate_opt_struct
+    deg_limit::Clong
+    eval_limit::Clong
+    depth_limit::Clong
+    use_heap::Cint
+    verbose::Cint
+
+    function calc_integrate_opt_struct(
+        deg_limit::Integer,
+        eval_limit::Integer,
+        depth_limit::Integer,
+        use_heap::Integer = 0,
+        verbose::Integer = 0,
+    )
+        return new(deg_limit, eval_limit, depth_limit, use_heap, verbose)
+    end
+
+    function calc_integrate_opt_struct()
+        opts = new()
+        ccall(
+            @libarb(acb_calc_integrate_opt_init),
+            Cvoid,
+            (Ref{calc_integrate_opt_struct},),
+            opts,
+        )
+        return opts
+    end
+end
+

--- a/src/calc_integrate.jl
+++ b/src/calc_integrate.jl
@@ -5,12 +5,9 @@ function _acb_calc_func!(
     order::Clong,
     prec::Clong,
 )
-    @assert iszero(order) || isone(order) # ← we'd need to verify holomorphicity
-    # x = Acb(unsafe_load(inp), prec=prec)
-    # TODO: Make Acb allow Nothing as parent
-    tmp = AcbVector(1)
-    x = AcbRef(inp, cstruct(tmp), prec = prec)
-    res = AcbRef(out, cstruct(tmp), prec = prec)
+    @assert iszero(order) || isone(order)
+    x = AcbRef(inp, nothing, prec = prec)
+    res = AcbRef(out, nothing, prec = prec)
     f! = unsafe_pointer_to_objref(param)
 
     f!(res, x, analytic = isone(order), prec = prec)

--- a/src/calc_integrate.jl
+++ b/src/calc_integrate.jl
@@ -153,6 +153,20 @@ particular, there are three differences from `integrate`:
 
 3. The default precision is taken from `res` instead of from `a` and
    `b`.
+
+# Examples
+```jldoctest
+julia> Arblib.integrate!(Arblib.sin!, Acb(0), Acb(0), Acb(10)) # Integrate sin from 0 to 10
+[1.83907152907645245225886394782406483451993016513316854683595373104879258687 +/- 5.15e-75]
+
+julia> Arblib.integrate!(Arblib.inv!, Acb(0), Acb(1, -5), Acb(1, 5)) # Integrate 1/z from 1 - 5i to 1 + 5i
+[+/- 2.02e-75] + [2.74680153389003172172254385288992229730199919179940161793956671182574846633 +/- 2.83e-75]im
+
+julia> # Integrate √z from 1 - 5im to 1 + 5im, taking into account the branch cut at (-∞, 0]
+julia> f! = (res, z; analytic = false) -> Arblib.sqrt_analytic!(res, z, analytic);
+julia> Arblib.integrate!(f!, Acb(0), Acb(1, -5), Acb(1, 10), check_analytic = true, prec = 64)
+[-9.0064084416559764 +/- 6.53e-17] + [23.8636067095598007 +/- 6.98e-17]im
+```
 """
 function integrate!(
     f!,
@@ -226,9 +240,8 @@ end
         rtol=0.0,
         atol=2.0^-prec,
         opts::Union{acb_calc_integrate_opt_struct, Ptr{Cvoid}} = C_NULL)
-Computes a rigorous enclosure of the integral
-∫ₐᵇ f(t) dt
-where `f` is any (holomorphic) julia function. From Arb docs:
+Computes a rigorous enclosure of the integral ∫ₐᵇ f(x) dx where
+`f(x::AcbRef)` is any (holomorphic) julia function. From Arb docs:
 
 > The integral follows a straight-line path between the complex numbers `a` and
 > `b`. For finite results, `a`, `b` must be finite and `f` must be bounded on
@@ -251,8 +264,8 @@ with branch cuts or other things which makes them non-holomorphic the
 argument `check_analytic` has to be set to `true`. In this case `f`
 will be given a keyword argument `analytic::Bool`, if `analytic` is
 `false` then nothing special has to be done, but if `analytic` is
-`true` then the output has to be non-finite if `f` is not
-holomorphic on the whole input ball (typically `Arb(NaN)`).
+`true` then the output has to be non-finite (typically `Acb(NaN)`) if
+`f` is not holomorphic on the whole input ball.
 
 !!! Note: It's users responsibility to verify holomorphicity of `f`.
 
@@ -266,11 +279,35 @@ Parameters:
    `acb_calc_integrate_opt_struct` controlling the algorithmic aspects of integration.
 
 !!! Note: `integrate` does not guarantee to satisfy provided
-    tolerances.
+    tolerances. But the result is guaranteed to be contained in the
+    resulting ball.
 
 For more information please consider arblib documentation and the
-paper https://arxiv.org/abs/1802.07942.
+paper
+> Fredrik Johansson, Numerical integration in arbitrary-precision ball arithmetic,
+> _Mathematical Software – ICMS 2018_
+> https://doi.org/10.1007/978-3-319-96418-8
+> https://arxiv.org/abs/1802.07942
 
+# Examples
+```jldoctest
+julia> Arblib.integrate(sin, 0, 10) # Integrate sin from 0 to 10
+[1.83907152907645245225886394782406483451993016513316854683595373104879258687 +/- 5.15e-75]
+
+julia> Arblib.integrate(z -> 1/z, Acb(1, -5), Acb(1, 5)) # Integrate 1/z from 1 - 5i to 1 + 5i
+[+/- 2.02e-75] + [2.74680153389003172172254385288992229730199919179940161793956671182574846633 +/- 2.83e-75]im
+
+julia> # Integrate √z from 1 - 5im to 1 + 5im, taking into account the branch cut at (-∞, 0]
+julia> f = (z; analytic = false) -> begin
+           if analytic && Arblib.contains_nonpositive(real(z))
+               return Acb(NaN, prec = precision(z))
+           else
+               return sqrt(z)
+           end
+       end;
+julia> Arblib.integrate(f, Acb(1, -5), Acb(1, 10), check_analytic = true, prec = 64)
+[-9.0064084416559764 +/- 7.40e-17] + [23.8636067095598007 +/- 9.03e-17]im
+```
 """
 function integrate(
     f,

--- a/src/calc_integrate.jl
+++ b/src/calc_integrate.jl
@@ -156,9 +156,9 @@ particular, there are three differences from `integrate`:
 """
 function integrate!(
     f!,
-    res::Union{Acb,AcbRef},
-    a::Union{Acb,AcbRef},
-    b::Union{Acb,AcbRef};
+    res::AcbOrRef,
+    a::AcbOrRef,
+    b::AcbOrRef;
     check_analytic::Bool = false,
     take_prec::Bool = false,
     prec::Integer = precision(res),
@@ -193,7 +193,7 @@ end
 
 function integrate!(
     f!,
-    res::Union{Acb,AcbRef},
+    res::AcbOrRef,
     a::Number,
     b::Number;
     check_analytic::Bool = false,
@@ -274,8 +274,8 @@ paper https://arxiv.org/abs/1802.07942.
 """
 function integrate(
     f,
-    a::Union{Acb,AcbRef},
-    b::Union{Acb,AcbRef};
+    a::AcbOrRef,
+    b::AcbOrRef;
     check_analytic::Bool = false,
     take_prec::Bool = false,
     prec = max(precision(a), precision(b)),

--- a/src/calc_integrate.jl
+++ b/src/calc_integrate.jl
@@ -170,11 +170,11 @@ function integrate!(
     rel_goal = iszero(rtol) ? prec : max(-floor(Int, log2(atol)), 0)
 
     if !check_analytic && !take_prec
-        g! = (inp, out; analytic, prec) -> f!(inp, out)
+        g! = (res, x; analytic, prec) -> f!(res, x)
     elseif !check_analytic && take_prec
-        g! = (inp, out; analytic, prec) -> f!(inp, out, prec = prec)
+        g! = (res, x; analytic, prec) -> f!(res, x, prec = prec)
     elseif check_analytic && !take_prec
-        g! = (inp, out; analytic, prec) -> f!(inp, out, analytic = analytic)
+        g! = (res, x; analytic, prec) -> f!(res, x, analytic = analytic)
     else
         g! = f!
     end
@@ -283,7 +283,7 @@ function integrate(
     atol = set_ui_2exp!(Mag(), one(UInt), -prec),
     opts::Union{Ptr{Cvoid},calc_integrate_opt_struct} = C_NULL,
 )
-    f! = (out, inp; kwargs...) -> set!(out, f(inp; kwargs...))
+    f! = (res, x; kwargs...) -> set!(res, f(x; kwargs...))
     res = Acb(prec = prec)
 
     return integrate!(

--- a/src/calc_integrate.jl
+++ b/src/calc_integrate.jl
@@ -1,0 +1,199 @@
+function _acb_calc_func!(
+    out::Ptr{acb_struct},
+    inp::Ptr{acb_struct},
+    param::Ptr{Cvoid}, # pointer to the actual function
+    order::Cint,
+    prec::Cint,
+)
+    @assert iszero(order) || isone(order) # ← we'd need to verify holomorphicity
+    # x = Acb(unsafe_load(inp), prec=prec)
+    x = inp
+    f = unsafe_pointer_to_objref(param)
+    # @debug "Evaluating at" x
+    f(out, x, prec = prec)
+    return zero(Cint)
+end
+
+_acb_calc_cfunc!() = @cfunction(
+    _acb_calc_func!,
+    Cint,
+    (Ptr{acb_struct}, Ptr{acb_struct}, Ptr{Cvoid}, Cint, Cint)
+)
+
+function calc_integrate!(
+    res::AcbLike,
+    acb_calc_cfunc::Ptr{Cvoid}, # cfunction
+    param,
+    a::AcbLike,
+    b::AcbLike,
+    rel_goal::Clong,
+    abs_tol::MagLike,
+    options::calc_integrate_opt_struct,
+    prec::Clong,
+)
+    @info "ccalling in calc_integrate!"
+    return ccall(
+        @libarb(acb_calc_integrate),
+        Cint,
+        (
+            Ref{acb_struct},
+            Ptr{Cvoid},
+            Any,
+            Ref{acb_struct},
+            Ref{acb_struct},
+            Clong,
+            Ref{mag_struct},
+            Ref{calc_integrate_opt_struct},
+            Clong,
+        ),
+        res,
+        acb_calc_cfunc,
+        param,
+        a,
+        b,
+        rel_goal,
+        abs_tol,
+        options,
+        prec,
+    )
+end
+
+function calc_integrate!(
+    res::AcbLike,
+    acb_calc_func,
+    param,
+    a::AcbLike,
+    b::AcbLike,
+    rel_goal::Clong,
+    abs_tol::MagLike,
+    options::Ptr{Cvoid},
+    prec::Clong,
+)
+    return ccall(
+        @libarb(acb_calc_integrate),
+        Cint,
+        (
+            Ref{acb_struct},
+            Ptr{Cvoid},
+            Any,
+            Ref{acb_struct},
+            Ref{acb_struct},
+            Clong,
+            Ref{mag_struct},
+            Ptr{Cvoid},
+            Clong,
+        ),
+        res,
+        acb_calc_func,
+        param,
+        a,
+        b,
+        rel_goal,
+        abs_tol,
+        options,
+        prec,
+    )
+end
+
+
+function integrate!(
+    res::AcbLike,
+    f,
+    a::AcbLike,
+    b::AcbLike;
+    prec = max(_precision(a), _precision(b)),
+    rel_goal = prec,
+    abs_tol::MagLike = set_ui_2exp!(Arblib.Mag(), one(UInt), -prec),
+    opts::Union{Ptr{Cvoid},calc_integrate_opt_struct} = C_NULL,
+)
+
+    return calc_integrate!(
+        res,
+        _acb_calc_cfunc!(),
+        f,
+        a,
+        b,
+        rel_goal,
+        abs_tol,
+        opts, # passing C_NULL uses the default options
+        prec,
+    )
+end
+
+"""
+    integrate(f, a::Number, b::Number;
+        prec = max(precision(a), precision(b)),
+        rtol=0.0,
+        atol=2.0^-prec,
+        opts::Union{acb_calc_integrate_opt_struct, Ptr{Cvoid}} = C_NULL)
+Computes a rigorous enclosure of the integral
+∫ₐᵇ f(t) dt
+where `f` is any (holomorphic) julia function. From Arb docs:
+> The integral follows a straight-line path between the complex numbers `a` and
+> `b`. For finite results, `a`, `b` must be finite and `f` must be bounded on
+> the path of integration. To compute improper integrals, the user should
+> therefore truncate the path of integration manually (or make a regularizing
+> change of variables, if possible).
+Parameters:
+ * `rtol` relative tolerance
+ * `atol` absolute tolerance
+ * `opts` a `C_NULL` (using the default options), or an instance of
+ `acb_calc_integrate_opt_struct` controlling the algorithmic aspects of integration.
+
+!!! Note: `integrate` does not guarantee to satisfy provided tolerances. For more
+information please consider arblib documentation.
+
+!!! Note: It's users responsibility to verify holomorphicity of `f`.
+"""
+function integrate(
+    f,
+    a::Union{Acb,AcbRef},
+    b::Union{Acb,AcbRef};
+    prec = max(precision(a), precision(b)),
+    rtol = 0.0,
+    atol = set_ui_2exp!(Mag(), one(UInt), -prec),
+    opts::Union{Ptr{Cvoid},calc_integrate_opt_struct} = C_NULL,
+)
+    # rel_goal = r where rel_tol ~2^-r
+    rel_goal = iszero(rtol) ? prec : rel_goal = -floor(Int, log2(atol))
+
+    res = Acb(prec = prec)
+
+    status = integrate!(
+        res,
+        f,
+        a,
+        b;
+        rel_goal = rel_goal,
+        abs_tol = convert(Mag, atol),
+        opts = opts,
+        prec = prec,
+    )
+
+    # status:
+    # ARB_CALC_SUCCESS = 0
+    # ARB_CALC_NO_CONVERGENCE = 2
+    status == 2 &&
+        @warn "Arb integrate did not achived convergence, the result might be incorrect"
+    return res
+end
+
+function integrate(
+    f,
+    a::Number,
+    b::Number;
+    prec::Integer,
+    rtol = 0.0,
+    atol = 0.0,
+    opts::Union{Ptr{Cvoid},calc_integrate_opt_struct} = C_NULL,
+)
+    return integrate(
+        f,
+        Acb(a, prec = prec),
+        Acb(b, prec = prec),
+        prec = prec,
+        rtol = rtol,
+        atol = atol,
+        opts = opts,
+    )
+end

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -19,7 +19,7 @@ function ArbRef(
 end
 function AcbRef(
     ptr::Ptr{acb_struct},
-    parent::Union{acb_vec_struct,acb_mat_struct};
+    parent::Union{Nothing,acb_vec_struct,acb_mat_struct};
     prec::Integer = DEFAULT_PRECISION[],
 )
     AcbRef(ptr, prec, parent)

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,7 +50,7 @@ end
 struct AcbRef <: Number
     acb_ptr::Ptr{acb_struct}
     prec::Int
-    parent::Union{acb_vec_struct,acb_mat_struct}
+    parent::Union{Nothing,acb_vec_struct,acb_mat_struct}
 end
 
 """

--- a/test/calc_integrate.jl
+++ b/test/calc_integrate.jl
@@ -28,6 +28,13 @@
     res3 = "[0.50000000000000000 +/- 2.68e-18]"
     res3! = "[0.50000000000000000 +/- 2.73e-18]"
     @test string(Arblib.integrate(f3, a, b, check_analytic = true, prec = prec)) == res3
+    @test_broken string(Arblib.integrate!(
+        f3!,
+        Acb(prec = prec),
+        a,
+        b,
+        check_analytic = true,
+    )) == res3
     @test string(Arblib.integrate!(f3!, Acb(prec = prec), a, b, check_analytic = true)) ==
           res3!
 

--- a/test/calc_integrate.jl
+++ b/test/calc_integrate.jl
@@ -1,0 +1,7 @@
+@testset "integration" begin
+    prec = 128
+    @test Arblib.integrate((res,x; prec)-> Arblib.mul!(res, x,x, prec=prec), 0, 1, prec=prec) isa Acb
+    @test real(Arblib.integrate((res,x; prec)-> Arblib.mul!(res, x,x, prec=prec), 0, 1, prec=prec)) - 1/3 < eps(Float64)
+    @test Arblib.contains_zero(real(Arblib.integrate(Arblib.sin!, 0, π, prec=prec)) - 2)
+    @test Arblib.contains_zero(real(Arblib.integrate(Arblib.cos!, -Acb(π), Acb(π), prec=prec)))
+end

--- a/test/calc_integrate.jl
+++ b/test/calc_integrate.jl
@@ -1,7 +1,57 @@
 @testset "integration" begin
-    prec = 128
-    @test Arblib.integrate((res,x; prec)-> Arblib.mul!(res, x,x, prec=prec), 0, 1, prec=prec) isa Acb
-    @test real(Arblib.integrate((res,x; prec)-> Arblib.mul!(res, x,x, prec=prec), 0, 1, prec=prec)) - 1/3 < eps(Float64)
-    @test Arblib.contains_zero(real(Arblib.integrate(Arblib.sin!, 0, π, prec=prec)) - 2)
-    @test Arblib.contains_zero(real(Arblib.integrate(Arblib.cos!, -Acb(π), Acb(π), prec=prec)))
+    prec = 64
+    a = Acb(0, prec = prec)
+    b = Acb(1, prec = prec)
+
+    # Test with just a plain method
+    f1 = sin
+    f1! = Arblib.sin!
+    res1 = "[0.459697694131860282 +/- 7.22e-19]"
+    @test string(Arblib.integrate(f1, a, b, prec = prec)) == res1
+    @test string(Arblib.integrate!(f1!, Acb(prec = prec), a, b)) == res1
+
+    # Test with a method that accepts precision as a keyword argument
+    f2 = (x; prec) -> Arblib.sin!(Acb(), x, prec = prec)
+    f2! = Arblib.sin!
+    res2 = "[0.459697694131860282 +/- 7.22e-19]"
+    @test string(Arblib.integrate(f2, a, b, take_prec = true, prec = prec)) == res2
+    @test string(Arblib.integrate!(f2!, Acb(prec = prec), a, b, take_prec = true)) == res2
+
+    # Test with a method that accepts analytic as a keyword argument
+    f3 = (x; analytic) -> Arblib.real_abs!(Acb(prec = prec), x, analytic)
+    f3! = (res, x; analytic) -> Arblib.real_abs!(res, x, analytic)
+    # FIXME: These are supposed to be identical but due to a bug in
+    # Arb the produce slightly different results, see
+    # https://github.com/kalmarek/Arblib.jl/issues/70. Once Arb is
+    # updated so that they start to produce identical results this can
+    # be updated and the issue closed.
+    res3 = "[0.50000000000000000 +/- 2.68e-18]"
+    res3! = "[0.50000000000000000 +/- 2.73e-18]"
+    @test string(Arblib.integrate(f3, a, b, check_analytic = true, prec = prec)) == res3
+    @test string(Arblib.integrate!(f3!, Acb(prec = prec), a, b, check_analytic = true)) ==
+          res3!
+
+    # Test with a method that accepts both precision and analytic as
+    # a keyword arguments
+    f4 = (x; analytic, prec) -> Arblib.real_abs!(Acb(), x, analytic, prec = prec)
+    f4! = (res, x; analytic, prec) -> Arblib.real_abs!(res, x, analytic, prec = prec)
+    # FIXME: See above
+    res4 = "[0.50000000000000000 +/- 2.68e-18]"
+    res4! = "[0.50000000000000000 +/- 2.73e-18]"
+    @test string(Arblib.integrate(
+        f4,
+        a,
+        b,
+        check_analytic = true,
+        take_prec = true,
+        prec = prec,
+    )) == res4
+    @test string(Arblib.integrate!(
+        f4!,
+        Acb(prec = prec),
+        a,
+        b,
+        check_analytic = true,
+        take_prec = true,
+    )) == res4!
 end

--- a/test/ref-test.jl
+++ b/test/ref-test.jl
@@ -86,7 +86,7 @@ end
     v = AcbRefVector([0])
     x = v[1]
     ptr = x.acb_ptr
-    parent = v.acb_vec
+    parent = nothing
     @test AcbRef(ptr, parent) == Acb()
     @test precision(AcbRef(ptr, parent)) == Arblib.DEFAULT_PRECISION[]
     @test precision(AcbRef(ptr, parent, prec = 80)) == 80

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using Arblib, Test, LinearAlgebra
     include("vector.jl")
     include("matrix.jl")
     include("eigen.jl")
+    include("calc_integrate.jl")
     include("ref-test.jl")
     include("poly.jl")
     include("series.jl")


### PR DESCRIPTION
I took the old code I've written wrapping integration and dumped it here;

at the moment:
* it's 2-orders of magnitude slower than Quadgk on the `sin` example:
```julia
julia> @btime Arblib.integrate($(Arblib.sin!), $(Acb(0)), $(Acb(1)), prec=53)
  22.574 μs (54 allocations: 2.14 KiB)
[0.459697694131860 +/- 6.21e-16]

julia> using QuadGK

julia> @btime quadgk($sin, 0, 1)
  248.713 ns (5 allocations: 144 bytes)
(0.4596976941318603, 5.551115123125783e-17)
```
* the function to be integrated is required to be of the signature `(res::Ptr{acb_struct}, x::Ptr{acb_struct}; prec) → (...)` and must modify `res`
* a slightly more user-firendly way of doing this goes through this:
```julia
function _acb_calc_func2!(
    out::Ptr{acb_struct},
    inp::Ptr{acb_struct},
    param::Ptr{Cvoid}, # pointer to the actual function
    order::Cint,
    prec::Cint,
)
    @assert iszero(order) || isone(order) # ← we'd need to verify holomorphicity
    x = Acb(unsafe_load(inp), prec=prec)
    # x = inp
    f = unsafe_pointer_to_objref(param)
    # @debug "Evaluating at" x
    set!(out, f(x))
    return zero(Cint)
end
```
allocates twice as much (at ~10% slowdown) but allows to write code like this:
```
julia> @btime Arblib.integrate($sin, $(Acb(0)), $(Acb(1)), prec=53)
  24.860 μs (102 allocations: 7.89 KiB)
[0.459697694131860 +/- 6.21e-16]
```
* tests are to be written