### PR TITLE
Cleanup types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         julia-version: ['1.3', '1.4', '1.5', 'nightly']
         os: [ubuntu-latest, macOS-latest]
-      fail-fast: true
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v1.0.0

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -49,6 +49,7 @@ include("predicates.jl")
 include("show.jl")
 include("arithmetic.jl")
 
+include("ref.jl")
 include("vector.jl")
 include("matrix.jl")
 include("array_common.jl")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -10,7 +10,7 @@ for T in (Unsigned, Base.GMP.CdoubleMax)
 end
 
 ## Arf
-for T in (Unsigned, Integer, Base.GMP.CdoubleMax, Mag)
+for T in (arf_struct, Unsigned, Integer, Base.GMP.CdoubleMax, Mag)
     @eval begin
         function Arf(x::$T; prec::Integer = DEFAULT_PRECISION[])
             res = Arf(prec = prec)
@@ -31,7 +31,7 @@ function Arf(x::Arf; prec::Integer = precision(x))
 end
 
 ## Arb
-for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
+for T in (arb_struct, Unsigned, Integer, Base.GMP.CdoubleMax)
     @eval begin
         function Arb(x::$T; prec::Integer = DEFAULT_PRECISION[])
             res = Arb(prec = prec)
@@ -66,7 +66,7 @@ function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
 end
 
 ## Acb
-for T in (Unsigned, Integer, Base.GMP.CdoubleMax)
+for T in (acb_struct, Unsigned, Integer, Base.GMP.CdoubleMax)
     @eval begin
         function Acb(x::$T; prec::Integer = DEFAULT_PRECISION[])
             res = Acb(prec = prec)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -77,8 +77,7 @@ for T in (acb_struct, Unsigned, Integer, Base.GMP.CdoubleMax)
 end
 function Acb(x::Arf; prec::Integer = precision(x))
     res = Acb(prec = prec)
-    # There is not set! with Acb and Arf. So create intermediate Arb :shrug:
-    set!(res, Arb(x, prec = prec))
+    set!(realref(res), x)
     return res
 end
 

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -60,7 +60,13 @@ Base.@propagate_inbounds function Base.setindex!(
 end
 
 # Constructors
-for TPoly in [:ArbPoly, :AcbPoly]
+for (TPoly, TPolyStruct) in [(:ArbPoly, :arb_poly_struct), (:AcbPoly, :acb_poly_struct)]
+    @eval function $TPoly(poly::$TPolyStruct; prec::Integer = DEFAULT_PRECISION[])
+        res = $TPoly(prec = prec)
+        set!(res, poly)
+        return res
+    end
+
     @eval function $TPoly(coeff; prec::Integer = _precision(coeff))
         poly = $TPoly(prec = prec)
         poly[0] = coeff
@@ -76,7 +82,18 @@ for TPoly in [:ArbPoly, :AcbPoly]
     end
 end
 
-for (TSeries, T) in [(:ArbSeries, :Arb), (:AcbSeries, :Acb)]
+for (TSeries, TPolyStruct, T) in
+    [(:ArbSeries, :arb_poly_struct, :Arb), (:AcbSeries, :acb_poly_struct, :Acb)]
+    @eval function $TSeries(
+        poly::$TPolyStruct,
+        degree::Integer = degree(poly);
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        res = $TSeries(degree, prec = prec)
+        set!(res, poly)
+        return res
+    end
+
     @eval $TSeries(; prec::Integer = DEFAULT_PRECISION[]) = $TSeries(0, prec = prec)
 
     @eval function $TSeries(coeff, degree::Integer; prec::Integer = _precision(coeff))

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -60,8 +60,8 @@ Base.@propagate_inbounds function Base.setindex!(
 end
 
 # Constructors
-for (TPoly, TPolyStruct) in [(:ArbPoly, :arb_poly_struct), (:AcbPoly, :acb_poly_struct)]
-    @eval function $TPoly(poly::$TPolyStruct; prec::Integer = DEFAULT_PRECISION[])
+for TPoly in [:ArbPoly, :AcbPoly]
+    @eval function $TPoly(poly::cstructtype($TPoly); prec::Integer = DEFAULT_PRECISION[])
         res = $TPoly(prec = prec)
         set!(res, poly)
         return res
@@ -82,10 +82,9 @@ for (TPoly, TPolyStruct) in [(:ArbPoly, :arb_poly_struct), (:AcbPoly, :acb_poly_
     end
 end
 
-for (TSeries, TPolyStruct, T) in
-    [(:ArbSeries, :arb_poly_struct, :Arb), (:AcbSeries, :acb_poly_struct, :Acb)]
+for TSeries in [:ArbSeries, :AcbSeries]
     @eval function $TSeries(
-        poly::$TPolyStruct,
+        poly::cstructtype($TSeries),
         degree::Integer = degree(poly);
         prec::Integer = DEFAULT_PRECISION[],
     )

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -1,0 +1,54 @@
+ArfRef(; prec::Integer = DEFAULT_PRECISION[]) = Arf(; prec = prec)
+ArbRef(; prec::Integer = DEFAULT_PRECISION[]) = Arb(; prec = prec)
+AcbRef(; prec::Integer = DEFAULT_PRECISION[]) = Acb(; prec = prec)
+MagRef() = Mag()
+
+function ArfRef(
+    ptr::Ptr{arf_struct},
+    parent::Union{arb_struct,ArbRef};
+    prec::Integer = DEFAULT_PRECISION[],
+)
+    ArfRef(ptr, prec, parent)
+end
+function ArbRef(
+    ptr::Ptr{arb_struct},
+    parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct};
+    prec::Integer = DEFAULT_PRECISION[],
+)
+    ArbRef(ptr, prec, parent)
+end
+function AcbRef(
+    ptr::Ptr{acb_struct},
+    parent::Union{acb_vec_struct,acb_mat_struct};
+    prec::Integer = DEFAULT_PRECISION[],
+)
+    AcbRef(ptr, prec, parent)
+end
+
+Mag(x::MagRef) = set!(Mag(), x)
+Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
+Arb(x::ArbRef; prec::Integer = precision(x)) = set!(Arb(prec = prec), x)
+Acb(x::AcbRef; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
+
+Base.getindex(x::MagRef) = Mag(x)
+Base.getindex(x::ArfRef) = Arf(x)
+Base.getindex(x::ArbRef) = Arb(x)
+Base.getindex(x::AcbRef) = Acb(x)
+
+function midref(x::Union{Arb,ArbRef}, prec = precision(x))
+    mid_ptr = ccall(@libarb(arb_mid_ptr), Ptr{arf_struct}, (Ref{arb_struct},), x)
+    ArfRef(mid_ptr, prec, parentstruct(x))
+end
+function radref(x::Union{Arb,ArbRef})
+    rad_ptr = ccall(@libarb(arb_rad_ptr), Ptr{mag_struct}, (Ref{arb_struct},), x)
+    MagRef(rad_ptr, parentstruct(x))
+end
+
+function realref(z::Union{Acb,AcbRef}; prec = precision(z))
+    real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, parentstruct(z))
+end
+function imagref(z::Union{Acb,AcbRef}; prec = precision(z))
+    real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(real_ptr, prec, parentstruct(z))
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,6 @@
+"""
+    Arf <: Real
+"""
 struct Arf <: Real
     arf::arf_struct
     prec::Int
@@ -7,6 +10,9 @@ struct Arf <: Real
     Arf(x::Union{UInt,Int}; prec::Integer = DEFAULT_PRECISION[]) = new(arf_struct(x), prec)
 end
 
+"""
+    Mag <: Real
+"""
 struct Mag <: Real
     mag::mag_struct
 
@@ -17,6 +23,9 @@ struct Mag <: Real
     Mag(x::Union{Mag,Arf}) = new(mag_struct(cstruct(x)))
 end
 
+"""
+    Arb <: Real
+"""
 struct Arb <: Real
     arb::arb_struct
     prec::Int
@@ -24,6 +33,9 @@ struct Arb <: Real
     Arb(; prec::Integer = DEFAULT_PRECISION[]) = new(arb_struct(), prec)
 end
 
+"""
+    Acb <: Number
+"""
 struct Acb <: Number
     acb::acb_struct
     prec::Int
@@ -32,29 +44,44 @@ struct Acb <: Number
 end
 
 # Refs are in reverse order to model their possible depencies
+"""
+    AcbRef <: Number
+"""
 struct AcbRef <: Number
     acb_ptr::Ptr{acb_struct}
     prec::Int
     parent::Union{acb_vec_struct,acb_mat_struct}
 end
 
+"""
+    ArbRef <: Real
+"""
 struct ArbRef <: Real
     arb_ptr::Ptr{arb_struct}
     prec::Int
     parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct}
 end
 
+"""
+    ArfRef <: Real
+"""
 struct ArfRef <: Real
     arf_ptr::Ptr{arf_struct}
     prec::Int
     parent::Union{arb_struct,ArbRef}
 end
 
+"""
+    MagRef <: Real
+"""
 struct MagRef <: Real
     mag_ptr::Ptr{mag_struct}
     parent::Union{arb_struct,ArbRef}
 end
 
+"""
+    ArbVector <: DenseVector{Arb}
+"""
 struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct
     prec::Int
@@ -62,6 +89,9 @@ end
 ArbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     ArbVector(arb_vec_struct(n), prec)
 
+"""
+    AcbVector <: DenseVector{Acb}
+"""
 struct AcbVector <: DenseVector{Acb}
     acb_vec::acb_vec_struct
     prec::Int
@@ -69,6 +99,9 @@ end
 AcbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     AcbVector(acb_vec_struct(n), prec)
 
+"""
+    ArbPoly
+"""
 struct ArbPoly
     arb_poly::arb_poly_struct
     prec::Int
@@ -76,6 +109,9 @@ struct ArbPoly
     ArbPoly(; prec::Integer = DEFAULT_PRECISION[]) = new(arb_poly_struct(), prec)
 end
 
+"""
+    ArbSeries <: Number
+"""
 struct ArbSeries <: Number
     arb_poly::arb_poly_struct
     degree::Int
@@ -85,6 +121,9 @@ struct ArbSeries <: Number
         new(arb_poly_struct(), degree, prec)
 end
 
+"""
+    AcbPoly
+"""
 struct AcbPoly
     acb_poly::acb_poly_struct
     prec::Int
@@ -92,6 +131,9 @@ struct AcbPoly
     AcbPoly(; prec::Integer = DEFAULT_PRECISION[]) = new(acb_poly_struct(), prec)
 end
 
+"""
+    AcbSeries <: Number
+"""
 struct AcbSeries <: Number
     acb_poly::acb_poly_struct
     degree::Int
@@ -101,6 +143,9 @@ struct AcbSeries <: Number
         new(acb_poly_struct(), degree, prec)
 end
 
+"""
+    ArbMatrix <: DenseMatrix{Arb}
+"""
 struct ArbMatrix <: DenseMatrix{Arb}
     arb_mat::arb_mat_struct
     prec::Int
@@ -108,6 +153,9 @@ end
 ArbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     ArbMatrix(arb_mat_struct(r, c), prec)
 
+"""
+    AcbMatrix <: DenseMatrix{Acb}
+"""
 struct AcbMatrix <: DenseMatrix{Acb}
     acb_mat::acb_mat_struct
     prec::Int
@@ -115,6 +163,9 @@ end
 AcbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     AcbMatrix(acb_mat_struct(r, c), prec)
 
+"""
+    ArbRefVector <: DenseMatrix{ArbRef}
+"""
 struct ArbRefVector <: DenseVector{ArbRef}
     arb_vec::arb_vec_struct
     prec::Int
@@ -122,6 +173,9 @@ end
 ArbRefVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     ArbRefVector(arb_vec_struct(n), prec)
 
+"""
+    AcbRefVector <: DenseMatrix{AcbRef}
+"""
 struct AcbRefVector <: DenseVector{AcbRef}
     acb_vec::acb_vec_struct
     prec::Int
@@ -129,6 +183,9 @@ end
 AcbRefVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     AcbRefVector(acb_vec_struct(n), prec)
 
+"""
+    ArbRefMatrix <: DenseMatrix{ArbRef}
+"""
 struct ArbRefMatrix <: DenseMatrix{ArbRef}
     arb_mat::arb_mat_struct
     prec::Int
@@ -136,6 +193,9 @@ end
 ArbRefMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
     ArbRefMatrix(arb_mat_struct(r, c), prec)
 
+"""
+    AcbRefMatrix <: DenseMatrix{AcbRef}
+"""
 struct AcbRefMatrix <: DenseMatrix{AcbRef}
     acb_mat::acb_mat_struct
     prec::Int

--- a/src/types.jl
+++ b/src/types.jl
@@ -94,7 +94,6 @@ end
 Mag(x::MagRef) = set!(Mag(), x)
 Base.getindex(x::MagRef) = Mag(x)
 
-
 struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct
     prec::Int
@@ -114,13 +113,6 @@ struct ArbPoly
     prec::Int
 
     ArbPoly(; prec::Integer = DEFAULT_PRECISION[]) = new(arb_poly_struct(), prec)
-
-    function ArbPoly(poly::arb_poly_struct; prec::Integer = DEFAULT_PRECISION[])
-        res = ArbPoly(prec = prec)
-        set!(res, poly)
-
-        return res
-    end
 end
 
 struct ArbSeries <: Number
@@ -130,17 +122,6 @@ struct ArbSeries <: Number
 
     ArbSeries(degree::Integer; prec::Integer = DEFAULT_PRECISION[]) =
         new(arb_poly_struct(), degree, prec)
-
-    function ArbSeries(
-        poly::arb_poly_struct,
-        degree::Integer = degree(poly);
-        prec::Integer = DEFAULT_PRECISION[],
-    )
-        res = ArbSeries(degree, prec = prec)
-        set!(res, poly)
-
-        return res
-    end
 end
 
 struct AcbPoly
@@ -148,13 +129,6 @@ struct AcbPoly
     prec::Int
 
     AcbPoly(; prec::Integer = DEFAULT_PRECISION[]) = new(acb_poly_struct(), prec)
-
-    function AcbPoly(poly::acb_poly_struct; prec::Integer = DEFAULT_PRECISION[])
-        res = AcbPoly(prec = prec)
-        set!(res, poly)
-
-        return res
-    end
 end
 
 struct AcbSeries <: Number
@@ -164,17 +138,6 @@ struct AcbSeries <: Number
 
     AcbSeries(degree::Integer; prec::Integer = DEFAULT_PRECISION[]) =
         new(acb_poly_struct(), degree, prec)
-
-    function AcbSeries(
-        poly::acb_poly_struct,
-        degree::Integer = degree(poly);
-        prec::Integer = DEFAULT_PRECISION[],
-    )
-        res = AcbSeries(degree, prec = prec)
-        set!(res, poly)
-
-        return res
-    end
 end
 
 struct ArbMatrix <: DenseMatrix{Arb}

--- a/src/types.jl
+++ b/src/types.jl
@@ -37,62 +37,23 @@ struct AcbRef <: Number
     prec::Int
     parent::Union{acb_vec_struct,acb_mat_struct}
 end
-function AcbRef(
-    ptr::Ptr{acb_struct},
-    parent::Union{acb_vec_struct,acb_mat_struct};
-    prec::Integer,
-)
-    AcbRef(ptr, prec, parent)
-end
-
-AcbRef(; prec::Int = DEFAULT_PRECISION[]) = Acb(; prec = prec)
-function Acb(x::AcbRef; prec::Integer = precision(x))
-    res = Acb(prec = prec)
-    set!(res, x)
-    return res
-end
-Base.getindex(x::AcbRef) = Acb(x)
 
 struct ArbRef <: Real
     arb_ptr::Ptr{arb_struct}
     prec::Int
     parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct}
 end
-function ArbRef(
-    ptr::Ptr{arb_struct},
-    parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct};
-    prec::Integer,
-)
-    ArbRef(ptr, prec, parent)
-end
-
-ArbRef(; prec::Int = DEFAULT_PRECISION[]) = Arb(; prec = prec)
-function Arb(x::ArbRef; prec::Integer = precision(x))
-    res = Arb(prec = prec)
-    set!(res, x)
-    return res
-end
-Base.getindex(x::ArbRef) = Arb(x)
 
 struct ArfRef <: Real
     arf_ptr::Ptr{arf_struct}
     prec::Int
     parent::Union{arb_struct,ArbRef}
 end
-function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Integer)
-    ArfRef(ptr, prec, parent)
-end
-
-ArfRef(; prec::Int = DEFAULT_PRECISION[]) = Arf(; prec = prec)
-Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
-Base.getindex(x::ArfRef) = Arf(x)
 
 struct MagRef <: Real
     mag_ptr::Ptr{mag_struct}
     parent::Union{arb_struct,ArbRef}
 end
-Mag(x::MagRef) = set!(Mag(), x)
-Base.getindex(x::MagRef) = Mag(x)
 
 struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct
@@ -271,24 +232,6 @@ Base.setindex!(x::Union{Mag,MagRef}, z::Ptr{mag_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arf,ArfRef}, z::Ptr{arf_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arb,ArbRef}, z::Ptr{arb_struct}) = set!(x, z)
 Base.setindex!(x::Union{Acb,AcbRef}, z::Ptr{acb_struct}) = set!(x, z)
-
-function midref(x::Union{Arb,ArbRef}, prec = precision(x))
-    mid_ptr = ccall(@libarb(arb_mid_ptr), Ptr{arf_struct}, (Ref{arb_struct},), x)
-    ArfRef(mid_ptr, prec, parentstruct(x))
-end
-function radref(x::Union{Arb,ArbRef})
-    rad_ptr = ccall(@libarb(arb_rad_ptr), Ptr{mag_struct}, (Ref{arb_struct},), x)
-    MagRef(rad_ptr, parentstruct(x))
-end
-
-function realref(z::Union{Acb,AcbRef}; prec = precision(z))
-    real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
-    ArbRef(real_ptr, prec, parentstruct(z))
-end
-function imagref(z::Union{Acb,AcbRef}; prec = precision(z))
-    real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
-    ArbRef(real_ptr, prec, parentstruct(z))
-end
 
 Base.Float64(x::MagLike) = get(x)
 function Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest)

--- a/src/types.jl
+++ b/src/types.jl
@@ -40,7 +40,7 @@ end
 function AcbRef(
     ptr::Ptr{acb_struct},
     parent::Union{acb_vec_struct,acb_mat_struct};
-    prec::Int,
+    prec::Integer,
 )
     AcbRef(ptr, prec, parent)
 end
@@ -61,7 +61,7 @@ end
 function ArbRef(
     ptr::Ptr{arb_struct},
     parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct};
-    prec::Int,
+    prec::Integer,
 )
     ArbRef(ptr, prec, parent)
 end
@@ -79,7 +79,7 @@ struct ArfRef <: Real
     prec::Int
     parent::Union{arb_struct,ArbRef}
 end
-function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Int)
+function ArfRef(ptr::Ptr{arf_struct}, parent::Union{arb_struct,ArbRef}; prec::Integer)
     ArfRef(ptr, prec, parent)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -205,15 +205,12 @@ for (T, prefix) in (
     (Union{AcbPoly,AcbSeries}, :acb_poly),
 )
     arbstruct = Symbol(prefix, :_struct)
-    spref = "$prefix"
-    @eval begin
-        cstructtype(::Type{<:$T}) = $arbstruct
-    end
     @eval begin
         cprefix(::Type{<:$T}) = $(QuoteNode(Symbol(prefix)))
         cstruct(x::$T) = getfield(x, cprefix($T))
         cstruct(x::$arbstruct) = x
-        Base.convert(::Type{$(cstructtype(T))}, x::$T) = cstruct(x)
+        cstructtype(::Type{<:$T}) = $arbstruct
+        Base.convert(::Type{$arbstruct}, x::$T) = cstruct(x)
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -192,9 +192,6 @@ for T in [:Arb, :Acb], A in [:Vector, :Matrix]
     end
 end
 
-const ArbLike = Union{Arb,ArbRef,Ptr{arb_struct},arb_struct}
-const AcbLike = Union{Acb,AcbRef,Ptr{acb_struct},acb_struct}
-
 for (T, prefix) in (
     (Mag, :mag),
     (Arf, :arf),

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,74 +2,33 @@ struct Arf <: Real
     arf::arf_struct
     prec::Int
 
-    function Arf(; prec::Integer = DEFAULT_PRECISION[])
-        res = new(arf_struct(), prec)
-        return res
-    end
+    Arf(; prec::Integer = DEFAULT_PRECISION[]) = new(arf_struct(), prec)
 
-    function Arf(x::arf_struct; prec::Integer = DEFAULT_PRECISION[])
-        res = Arf(prec = prec)
-        set!(res, x)
-        return res
-    end
-
-    function Arf(x::Union{UInt,Int}; prec::Integer = DEFAULT_PRECISION[])
-        res = new(arf_struct(x), prec)
-        return res
-    end
+    Arf(x::Union{UInt,Int}; prec::Integer = DEFAULT_PRECISION[]) = new(arf_struct(x), prec)
 end
 
 struct Mag <: Real
     mag::mag_struct
 
-    function Mag()
-        res = new(mag_struct())
-        return res
-    end
+    Mag() = new(mag_struct())
 
-    function Mag(x::mag_struct)
-        res = new(mag_struct(x))
-        return res
-    end
+    Mag(x::mag_struct) = new(mag_struct(x))
 
-    function Mag(x::Union{Mag,Arf})
-        res = new(mag_struct(cstruct(x)))
-        return res
-    end
+    Mag(x::Union{Mag,Arf}) = new(mag_struct(cstruct(x)))
 end
-
 
 struct Arb <: Real
     arb::arb_struct
     prec::Int
 
-    function Arb(; prec::Integer = DEFAULT_PRECISION[])
-        res = new(arb_struct(), prec)
-        return res
-    end
-
-    function Arb(x::arb_struct; prec::Integer = DEFAULT_PRECISION[])
-        res = Arb(prec = prec)
-        set!(res, x)
-        return res
-    end
+    Arb(; prec::Integer = DEFAULT_PRECISION[]) = new(arb_struct(), prec)
 end
-
 
 struct Acb <: Number
     acb::acb_struct
     prec::Int
 
-    function Acb(; prec::Integer = DEFAULT_PRECISION[])
-        res = new(acb_struct(), prec)
-        return res
-    end
-
-    function Acb(x::acb_struct; prec::Integer = DEFAULT_PRECISION[])
-        res = Acb(prec = prec)
-        set!(res, x)
-        return res
-    end
+    Acb(; prec::Integer = DEFAULT_PRECISION[]) = new(acb_struct(), prec)
 end
 
 # Refs are in reverse order to model their possible depencies

--- a/src/types.jl
+++ b/src/types.jl
@@ -80,26 +80,6 @@ struct MagRef <: Real
 end
 
 """
-    ArbVector <: DenseVector{Arb}
-"""
-struct ArbVector <: DenseVector{Arb}
-    arb_vec::arb_vec_struct
-    prec::Int
-end
-ArbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    ArbVector(arb_vec_struct(n), prec)
-
-"""
-    AcbVector <: DenseVector{Acb}
-"""
-struct AcbVector <: DenseVector{Acb}
-    acb_vec::acb_vec_struct
-    prec::Int
-end
-AcbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    AcbVector(acb_vec_struct(n), prec)
-
-"""
     ArbPoly
 """
 struct ArbPoly
@@ -142,6 +122,26 @@ struct AcbSeries <: Number
     AcbSeries(degree::Integer; prec::Integer = DEFAULT_PRECISION[]) =
         new(acb_poly_struct(), degree, prec)
 end
+
+"""
+    ArbVector <: DenseVector{Arb}
+"""
+struct ArbVector <: DenseVector{Arb}
+    arb_vec::arb_vec_struct
+    prec::Int
+end
+ArbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
+    ArbVector(arb_vec_struct(n), prec)
+
+"""
+    AcbVector <: DenseVector{Acb}
+"""
+struct AcbVector <: DenseVector{Acb}
+    acb_vec::acb_vec_struct
+    prec::Int
+end
+AcbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
+    AcbVector(acb_vec_struct(n), prec)
 
 """
     ArbMatrix <: DenseMatrix{Arb}

--- a/test/ref-test.jl
+++ b/test/ref-test.jl
@@ -1,3 +1,91 @@
+@testset "MagRef" begin
+    @test isequal(MagRef(), Mag())
+
+    x = Arb()
+    Arblib.set!(Arblib.radref(x), UInt(2))
+    @test Arblib.radref(x) == Mag(UInt(2))
+
+    y = Mag(Arblib.radref(x))
+    Arblib.set!(y, UInt(3))
+    @test Arblib.radref(x) == Mag(UInt(2))
+
+    z = Arblib.radref(x)[]
+    Arblib.set!(z, UInt(4))
+    @test Arblib.radref(x) == Mag(UInt(2))
+end
+
+@testset "ArfRef" begin
+    @test ArfRef() isa Arf
+    @test isequal(ArfRef(), Arf())
+    @test precision(ArfRef()) == Arblib.DEFAULT_PRECISION[]
+    @test precision(ArfRef(prec = 80)) == 80
+
+    x = Arb()
+    ptr = Arblib.midref(x).arf_ptr
+    parent = Arblib.parentstruct(x)
+    @test ArfRef(ptr, parent) == Arf()
+    @test precision(ArfRef(ptr, parent)) == Arblib.DEFAULT_PRECISION[]
+    @test precision(ArfRef(ptr, parent, prec = 80)) == 80
+
+    Arblib.set!(Arblib.midref(x), 2)
+    @test Arblib.midref(x) == Arf(2)
+    y = Arf(Arblib.midref(x))
+    Arblib.set!(y, 3)
+    @test Arblib.midref(x) == Arf(2)
+    z = Arblib.midref(x)[]
+    Arblib.set!(z, 4)
+    @test Arblib.midref(x) == Arf(2)
+end
+
+@testset "ArbRef" begin
+    @test ArbRef() isa Arb
+    @test isequal(ArbRef(), Arb())
+    @test precision(ArbRef()) == Arblib.DEFAULT_PRECISION[]
+    @test precision(ArbRef(prec = 80)) == 80
+
+    x = Acb()
+    ptr = Arblib.realref(x).arb_ptr
+    parent = Arblib.parentstruct(x)
+    @test ArbRef(ptr, parent) == Arb()
+    @test precision(ArbRef(ptr, parent)) == Arblib.DEFAULT_PRECISION[]
+    @test precision(ArbRef(ptr, parent, prec = 80)) == 80
+
+    Arblib.set!(Arblib.realref(x), 2)
+    @test Arblib.realref(x) == Arb(2)
+    Arblib.set!(Arblib.imagref(x), 3)
+    @test Arblib.imagref(x) == Arb(3)
+    y = Arb(Arblib.realref(x))
+    Arblib.set!(y, 3)
+    @test Arblib.realref(x) == Arf(2)
+    z = Arblib.realref(x)[]
+    Arblib.set!(z, 4)
+    @test Arblib.realref(x) == Arf(2)
+end
+
+@testset "AcbRef" begin
+    @test AcbRef() isa Acb
+    @test isequal(AcbRef(), Acb())
+    @test precision(AcbRef()) == Arblib.DEFAULT_PRECISION[]
+    @test precision(AcbRef(prec = 80)) == 80
+
+    v = AcbRefVector([0])
+    x = v[1]
+    ptr = x.acb_ptr
+    parent = v.acb_vec
+    @test AcbRef(ptr, parent) == Acb()
+    @test precision(AcbRef(ptr, parent)) == Arblib.DEFAULT_PRECISION[]
+    @test precision(AcbRef(ptr, parent, prec = 80)) == 80
+
+    Arblib.set!(x, 2)
+    @test v[1] == Acb(2)
+    y = Acb(x)
+    Arblib.set!(y, 3)
+    @test v[1] == Acb(2)
+    z = x[]
+    Arblib.set!(z, 4)
+    @test v[1] == Acb(2)
+end
+
 @testset "ArfRef from ArbRef" begin
     v = ArbRefVector([1.0, 2.0, 3.0])
     @test v[3] isa ArbRef

--- a/test/types-test.jl
+++ b/test/types-test.jl
@@ -1,28 +1,48 @@
 @testset "types" begin
-    Mag = Arblib.Mag
-
     @testset "Mag" begin
-        @test typeof(Mag()) == Mag
-        @test typeof(Mag(Mag())) == Mag
-        @test typeof(Mag(Arf())) == Mag
+        @test Mag() isa Mag
+        @test Mag(Mag()) isa Mag
+        @test Mag(Arf()) isa Mag
     end
 
     @testset "Arf" begin
-        @test typeof(Arf()) == Arf
-        @test precision(Arf(prec = 64)) == 64
-        @test typeof(Arf(UInt64(1))) == Arf
-        @test precision(Arf(UInt64(1), prec = 64)) == 64
-        @test typeof(Arf(1)) == Arf
-        @test precision(Arf(1, prec = 64)) == 64
+        @test Arf() isa Arf
+        @test precision(Arf(prec = 80)) == 80
+        @test Arf(UInt64(1)) isa Arf
+        @test precision(Arf(UInt64(1), prec = 80)) == 80
+        @test Arf(1) isa Arf
+        @test precision(Arf(1, prec = 80)) == 80
     end
 
     @testset "Arb" begin
-        @test typeof(Arb()) == Arb
-        @test precision(Arb(prec = 64)) == 64
+        @test Arb() isa Arb
+        @test precision(Arb(prec = 80)) == 80
     end
 
     @testset "Acb" begin
-        @test typeof(Acb()) == Acb
-        @test precision(Acb(prec = 64)) == 64
+        @test Acb() isa Acb
+        @test precision(Acb(prec = 80)) == 80
+    end
+
+    @testset "ArbPoly" begin
+        @test ArbPoly() isa ArbPoly
+        @test precision(ArbPoly(prec = 80)) == 80
+    end
+
+    @testset "ArbSeries" begin
+        @test ArbSeries(3) isa ArbSeries
+        @test precision(ArbSeries(3, prec = 80)) == 80
+        @test ArbSeries(3).degree == 3
+    end
+
+    @testset "AcbPoly" begin
+        @test AcbPoly() isa AcbPoly
+        @test precision(AcbPoly(prec = 80)) == 80
+    end
+
+    @testset "AcbSeries" begin
+        @test AcbSeries(3) isa AcbSeries
+        @test precision(AcbSeries(3, prec = 80)) == 80
+        @test AcbSeries(3).degree == 3
     end
 end


### PR DESCRIPTION
I made some cleanup of the `types.jl` file, moving many of the constructors and simplifying some code. I want to move some of the methods defined in the bottom of the file, but I'm not sure exactly where or if I should do it in this pull request.