### PR TITLE
Cleanup constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ add!(z::ArbLike, x::ArbLike, y::Int; prec = precision(z))
 
 Arb defines a number of functions for setting something to a specific
 value, for example `void arb_set_si(arb_t y, slong x)`. All of these
-are renamed to `set!` and really on multiple dispatch to choose the
-correct one. In addition to the ones defined in Arb there are a number
-of ones added in Arblib to make it more convenient to work with. For
-example there are setters for `Rational` and all irrationals defined
-in `Base.MathConstants`.
+are renamed to `set!` and rely on multiple dispatch to choose the
+correct one. In addition to the ones defined in Arb there is a number
+of methods of `set!` added in Arblib to make it more convenient to
+work with. For example there are setters for `Rational` and all
+irrationals defined in `Base.MathConstants`.
 
 Almost all of the constructors are simple wrappers around these
 setters. This means that it's usually more informative to look at the

--- a/README.md
+++ b/README.md
@@ -110,6 +110,31 @@ becomes
 add!(z::ArbLike, x::ArbLike, y::Int; prec = precision(z))
 ```
 
+## Constructors and setters
+
+Arb defines a number of functions for setting something to a specific
+value, for example `void arb_set_si(arb_t y, slong x)`. All of these
+are renamed to `set!` and really on multiple dispatch to choose the
+correct one. In addition to the ones defined in Arb there are a number
+of ones added in Arblib to make it more convenient to work with. For
+example there are setters for `Rational` and all irrationals defined
+in `Base.MathConstants`.
+
+Almost all of the constructors are simple wrappers around these
+setters. This means that it's usually more informative to look at the
+methods for `set!` than for say `Arb` to figure out what constructors
+exists. Both `Arb` and `Acb` are constructed in such a way that the
+result will always enclose the input.
+
+**Example:**
+``` julia
+x = Arblib.set!(Arb(), π)
+y = Arb(π)
+
+x = Arblib.set!(Arb(), 5//13)
+y = Arb(5//13)
+```
+
 ## Example
 
 Here is the naive sine compuation example form the [Arb documentation](http://arblib.org/using.html#a-worked-example-the-sine-function) in Julia:

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -45,6 +45,7 @@ include("manual_overrides.jl")
 
 include("precision.jl")
 
+include("setters.jl")
 include("constructors.jl")
 include("predicates.jl")
 include("show.jl")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -128,8 +128,8 @@ Base.one(x::ArbRef) = Arb(1, prec = precision(x))
 # I.e. only allocating **one** Arf/Arb/Acb.
 Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]
 Base.ones(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(x) for _ = 1:n]
-Base.zeros(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(T) for _ = 1:n]
-Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ = 1:n]
+Base.zeros(::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(T) for _ = 1:n]
+Base.ones(::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ = 1:n]
 
 # Irrationals
 Mag(::Irrational{:π}) = const_pi!(Mag())

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -120,10 +120,7 @@ Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))
 Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))
 Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
-Base.zero(x::AcbRef) = Acb(0, prec = precision(x))
-Base.one(x::AcbRef) = Acb(1, prec = precision(x))
-Base.zero(x::ArbRef) = Arb(0, prec = precision(x))
-Base.one(x::ArbRef) = Arb(1, prec = precision(x))
+
 # Define these since the base implementation would create `n` copies of the same element
 # I.e. only allocating **one** Arf/Arb/Acb.
 Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,28 +1,16 @@
 # Mag
-Mag() = Mag(mag_struct())
-Mag(x::Union{Unsigned,Base.GMP.CdoubleMax}) = set!(Mag(), x)
+Mag(x) = set!(Mag(), x)
 Mag(x::Union{MagRef,ArfRef}) = Mag(mag_struct(cstruct(x)))
 
 # Arf
-Arf(
-    x::Union{arf_struct,Unsigned,Integer,Base.GMP.CdoubleMax,Mag,MagRef};
-    prec::Integer = DEFAULT_PRECISION[],
-) = set!(Arf(prec = prec), x)
-Arf(x::Union{Arf,BigFloat}; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
+Arf(x; prec::Integer = _precision(x)) = set!(Arf(prec = prec), x)
+# disambiguation
+Arf(x::Arf; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
 
-# Arb
-Arb(
-    x::Union{arb_struct,Unsigned,Integer,Base.GMP.CdoubleMax};
-    prec::Integer = DEFAULT_PRECISION[],
-) = set!(Arb(prec = prec), x)
-Arb(x::Union{Arf,ArfRef,Arb,ArbRef}; prec::Integer = precision(x)) =
-    set!(Arb(prec = prec), x)
-
-function Arb(x::BigFloat; prec::Integer = precision(x))
-    res = Arb(prec = prec)
-    set!(midref(res), x)
-    return res
-end
+#Arb
+Arb(x; prec::Integer = _precision(x)) = set!(Arb(prec = prec), x)
+# disambiguation
+Arb(x::Arb; prec::Integer = precision(x)) = set!(Arb(prec = prec), x)
 
 function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     res = Arb(prec = prec)
@@ -31,100 +19,36 @@ function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     return res
 end
 
-function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
-    num = Arb(numerator(x); prec = prec)
-    div!(num, num, denominator(x))
-    return num
-end
-
-Arb(x::Real; prec::Integer = _precision(x)) = Arb(Arf(x, prec = prec))
-
 ## Acb
-# From real part
-Acb(
-    x::Union{acb_struct,Unsigned,Integer,Base.GMP.CdoubleMax};
-    prec::Integer = DEFAULT_PRECISION[],
-) = set!(Acb(prec = prec), x)
-Acb(x::Union{Arb,ArbRef,Acb,AcbRef}; prec::Integer = precision(x)) =
+Acb(x::Union{Real,arb_struct,arf_struct}; prec::Integer = _precision(x)) =
     set!(Acb(prec = prec), x)
-
-function Acb(x::Union{Arf,ArfRef}; prec::Integer = precision(x))
-    res = Acb(prec = prec)
-    set!(realref(res), x)
-    return res
-end
-
-function Acb(x::BigFloat; prec::Integer = precision(x))
-    res = Acb(prec = prec)
-    set!(midref(realref(res)), x)
-    return res
-end
-
-# Fallback version
-# TODO: We could get rid of the allocation of one Arb in many cases by
-# directly manipulating the real part of the Acb. For example when x
-# is a string, a rational or certain irrationals.
-Acb(x::Union{Real,AbstractString}; prec::Integer = DEFAULT_PRECISION[]) =
-    Acb(Arb(x, prec = prec), prec = prec)
-
-# From real and imaginary part separately
 Acb(
-    re::T,
-    im::T;
-    prec::Integer = DEFAULT_PRECISION[],
-) where {T<:Union{arb_struct,Integer,Base.GMP.CdoubleMax}} = set!(Acb(prec = prec), re, im)
-Acb(
-    re::Union{Arb,ArbRef},
-    im::Union{Arb,ArbRef};
-    prec::Integer = max(precision(re), precision(im)),
+    re::Union{Real,arb_struct,arf_struct},
+    im::Union{Real,arb_struct,arf_struct};
+    prec::Integer = max(_precision(re), _precision(im)),
 ) = set!(Acb(prec = prec), re, im)
 
-function Acb(
-    re::Union{Arf,ArfRef},
-    im::Union{Arf,ArfRef};
-    prec::Integer = max(precision(re), precision(im)),
-)
+Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
+    set!(Acb(prec = prec), z)
+Acb(x::AcbLike; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
+# disambiguation
+Acb(x::Acb; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
+
+function Acb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     res = Acb(prec = prec)
-    set!(realref(res), re)
-    set!(imagref(res), im)
+    flag = set!(realref(res), str)
+    iszero(flag) || throw(ArgumentError("could not parse $str as an Arb"))
     return res
 end
 
-function Acb(re::BigFloat, im::BigFloat; prec::Integer = max(precision(re), precision(im)))
+function Acb(re::AbstractString, im::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     res = Acb(prec = prec)
-    set!(midref(realref(res)), re)
-    set!(midref(imagref(res)), im)
+    flag = set!(realref(res), re)
+    iszero(flag) || throw(ArgumentError("could not parse $str as an Arb"))
+    flag = set!(imagref(res), im)
+    iszero(flag) || throw(ArgumentError("could not parse $str as an Arb"))
     return res
 end
-
-# Fallback version
-# TODO: Similar for the one with only real part above we could get rid
-# of two allocations of Arb in many cases.
-# TODO: Handle the case when the inputs have a precision we want to
-# use
-Acb(
-    re::Union{Real,AbstractString},
-    im::Union{Real,AbstractString};
-    prec::Integer = DEFAULT_PRECISION[],
-) = Acb(Arb(re, prec = prec), Arb(im, prec = prec), prec = prec)
-
-# From complex
-set!(z::AcbLike, x::Complex{<:Union{ArbLike,Integer,Base.GMP.CdoubleMax}}) =
-    set!(z, real(x), imag(x))
-
-Acb(
-    z::Complex{<:Union{Arb,ArbRef}};
-    prec::Integer = max(precision(real(z)), precision(imag(z))),
-) = set!(Acb(prec = prec), real(z), imag(z))
-
-Acb(
-    z::Complex{<:Union{Arf,ArfRef,BigFloat}};
-    prec::Integer = max(precision(real(z)), precision(imag(z))),
-) = Acb(real(z), imag(z), prec = prec)
-
-# TODO: Handle the case when the inputs have a precision we want to
-# use
-Acb(z::Complex; prec::Integer = DEFAULT_PRECISION[]) = Acb(real(z), imag(z), prec = prec)
 
 Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))
@@ -133,40 +57,7 @@ Base.one(x::T) where {T<:Union{Arf,Arb,Acb}} = T(1, prec = precision(x))
 
 # Define these since the base implementation would create `n` copies of the same element
 # I.e. only allocating **one** Arf/Arb/Acb.
-Base.zeros(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(x) for _ = 1:n]
-Base.ones(x::T, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(x) for _ = 1:n]
-Base.zeros(::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [zero(T) for _ = 1:n]
-Base.ones(::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ = 1:n]
-
-function set!(z::ArbLike, x::Rational)
-    z[] = numerator(x)
-    div!(z, z, denominator(x))
-end
-
-function set!(z::AcbLike, x::Union{Rational,Complex{<:Rational}})
-    set!(realref(z), real(x))
-    set!(imagref(z), imag(x))
-    z
-end
-
-# Irrationals
-Mag(::Irrational{:π}) = const_pi!(Mag())
-
-for (irr, suffix) in ((:π, "pi"), (:ℯ, "e"), (:γ, "euler"), (:catalan, "catalan"))
-    jlf = Symbol("const_$suffix", "!")
-    IrrT = Irrational{irr}
-    @eval begin
-        Arb(::$IrrT; prec::Integer = DEFAULT_PRECISION[]) = $jlf(Arb(prec = prec))
-    end
-end
-
-function Arb(::Irrational{:φ}; prec::Integer = DEFAULT_PRECISION[])
-    res = Arb(5, prec = prec)
-    sqrt!(res, res)
-    add!(res, res, 1)
-    div!(res, res, 2)
-    return res
-end
-
-
-Acb(::Irrational{:π}; prec::Integer = DEFAULT_PRECISION[]) = const_pi!(Acb(prec = prec))
+Base.zeros(x::T, n::Integer) where {T<:Union{Mag,Arf,Arb,Acb}} = [zero(x) for _ = 1:n]
+Base.ones(x::T, n::Integer) where {T<:Union{Mag,Arf,Arb,Acb}} = [one(x) for _ = 1:n]
+Base.zeros(::Type{T}, n::Integer) where {T<:Union{Mag,Arf,Arb,Acb}} = [zero(T) for _ = 1:n]
+Base.ones(::Type{T}, n::Integer) where {T<:Union{Mag,Arf,Arb,Acb}} = [one(T) for _ = 1:n]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -134,12 +134,21 @@ Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ 
 # Irrationals
 Mag(::Irrational{:π}) = const_pi!(Mag())
 
-for (irr, suffix) in ((:π, "pi"), (:ℯ, "e"), (:γ, "euler"))
+for (irr, suffix) in ((:π, "pi"), (:ℯ, "e"), (:γ, "euler"), (:catalan, "catalan"))
     jlf = Symbol("const_$suffix", "!")
     IrrT = Irrational{irr}
     @eval begin
         Arb(::$IrrT; prec::Integer = DEFAULT_PRECISION[]) = $jlf(Arb(prec = prec))
     end
 end
+
+function Arb(::Irrational{:φ}; prec::Integer = DEFAULT_PRECISION[])
+    res = Arb(5, prec = prec)
+    sqrt!(res, res)
+    add!(res, res, 1)
+    div!(res, res, 2)
+    return res
+end
+
 
 Acb(::Irrational{:π}; prec::Integer = DEFAULT_PRECISION[]) = const_pi!(Acb(prec = prec))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,10 +1,11 @@
 # Mag
 Mag() = Mag(mag_struct())
 Mag(x::Union{Unsigned,Base.GMP.CdoubleMax}) = set!(Mag(), x)
+Mag(x::Union{MagRef,ArfRef}) = Mag(mag_struct(cstruct(x)))
 
 # Arf
 Arf(
-    x::Union{arf_struct,Unsigned,Integer,Base.GMP.CdoubleMax,Mag};
+    x::Union{arf_struct,Unsigned,Integer,Base.GMP.CdoubleMax,Mag,MagRef};
     prec::Integer = DEFAULT_PRECISION[],
 ) = set!(Arf(prec = prec), x)
 Arf(x::Union{Arf,BigFloat}; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
@@ -14,7 +15,8 @@ Arb(
     x::Union{arb_struct,Unsigned,Integer,Base.GMP.CdoubleMax};
     prec::Integer = DEFAULT_PRECISION[],
 ) = set!(Arb(prec = prec), x)
-Arb(x::Union{Arf,Arb}; prec::Integer = precision(x)) = set!(Arb(prec = prec), x)
+Arb(x::Union{Arf,ArfRef,Arb,ArbRef}; prec::Integer = precision(x)) =
+    set!(Arb(prec = prec), x)
 
 function Arb(x::BigFloat; prec::Integer = precision(x))
     res = Arb(prec = prec)
@@ -42,9 +44,10 @@ Acb(
     x::Union{acb_struct,Unsigned,Integer,Base.GMP.CdoubleMax};
     prec::Integer = DEFAULT_PRECISION[],
 ) = set!(Acb(prec = prec), x)
-Acb(x::Union{Arb,Acb}; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
+Acb(x::Union{Arb,ArbRef,Acb,AcbRef}; prec::Integer = precision(x)) =
+    set!(Acb(prec = prec), x)
 
-function Acb(x::Arf; prec::Integer = precision(x))
+function Acb(x::Union{Arf,ArfRef}; prec::Integer = precision(x))
     res = Acb(prec = prec)
     set!(realref(res), x)
     return res
@@ -69,10 +72,17 @@ Acb(
     im::T;
     prec::Integer = DEFAULT_PRECISION[],
 ) where {T<:Union{arb_struct,Integer,Base.GMP.CdoubleMax}} = set!(Acb(prec = prec), re, im)
-Acb(re::Arb, im::Arb; prec::Integer = max(precision(re), precision(im))) =
-    set!(Acb(prec = prec), re, im)
+Acb(
+    re::Union{Arb,ArbRef},
+    im::Union{Arb,ArbRef};
+    prec::Integer = max(precision(re), precision(im)),
+) = set!(Acb(prec = prec), re, im)
 
-function Acb(re::Arf, im::Arf; prec::Integer = max(precision(re), precision(im)))
+function Acb(
+    re::Union{Arf,ArfRef},
+    im::Union{Arf,ArfRef};
+    prec::Integer = max(precision(re), precision(im)),
+)
     res = Acb(prec = prec)
     set!(realref(res), re)
     set!(imagref(res), im)
@@ -101,11 +111,13 @@ Acb(
 set!(z::AcbLike, x::Complex{<:Union{ArbLike,Integer,Base.GMP.CdoubleMax}}) =
     set!(z, real(x), imag(x))
 
-Acb(z::Complex{Arb}; prec::Integer = max(precision(real(z)), precision(imag(z)))) =
-    set!(Acb(prec = prec), real(z), imag(z))
+Acb(
+    z::Complex{<:Union{Arb,ArbRef}};
+    prec::Integer = max(precision(real(z)), precision(imag(z))),
+) = set!(Acb(prec = prec), real(z), imag(z))
 
 Acb(
-    z::Complex{<:Union{Arf,BigFloat}};
+    z::Complex{<:Union{Arf,ArfRef,BigFloat}};
     prec::Integer = max(precision(real(z)), precision(imag(z))),
 ) = Acb(real(z), imag(z), prec = prec)
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -71,18 +71,14 @@ Acb(
 Acb(re::Arb, im::Arb; prec::Integer = max(precision(re), precision(im))) =
     set!(Acb(prec = prec), re, im)
 
-function Acb(re::Arf, im::Union{Arf}; prec::Integer = max(precision(re), precision(im)))
+function Acb(re::Arf, im::Arf; prec::Integer = max(precision(re), precision(im)))
     res = Acb(prec = prec)
     set!(realref(res), re)
     set!(imagref(res), im)
     return res
 end
 
-function Acb(
-    re::BigFloat,
-    im::Union{BigFloat};
-    prec::Integer = max(precision(re), precision(im)),
-)
+function Acb(re::BigFloat, im::BigFloat; prec::Integer = max(precision(re), precision(im)))
     res = Acb(prec = prec)
     set!(midref(realref(res)), re)
     set!(midref(imagref(res)), im)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,4 +1,5 @@
 # Mag
+Mag() = Mag(mag_struct())
 Mag(x::Union{Unsigned,Base.GMP.CdoubleMax}) = set!(Mag(), x)
 
 # Arf

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -13,10 +13,11 @@ Base.precision(::Type{<:Ptr{<:ArbStructTypes}}) = DEFAULT_PRECISION[]
 Base.precision(x::ArbStructTypes) = DEFAULT_PRECISION[]
 Base.precision(x::Ptr{<:ArbStructTypes}) = DEFAULT_PRECISION[]
 Base.precision(x::ArbTypes) = x.prec
-# MagLike <: ArbTypes
-Base.precision(x::MagLike) = DEFAULT_PRECISION[]
+# disambiguation
+Base.precision(::Union{Mag,MagRef}) = DEFAULT_PRECISION[]
 
 @inline _precision(x::ArbTypes) = precision(x)
+@inline _precision(x::BigFloat) = precision(x)
 @inline _precision(_) = DEFAULT_PRECISION[]
 
 """

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -46,20 +46,20 @@ Base.getindex(x::ArfRef) = Arf(x)
 Base.getindex(x::ArbRef) = Arb(x)
 Base.getindex(x::AcbRef) = Acb(x)
 
-function midref(x::Union{Arb,ArbRef}, prec = precision(x))
+function midref(x::ArbLike, prec = precision(x))
     mid_ptr = ccall(@libarb(arb_mid_ptr), Ptr{arf_struct}, (Ref{arb_struct},), x)
     ArfRef(mid_ptr, prec, parentstruct(x))
 end
-function radref(x::Union{Arb,ArbRef})
+function radref(x::ArbLike)
     rad_ptr = ccall(@libarb(arb_rad_ptr), Ptr{mag_struct}, (Ref{arb_struct},), x)
     MagRef(rad_ptr, parentstruct(x))
 end
 
-function realref(z::Union{Acb,AcbRef}; prec = precision(z))
+function realref(z::AcbLike; prec = precision(z))
     real_ptr = ccall(@libarb(acb_real_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
     ArbRef(real_ptr, prec, parentstruct(z))
 end
-function imagref(z::Union{Acb,AcbRef}; prec = precision(z))
+function imagref(z::AcbLike; prec = precision(z))
     real_ptr = ccall(@libarb(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
     ArbRef(real_ptr, prec, parentstruct(z))
 end

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -30,6 +30,17 @@ Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
 Arb(x::ArbRef; prec::Integer = precision(x)) = set!(Arb(prec = prec), x)
 Acb(x::AcbRef; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
 
+Base.zero(::Union{Type{MagRef},MagRef}) = zero(Mag)
+Base.one(::Union{Type{MagRef},MagRef}) = one(Mag)
+for (TRef, T) in [(ArfRef, Arf), (ArbRef, Arb), (AcbRef, Acb)]
+    @eval begin
+        Base.zero(x::$TRef) = $T(0, prec = precision(x))
+        Base.zero(::Type{$TRef}) = zero($T)
+        Base.one(x::$TRef) = $T(1, prec = precision(x))
+        Base.one(::Type{$TRef}) = one($T)
+    end
+end
+
 Base.getindex(x::MagRef) = Mag(x)
 Base.getindex(x::ArfRef) = Arf(x)
 Base.getindex(x::ArbRef) = Arb(x)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -1,0 +1,49 @@
+# Mag
+set!(res::MagLike, ::Irrational{:π}) = const_pi!(res)
+
+# Arb
+function set!(res::ArbLike, x::Union{MagLike,BigFloat})
+    set!(radref(res), UInt64(0))
+    set!(midref(res), x)
+    return res
+end
+
+function set!(res::ArbLike, x::Rational; prec::Integer = precision(res))
+    set!(res, numerator(x))
+    return div!(res, res, denominator(x), prec = prec)
+end
+
+for (irr, suffix) in ((:π, "pi"), (:ℯ, "e"), (:γ, "euler"), (:catalan, "catalan"))
+    jlf = Symbol("const_$suffix", "!")
+    IrrT = Irrational{irr}
+    @eval begin
+        set!(res::ArbLike, ::$IrrT; prec::Integer = precision(res)) = $jlf(res, prec = prec)
+    end
+end
+
+function set!(res::ArbLike, ::Irrational{:φ}; prec::Integer = precision(res))
+    set!(res, 5)
+    sqrt!(res, res, prec)
+    add!(res, res, 1, prec)
+    return div!(res, res, 2, prec)
+end
+
+# Acb
+function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct})
+    set!(realref(res), x)
+    set!(imagref(res), 0)
+    return res
+end
+
+function set!(
+    res::AcbLike,
+    re::Union{Real,arb_struct,arf_struct,mag_struct},
+    im::Union{Real,arb_struct,arf_struct,mag_struct},
+)
+    set!(realref(res), re)
+    set!(imagref(res), im)
+    return res
+end
+
+set!(res::AcbLike, z::Complex) = set!(res, real(z), imag(z))
+set!(res::AcbLike, ::Irrational{:π}) = const_pi!(res)

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,6 +16,8 @@ end
 struct Mag <: Real
     mag::mag_struct
 
+    Mag() = Mag(mag_struct())
+
     Mag(x::mag_struct) = new(mag_struct(x))
 
     Mag(x::Union{Mag,Arf}) = new(mag_struct(cstruct(x)))
@@ -248,6 +250,7 @@ for prefix in [:mag, :arf, :arb, :acb]
 
         parentstruct(x::$T) = cstruct(x)
         parentstruct(x::$TRef) = x
+        parentstruct(x::$TStruct) = x
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,8 +16,6 @@ end
 struct Mag <: Real
     mag::mag_struct
 
-    Mag() = new(mag_struct())
-
     Mag(x::mag_struct) = new(mag_struct(x))
 
     Mag(x::Union{Mag,Arf}) = new(mag_struct(cstruct(x)))

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,7 +16,7 @@ end
 struct Mag <: Real
     mag::mag_struct
 
-    Mag() = Mag(mag_struct())
+    Mag() = new(mag_struct())
 
     Mag(x::mag_struct) = new(mag_struct(x))
 

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -1,38 +1,29 @@
 @testset "constructors" begin
     @testset "Mag" begin
-        @test typeof(Mag(UInt64(1))) == Mag
-        @test typeof(Mag(1.0)) == Mag
-        @test typeof(zero(Mag)) == Mag
-        @test typeof(one(Mag)) == Mag
-        @test typeof(zero(Mag())) == Mag
-        @test typeof(one(Mag())) == Mag
-        @test typeof(Mag(π)) == Mag
-        @test typeof(Mag(Mag().mag)) == Mag
-        @test typeof(Mag(Mag().mag)) == Mag
-        @test Float64(Mag(2.0)) isa Float64
-        # Mag doesn't guarantee exact conversions, just upper bounds
-        @test Float64(Mag(2.0)) ≥ 2.0
+        # Results for doubles are only upper bounds, even for integers
+        # they are quite crude
+        @test Mag(UInt64(0)) == zero(Mag) == zero(Mag()) == Mag(0.0)
+        @test Mag(UInt64(1)) == one(Mag) == one(Mag()) <= Mag(1.0)
+        @test π < Float64(Mag(π)) < 3.15
     end
 
     @testset "Arf" begin
-        @test typeof(Arf(UInt64(1))) == Arf
-        @test typeof(Arf(1)) == Arf
-        @test typeof(Arf(1.0)) == Arf
-        @test typeof(Arf(BigFloat(1))) == Arf
-        @test typeof(Arf(Mag())) == Arf
-        @test typeof(Arf(Arf())) == Arf
-        @test typeof(zero(Arf)) == Arf
-        @test typeof(one(Arf)) == Arf
+        for T in [UInt, Int, Float64, Mag, Arf, BigFloat]
+            @test Arf(zero(T)) == zero(Arf)
+            @test Arf(one(T)) == one(Arf)
+            @test precision(Arf(zero(T), prec = 80)) == 80
+        end
 
-        @test precision(Arf(UInt64(1), prec = 64)) == 64
-        @test precision(Arf(1, prec = 64)) == 64
-        @test precision(Arf(1.0, prec = 64)) == 64
-        @test precision(Arf(BigFloat(1, precision = 64))) == 64
-        @test precision(Arf(Mag(), prec = 64)) == 64
-        @test precision(Arf(Arf(prec = 64))) == 64
-        @test precision(zero(Arf(prec = 64))) == 64
-        @test precision(one(Arf(prec = 64))) == 64
+        @test Arf(zero(Arf).arf) == zero(Arf)
+        @test precision(Arf(zero(Arf).arf, prec = 80)) == 80
 
+        @test precision(Arf(Arf(prec = 80))) == 80
+        @test precision(Arf(BigFloat(0, precision = 80))) == 80
+
+        @test precision(zero(Arf(prec = 80))) == 80
+        @test precision(one(Arf(prec = 80))) == 80
+
+        # TODO: Move these to other file
         @test Float64(Arf(2.0)) isa Float64
         @test Float64(Arf(2.0)) == 2.0
         @test convert(Float64, Arf(2.0)) isa Float64
@@ -47,74 +38,85 @@
     end
 
     @testset "Arb" begin
-        @test typeof(Arb(UInt64(1))) == Arb
-        @test typeof(Arb(1)) == Arb
-        @test typeof(Arb(1.0)) == Arb
-        @test typeof(Arb(Arf())) == Arb
-        @test typeof(Arb(Arb())) == Arb
-        @test typeof(Arb("1.1")) == Arb
-        @test typeof(zero(Arb)) == Arb
-        @test typeof(one(Arb)) == Arb
-        @test typeof(Arb(π)) == Arb
-        @test typeof(Arb(ℯ)) == Arb
-        @test typeof(Arb(MathConstants.γ)) == Arb
+        for T in [UInt, Int, Float64, Arf, Arb, BigFloat, Rational{Int}]
+            @test Arb(zero(T)) == zero(Arb)
+            @test Arb(one(T)) == one(Arb)
+            @test precision(Arb(zero(T), prec = 80)) == 80
+        end
 
-        @test precision(Arb(UInt64(1), prec = 64)) == 64
-        @test precision(Arb(1, prec = 64)) == 64
-        @test precision(Arb(1.0, prec = 64)) == 64
-        @test precision(Arb(Arf(prec = 64))) == 64
-        @test precision(Arb(Arb(prec = 64))) == 64
-        @test precision(Arb("1.1", prec = 64)) == 64
-        @test precision(zero(Arb(prec = 64))) == 64
-        @test precision(one(Arb(prec = 64))) == 64
-        @test precision(Arb(π, prec = 64)) == 64
-        @test typeof(Arb(ℯ, prec = 64)) == Arb
-        @test typeof(Arb(MathConstants.γ, prec = 64)) == Arb
+        @test Arb(zero(Arb).arb) == Arb("0.0") == zero(Arb)
+        @test Arb(one(Arb).arb) == Arb("1.0") == one(Arb)
+        @test precision(Arb(zero(Arb).arb, prec = 80)) ==
+              precision(Arb("0.0", prec = 80)) ==
+              80
+
+        @test precision(Arb(Arf(prec = 80))) == 80
+        @test precision(Arb(Arb(prec = 80))) == 80
+        @test precision(Arb(BigFloat(0, precision = 80))) == 80
+
+        @test precision(zero(Arb(prec = 80))) == 80
+        @test precision(one(Arb(prec = 80))) == 80
+
+        @test Arb(3) < Arb(π) < Arb(4)
+        @test Arb(2) < Arb(ℯ) < Arb(3)
+        @test Arb(0) < Arb(MathConstants.γ) < Arb(1)
+        @test precision(Arb(π, prec = 80)) == 80
+        @test precision(Arb(ℯ, prec = 80)) == 80
+        @test precision(Arb(MathConstants.γ, prec = 80)) == 80
     end
 
     @testset "Acb" begin
-        @test typeof(Acb(UInt64(1))) == Acb
-        @test typeof(Acb(1)) == Acb
-        @test typeof(Acb(1.0)) == Acb
-        @test typeof(Acb(Arb())) == Acb
-        @test typeof(Acb(Acb())) == Acb
-        @test typeof(Acb(1, 1)) == Acb
-        @test typeof(Acb(1.0, 1.0)) == Acb
-        @test typeof(Acb(Arb(), Arb())) == Acb
-        @test typeof(Acb(complex(1, 1))) == Acb
-        @test typeof(Acb(complex(1.0, 1.0))) == Acb
-        @test typeof(Acb(complex(Arb(), Arb()))) == Acb
-        @test typeof(zero(Acb)) == Acb
-        @test typeof(one(Acb)) == Acb
-        @test typeof(Acb(π)) == Acb
+        for T in [UInt, Int, Float64, Arf, Arb, BigFloat, Rational{Int}]
+            @test Acb(zero(T)) == zero(Acb)
+            @test Acb(one(T)) == one(Acb)
+            @test precision(Acb(zero(T), prec = 80)) == 80
 
-        @test precision(Acb(UInt64(1), prec = 64)) == 64
-        @test precision(Acb(1, prec = 64)) == 64
-        @test precision(Acb(1.0, prec = 64)) == 64
-        @test precision(Acb(Arb(prec = 64))) == 64
-        @test precision(Acb(Acb(prec = 64))) == 64
-        @test precision(Acb(1, 1, prec = 64)) == 64
-        @test precision(Acb(1.0, 1.0, prec = 64)) == 64
-        @test precision(Acb(Arb(), Arb(), prec = 64)) == 64
-        @test precision(zero(Acb(prec = 64))) == 64
-        @test precision(one(Acb(prec = 64))) == 64
-        @test precision(Acb(π, prec = 64)) == 64
+            @test imag(Acb(zero(T), one(T))) == one(Arb)
+            @test precision(Acb(zero(T), zero(T), prec = 80)) == 80
 
-        x = Acb()
-        x[] = (1.0 + 2.0im)
-        @test x == Acb(1, 2)
-    end
+            @test imag(Acb(Complex(zero(T), one(T)))) == one(Arb)
+            @test precision(Acb(Complex(zero(T), zero(T)), prec = 80)) == 80
+        end
 
-    @testset "MagRef/ArfRef" begin
-        x = Arb(2.0)
-        m = Arblib.radref(x)
-        @test m isa MagRef
-        @test m[] isa Mag
-        @test m == m[]
+        @test Acb(zero(Acb).acb) == Acb("0.0") == zero(Acb)
+        @test Acb(one(Acb).acb) == Acb("1.0") == one(Acb)
+        @test precision(Acb(zero(Acb).acb, prec = 80)) ==
+              precision(Acb("0.0", prec = 80)) ==
+              80
 
-        d = Arblib.midref(x)
-        @test d isa ArfRef
-        @test d[] isa Arf
-        @test d == d[]
+        @test imag(Acb(zero(Arb).arb, one(Arb).arb)) == imag(Acb("0.0", "1.0")) == one(Arb)
+        @test precision(Acb(zero(Arb).arb, zero(Arb).arb, prec = 80)) ==
+              precision(Acb("0.0", "0.0", prec = 80)) ==
+              80
+
+        @test precision(Acb(Arf(prec = 80))) == 80
+        @test precision(Acb(Arb(prec = 80))) == 80
+        @test precision(Acb(Acb(prec = 80))) == 80
+        @test precision(Acb(BigFloat(0, precision = 80))) == 80
+
+        @test precision(Acb(Arf(prec = 80), Arf(prec = 100))) == 100
+        @test precision(Acb(Arb(prec = 80), Arb(prec = 100))) == 100
+        @test precision(Acb(BigFloat(0, precision = 80), BigFloat(0, precision = 100))) ==
+              100
+
+        @test precision(Acb(Complex(Arf(prec = 80), Arf(prec = 100)))) == 100
+        @test precision(Acb(Complex(Arb(prec = 80), Arb(prec = 100)))) == 100
+        @test precision(Acb(Complex(
+            BigFloat(0, precision = 80),
+            BigFloat(0, precision = 100),
+        ))) == 100
+
+        @test precision(zero(Arb(prec = 80))) == 80
+        @test precision(one(Arb(prec = 80))) == 80
+
+        @test isequal(real(Acb(π)), Arb(π))
+        @test isequal(real(Acb(ℯ)), Arb(ℯ))
+        @test isequal(real(Acb(MathConstants.γ)), Arb(MathConstants.γ))
+        @test precision(Acb(π, prec = 80)) == 80
+        @test precision(Acb(ℯ, prec = 80)) == 80
+        @test precision(Acb(MathConstants.γ, prec = 80)) == 80
+
+        @test isequal(Acb(π, -1), Acb(Arb(π), Arb(-1)))
+        @test isequal(Acb(BigFloat(1.3), ℯ), Acb(Arb(1.3), Arb(ℯ)))
     end
 end

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -60,9 +60,13 @@
         @test Arb(3) < Arb(π) < Arb(4)
         @test Arb(2) < Arb(ℯ) < Arb(3)
         @test Arb(0) < Arb(MathConstants.γ) < Arb(1)
+        @test Arb(0) < Arb(MathConstants.catalan) < Arb(1)
+        @test Arblib.overlaps(Arb(BigFloat(MathConstants.φ)), Arb(MathConstants.φ))
         @test precision(Arb(π, prec = 80)) == 80
         @test precision(Arb(ℯ, prec = 80)) == 80
         @test precision(Arb(MathConstants.γ, prec = 80)) == 80
+        @test precision(Arb(MathConstants.catalan, prec = 80)) == 80
+        @test precision(Arb(MathConstants.φ, prec = 80)) == 80
     end
 
     @testset "Acb" begin

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -2,7 +2,7 @@
     @testset "Mag" begin
         # Results for doubles are only upper bounds, even for integers
         # they are quite crude
-        @test Mag(UInt64(0)) == zero(Mag) == zero(Mag()) == Mag(0.0)
+        @test Mag() == Mag(UInt64(0)) == zero(Mag) == zero(Mag()) == Mag(0.0)
         @test Mag(UInt64(1)) == one(Mag) == one(Mag()) <= Mag(1.0)
         @test π < Float64(Mag(π)) < 3.15
     end
@@ -141,19 +141,5 @@
         @test v[1] == v[2] == one(Arb)
         Arblib.set!(v[2], 0)
         @test v[1] == one(Arb) && v[2] == zero(Arb)
-    end
-
-    @testset "Set Rational" begin
-        z = Arb(prec = 64)
-        z[] = 1 // 2
-        @test z == 0.5
-
-        z = Acb(prec = 64)
-        z[] = 1 // 2
-        @test z == 0.5
-
-        z = Acb(prec = 64)
-        z[] = 1 // 2 + 3 // 4 * im
-        @test z == 0.5 + 0.75im
     end
 end

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -123,4 +123,23 @@
         @test isequal(Acb(π, -1), Acb(Arb(π), Arb(-1)))
         @test isequal(Acb(BigFloat(1.3), ℯ), Acb(Arb(1.3), Arb(ℯ)))
     end
+
+    @testset "zeros/ones" begin
+        for T in [Arf, Arb, Acb]
+            @test zeros(T, 2) == [zero(T), zero(T)]
+            @test ones(T, 2) == [one(T), one(T)]
+        end
+
+        v = zeros(Arb, 2)
+        @test length(v) == 2
+        @test v[1] == v[2] == zero(Arb)
+        Arblib.set!(v[2], 1)
+        @test v[1] == zero(Arb) && v[2] == one(Arb)
+
+        v = ones(Arb, 2)
+        @test length(v) == 2
+        @test v[1] == v[2] == one(Arb)
+        Arblib.set!(v[2], 0)
+        @test v[1] == one(Arb) && v[2] == zero(Arb)
+    end
 end

--- a/test/ref-test.jl
+++ b/test/ref-test.jl
@@ -12,6 +12,11 @@
     z = Arblib.radref(x)[]
     Arblib.set!(z, UInt(4))
     @test Arblib.radref(x) == Mag(UInt(2))
+
+    @test isequal(zero(MagRef), zero(Mag))
+    @test isequal(zero(Arblib.radref(x)), zero(Mag))
+    @test isequal(one(MagRef), one(Mag))
+    @test isequal(one(Arblib.radref(x)), one(Mag))
 end
 
 @testset "ArfRef" begin
@@ -35,6 +40,11 @@ end
     z = Arblib.midref(x)[]
     Arblib.set!(z, 4)
     @test Arblib.midref(x) == Arf(2)
+
+    @test isequal(zero(ArfRef), zero(Arf))
+    @test isequal(zero(Arblib.midref(x)), zero(Arf))
+    @test isequal(one(ArfRef), one(Arf))
+    @test isequal(one(Arblib.midref(x)), one(Arf))
 end
 
 @testset "ArbRef" begin
@@ -60,6 +70,11 @@ end
     z = Arblib.realref(x)[]
     Arblib.set!(z, 4)
     @test Arblib.realref(x) == Arf(2)
+
+    @test isequal(zero(ArbRef), zero(Arb))
+    @test isequal(zero(Arblib.realref(x)), zero(Arb))
+    @test isequal(one(ArbRef), one(Arb))
+    @test isequal(one(Arblib.realref(x)), one(Arb))
 end
 
 @testset "AcbRef" begin
@@ -75,6 +90,11 @@ end
     @test AcbRef(ptr, parent) == Acb()
     @test precision(AcbRef(ptr, parent)) == Arblib.DEFAULT_PRECISION[]
     @test precision(AcbRef(ptr, parent, prec = 80)) == 80
+
+    @test isequal(zero(AcbRef), zero(Acb))
+    @test isequal(zero(x), zero(Acb))
+    @test isequal(one(AcbRef), one(Acb))
+    @test isequal(one(x), one(Acb))
 
     Arblib.set!(x, 2)
     @test v[1] == Acb(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Arblib, Test, LinearAlgebra
     include("types-test.jl")
     include("arbcall-test.jl")
     include("precision-test.jl")
+    include("setters-test.jl")
     include("constructors-test.jl")
     include("predicates-test.jl")
     include("show-test.jl")

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -1,0 +1,107 @@
+@testset "setters" begin
+    @testset "Mag" begin
+        @test π <
+              Float64(Arblib.set!(Mag(), π)) ==
+              Float64(Arblib.set!(Arblib.radref(Arb()), π)) ==
+              Float64(Arblib.set!(Arblib.mag_struct(), π)) <
+              3.15
+    end
+
+    @testset "Arb" begin
+        @test Arblib.set!(Arb(), BigFloat(1.0)) == one(Arb)
+        @test Arblib.set!(Arblib.realref(Acb()), BigFloat(1.0)) == one(Arb)
+        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigFloat(1.0)), one(Arb))
+        @test Arblib.set!(Arb(), one(Mag)) == one(Arb)
+        @test Arblib.set!(Arblib.realref(Acb()), one(Mag)) == one(Arb)
+        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), one(Mag).mag), one(Arb))
+
+        @test Arblib.set!(Arb(), 1 // 2) == one(Arb) / 2
+        @test Arblib.set!(Arblib.realref(Acb()), 1 // 2) == one(Arb) / 2
+        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), 1 // 2), one(Arb) / 2)
+
+        @test Arb(3) < Arblib.set!(Arb(), π) < Arb(4)
+        @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.realref(Acb()), π))
+        @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.arb_struct(), π))
+
+        @test Arb(2) < Arblib.set!(Arb(), ℯ) < Arb(3)
+        @test Arblib.equal(Arblib.set!(Arb(), ℯ), Arblib.set!(Arblib.realref(Acb()), ℯ))
+        @test Arblib.equal(Arblib.set!(Arb(), ℯ), Arblib.set!(Arblib.arb_struct(), ℯ))
+
+        @test Arb(0) < Arblib.set!(Arb(), MathConstants.γ) < Arb(1)
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.γ),
+            Arblib.set!(Arblib.realref(Acb()), MathConstants.γ),
+        )
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.γ),
+            Arblib.set!(Arblib.arb_struct(), MathConstants.γ),
+        )
+
+        @test Arb(0) < Arblib.set!(Arb(), MathConstants.catalan) < Arb(1)
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.catalan),
+            Arblib.set!(Arblib.realref(Acb()), MathConstants.catalan),
+        )
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.catalan),
+            Arblib.set!(Arblib.arb_struct(), MathConstants.catalan),
+        )
+
+        @test Arblib.overlaps(
+            Arb(BigFloat(MathConstants.φ)),
+            Arblib.set!(Arb(), MathConstants.φ),
+        )
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.φ),
+            Arblib.set!(Arblib.realref(Acb()), MathConstants.φ),
+        )
+        @test Arblib.equal(
+            Arblib.set!(Arb(), MathConstants.φ),
+            Arblib.set!(Arblib.arb_struct(), MathConstants.φ),
+        )
+    end
+
+    @testset "Acb" begin
+        @test Arblib.set!(Acb(), BigFloat(1.0)) == one(Acb)
+        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), BigFloat(1.0)), one(Acb))
+        x = Arblib.set!(Acb(), ℯ)
+        @test isequal(Arblib.realref(x), Arb(ℯ))
+        @test Arblib.imagref(x) == zero(Arb)
+        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), BigFloat(1.0)), one(Acb))
+        @test Arblib.set!(Acb(), one(Arf).arf) == one(Acb)
+        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), one(Arf).arf), one(Acb))
+        @test Arblib.set!(Acb(0, 5), BigFloat(1.0)) == one(Acb)
+
+        @test Arblib.set!(Acb(), BigFloat(1.0), 2) == Acb(1, 2)
+        x = Arblib.set!(Acb(), π, Arf(4))
+        @test isequal(Arblib.realref(x), Arb(π))
+        @test isequal(Arblib.imagref(x), Arb(4))
+        @test Arblib.set!(Acb(), Arb(1), Arf(2)) == Acb(1, 2)
+        @test Arblib.set!(Acb(), Arb(1).arb, Arf(2).arf) == Acb(1, 2)
+
+        @test Arblib.set!(Acb(), Complex(1, 2)) == Acb(1, 2)
+        @test Arblib.set!(Acb(), Complex(BigFloat(1), BigFloat(2))) == Acb(1, 2)
+        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), Complex(1, 2)), Acb(1, 2))
+
+        x = Arblib.set!(Acb(), π)
+        @test isequal(Arblib.realref(x), Arb(π))
+        @test Arblib.imagref(x) == zero(Arb)
+        x = Arblib.set!(Arblib.acb_struct(), π)
+        @test Arblib.equal(Arblib.realref(x), Arb(π))
+        @test Arblib.equal(Arblib.imagref(x), zero(Arb))
+    end
+
+    @testset "Set Rational" begin
+        z = Arb(prec = 64)
+        z[] = 1 // 2
+        @test z == 0.5
+
+        z = Acb(prec = 64)
+        z[] = 1 // 2
+        @test z == 0.5
+
+        z = Acb(prec = 64)
+        z[] = 1 // 2 + 3 // 4 * im
+        @test z == 0.5 + 0.75im
+    end
+end


### PR DESCRIPTION
I did some cleanup of `constructors.jl`. Mainly
- Rewriting to remove most of the `@eval`s
- Add some more constructors
- Add more test
- Add constructors for more `MathConstants`
- Move some code to `ref.jl`

Also, what do you think about adding `@inline _precision(x::BigFloat) = precision(x)`to `precision.jl`? I think that could make some of the logic simpler since we usually want to take the precision of a `BigFloat` into account.