### PR TITLE
Allow to set Rational to Arb and Acb

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -60,8 +60,7 @@ end
 
 function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
     num = Arb(numerator(x); prec = prec)
-    denom = Arb(denominator(x); prec = prec)
-    div!(num, num, denom)
+    div!(num, num, denominator(x))
     return num
 end
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -141,6 +141,18 @@ Base.ones(x::Type{T}, n::Integer) where {T<:Union{Arf,Arb,Acb}} = [one(T) for _ 
 
 set!(z::Union{Acb,AcbRef,Ptr{acb_struct},acb_struct}, x::Complex{<:Base.GMP.CdoubleMax}) =
     set!(z, real(x), imag(x))
+
+function set!(z::ArbLike, x::Rational)
+    z[] = numerator(x)
+    div!(z, z, denominator(x))
+end
+
+function set!(z::AcbLike, x::Union{Rational,Complex{<:Rational}})
+    set!(realref(z), real(x))
+    set!(imagref(z), imag(x))
+    z
+end
+
 # Irrationals
 function Mag(::Irrational{:π})
     res = Mag()

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -117,4 +117,18 @@
         @test d[] isa Arf
         @test d == d[]
     end
+
+    @testset "Set Rational" begin
+        z = Arb(prec=64)
+        z[] = 1//2
+        @test z == 0.5
+
+        z = Acb(prec=64)
+        z[] = 1//2
+        @test z == 0.5
+
+        z = Acb(prec=64)
+        z[] = 1//2 + 3//4  * im
+        @test z == 0.5 + 0.75im
+    end
 end

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -119,16 +119,16 @@
     end
 
     @testset "Set Rational" begin
-        z = Arb(prec=64)
-        z[] = 1//2
+        z = Arb(prec = 64)
+        z[] = 1 // 2
         @test z == 0.5
 
-        z = Acb(prec=64)
-        z[] = 1//2
+        z = Acb(prec = 64)
+        z[] = 1 // 2
         @test z == 0.5
 
-        z = Acb(prec=64)
-        z[] = 1//2 + 3//4  * im
+        z = Acb(prec = 64)
+        z[] = 1 // 2 + 3 // 4 * im
         @test z == 0.5 + 0.75im
     end
 end


### PR DESCRIPTION
This uses the same strategy as for the constructors, i.e. performing a division by the denominator to get a result which is guaranteed to contain the rational number.