### PR TITLE
Define arf_get_d and arf_get_si manually

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -41,6 +41,7 @@ include("arb_types.jl")
 include("rounding.jl")
 include("types.jl")
 include("arbcall.jl")
+include("manual_overrides.jl")
 
 include("precision.jl")
 

--- a/src/manual_overrides.jl
+++ b/src/manual_overrides.jl
@@ -1,0 +1,9 @@
+# arf_get_d and arf_get_si clash
+get_d(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_d(x, rnd)
+function get_d(x::ArfLike, rnd::Union{arb_rnd,RoundingMode})
+    ccall(@libarb(arf_get_d), Float64, (Ref{arf_struct}, arb_rnd), x, rnd)
+end
+get_si(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_si(x, rnd)
+function get_si(x::ArfLike, rnd::Union{arb_rnd,RoundingMode})
+    ccall(@libarb(arf_get_si), Int, (Ref{arf_struct}, arb_rnd), x, rnd)
+end

--- a/test/manual_overrides_test.jl
+++ b/test/manual_overrides_test.jl
@@ -1,0 +1,16 @@
+@testset "Manual overrides" begin
+    @testset "arf_get_d / arf_get_si" begin
+        a = Arf(2.3)
+
+        @test Arblib.get_d(a) isa Float64
+        @test Arblib.get_d(a) == 2.3
+        @test Arblib.get_d(a, rnd = RoundNearest) == 2.3
+        @test Arblib.get_d(a, RoundNearest) == 2.3
+
+        @test Arblib.get_si(a) isa Int
+        @test Arblib.get_si(a) == 2
+        @test Arblib.get_si(a, rnd = RoundUp) == 3
+        @test Arblib.get_si(a, RoundUp) == 3
+        @test Arblib.get_si(a, RoundToZero) == 2
+    end
+end


### PR DESCRIPTION
These two definitions are manually overridden in arbcall since they 
clash with our renaming rules. However, I need `arf_get_d`. So I 
manually defined the methods `get_d` resp. `get_si`. The idea is to keep 
the parth of original arb name which is necessary disambuige these two.