### PR TITLE
add generic constructors for Acb and Arb (through Arf)

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -64,6 +64,8 @@ function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
     return num
 end
 
+Arb(x::Real; prec::Integer = _precision(x)) = Arb(Arf(x, prec=prec))
+
 ## Acb
 for T in (acb_struct, Unsigned, Integer, Base.GMP.CdoubleMax)
     @eval begin
@@ -110,6 +112,7 @@ function Acb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
     Acb(Arb(x; prec = prec); prec = prec)
 end
 
+Acb(x::Real; prec::Integer = _precision(x)) = Acb(Arb(x, prec=prec))
 
 function Acb(re::Arb, im::Arb; prec::Integer = max(precision(re), precision(im)))
     res = Acb(prec = prec)
@@ -122,6 +125,12 @@ function Acb(z::Complex{Arb}; prec::Integer = max(precision(real(z)), precision(
     set!(res, real(z), imag(z))
     return res
 end
+
+Acb(re::Real, im::Real; prec::Integer = max(_precision(re), _precision(im))) =
+    Acb(Arb(re, prec=prec), Arb(im, prec=prec))
+
+Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
+    Acb(real(z), imag(z), prec=prec)
 
 Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -64,7 +64,7 @@ function Arb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
     return num
 end
 
-Arb(x::Real; prec::Integer = _precision(x)) = Arb(Arf(x, prec=prec))
+Arb(x::Real; prec::Integer = _precision(x)) = Arb(Arf(x, prec = prec))
 
 ## Acb
 for T in (acb_struct, Unsigned, Integer, Base.GMP.CdoubleMax)
@@ -112,7 +112,7 @@ function Acb(x::Rational; prec::Integer = DEFAULT_PRECISION[])
     Acb(Arb(x; prec = prec); prec = prec)
 end
 
-Acb(x::Real; prec::Integer = _precision(x)) = Acb(Arb(x, prec=prec))
+Acb(x::Real; prec::Integer = _precision(x)) = Acb(Arb(x, prec = prec))
 
 function Acb(re::Arb, im::Arb; prec::Integer = max(precision(re), precision(im)))
     res = Acb(prec = prec)
@@ -127,10 +127,10 @@ function Acb(z::Complex{Arb}; prec::Integer = max(precision(real(z)), precision(
 end
 
 Acb(re::Real, im::Real; prec::Integer = max(_precision(re), _precision(im))) =
-    Acb(Arb(re, prec=prec), Arb(im, prec=prec))
+    Acb(Arb(re, prec = prec), Arb(im, prec = prec))
 
 Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
-    Acb(real(z), imag(z), prec=prec)
+    Acb(real(z), imag(z), prec = prec)
 
 Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -50,6 +50,8 @@
         @test typeof(Arb(UInt64(1))) == Arb
         @test typeof(Arb(1)) == Arb
         @test typeof(Arb(1.0)) == Arb
+        @test typeof(Arb(big(1.0))) == Arb
+        @test typeof(Arb(big(1))) == Arb
         @test typeof(Arb(Arf())) == Arb
         @test typeof(Arb(Arb())) == Arb
         @test typeof(Arb("1.1")) == Arb
@@ -62,6 +64,7 @@
         @test precision(Arb(UInt64(1), prec = 64)) == 64
         @test precision(Arb(1, prec = 64)) == 64
         @test precision(Arb(1.0, prec = 64)) == 64
+        @test precision(Arb(big(1.0), prec = 64)) == 64
         @test precision(Arb(Arf(prec = 64))) == 64
         @test precision(Arb(Arb(prec = 64))) == 64
         @test precision(Arb("1.1", prec = 64)) == 64
@@ -75,11 +78,15 @@
     @testset "Acb" begin
         @test typeof(Acb(UInt64(1))) == Acb
         @test typeof(Acb(1)) == Acb
+        @test typeof(Acb(big(1))) == Acb
         @test typeof(Acb(1.0)) == Acb
+        @test typeof(Acb(big(1.0))) == Acb
         @test typeof(Acb(Arb())) == Acb
         @test typeof(Acb(Acb())) == Acb
         @test typeof(Acb(1, 1)) == Acb
+        @test typeof(Acb(big(1), 1.0)) == Acb
         @test typeof(Acb(1.0, 1.0)) == Acb
+        @test typeof(Acb(big(1.0), 1.0)) == Acb
         @test typeof(Acb(Arb(), Arb())) == Acb
         @test typeof(Acb(complex(1, 1))) == Acb
         @test typeof(Acb(complex(1.0, 1.0))) == Acb
@@ -94,7 +101,9 @@
         @test precision(Acb(Arb(prec = 64))) == 64
         @test precision(Acb(Acb(prec = 64))) == 64
         @test precision(Acb(1, 1, prec = 64)) == 64
+        @test precision(Acb(big(1), 1, prec = 64)) == 64
         @test precision(Acb(1.0, 1.0, prec = 64)) == 64
+        @test precision(Acb(big(1.0), 1.0, prec = 64)) == 64
         @test precision(Acb(Arb(), Arb(), prec = 64)) == 64
         @test precision(zero(Acb(prec = 64))) == 64
         @test precision(one(Acb(prec = 64))) == 64


### PR DESCRIPTION
Add general constructors for `Real`, which go through `Arf`.

this allows you to write `Arb(big(1.))` and `Acb(big(1.0), big(2))`