### PR TITLE
Enh/rand

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.1"
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -50,6 +50,7 @@ include("constructors.jl")
 include("predicates.jl")
 include("show.jl")
 include("arithmetic.jl")
+include("rand.jl")
 
 include("ref.jl")
 include("vector.jl")

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -34,13 +34,13 @@ function Base.:(^)(x::T, k::Integer) where {T<:MagOrRef}
 end
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
-    @eval function Base.$jf(x::T, y::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+    @eval function Base.$jf(x::T, y::T) where {T<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
         z = T(prec = max(precision(x), precision(y)))
         $af(z, x, y)
         z
     end
 end
-function Base.:(-)(x::T) where {T<:Union{Arf,Arb,ArbRef,Acb,AcbRef}}
+function Base.:(-)(x::T) where {T<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
     z = T(prec = precision(x))
     neg!(z, x)
     z

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -20,14 +20,14 @@ Base.promote_rule(
 ) = Acb
 
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
-    @eval function Base.$jf(x::T, y::T) where {T<:Union{Mag,MagRef}}
+    @eval function Base.$jf(x::T, y::T) where {T<:MagOrRef}
         z = T()
         $af(z, x, y)
         z
     end
 end
 
-function Base.:(^)(x::T, k::Integer) where {T<:Union{Mag,MagRef}}
+function Base.:(^)(x::T, k::Integer) where {T<:MagOrRef}
     z = T()
     pow!(z, x, convert(UInt, k))
     z

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -16,7 +16,7 @@ Base.precision(x::ArbTypes) = x.prec
 # MagLike <: ArbTypes
 Base.precision(x::MagLike) = DEFAULT_PRECISION[]
 # disambiguation
-Base.precision(::Union{Mag,MagRef}) = DEFAULT_PRECISION[]
+Base.precision(::MagOrRef) = DEFAULT_PRECISION[]
 
 @inline _precision(x::ArbTypes) = precision(x)
 @inline _precision(x::BigFloat) = precision(x)

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -2,15 +2,13 @@ import Random
 
 # TODO: remove Random.CloseOpen01{BigFloat} parameters
 # TODO: remove setprecision
-# possibly fixed by
+# possibly fixed by https://github.com/JuliaLang/julia/pull/38169
 
 function Random.Sampler(
     RNG::Type{<:Random.AbstractRNG},
-    st::Random.SamplerType{TOrRef},
+    st::Random.SamplerType{T},
     n::Random.Repetition,
-) where {TOrRef<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
-
-    T = _nonreftype(TOrRef)
+) where {T<:Union{Arf,Arb,Acb}}
     return Random.SamplerSimple(
         Random.SamplerType{T}(),
         Random.SamplerBigFloat{Random.CloseOpen01{BigFloat}}(precision(T)),

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -27,16 +27,17 @@ function Random.Sampler(
     )
 end
 
-Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arf}) where {A,B} =
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{Random.SamplerType{Arf}}) =
     setprecision(BigFloat, sp.data.prec) do
         Arf(rand(rng, sp.data), prec = sp.data.prec)
     end
 
-Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arb}) where {A,B} =
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{Random.SamplerType{Arb}}) =
     setprecision(BigFloat, sp.data.prec) do
         Arb(rand(rng, sp.data), prec = sp.data.prec)
     end
-Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Acb}) where {A,B} =
+
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{Random.SamplerType{Acb}}) =
     setprecision(BigFloat, sp.data.prec) do
         Acb(rand(rng, sp.data), rand(rng, sp.data), prec = sp.data.prec)
     end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,9 +1,5 @@
-import Random
 
-const MagOrRef = Union{Mag,MagRef}
-const ArfOrRef = Union{Arf,ArfRef}
-const ArbOrRef = Union{Arb,ArbRef}
-const AcbOrRef = Union{Acb,AcbRef}
+import Random
 
 for (T, RefT) in ((Arf, ArfOrRef), (Arb, ArbOrRef), (Acb, AcbOrRef))
     @eval begin

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,22 +1,19 @@
 import Random
 
-for (T, RefT) in ((Arf, ArfOrRef), (Arb, ArbOrRef), (Acb, AcbOrRef))
-    @eval begin
-        function Random.Sampler(
-            RNG::Type{<:Random.AbstractRNG},
-            st::Random.SamplerType{<:$RefT},
-            n::Random.Repetition,
-        )
-            # return Random.SamplerSimple(
-            #     Random.SamplerType{Arf}(),
-            #     Random.SamplerBigFloat(precision(Arf)),
-            # )
-            res = setprecision(BigFloat, precision($T)) do
-                Random.SamplerSimple(Random.SamplerType{$T}(), Random.Sampler(RNG, BigFloat, n))
-            end
-            return res
-        end
+function Random.Sampler(
+    RNG::Type{<:Random.AbstractRNG},
+    st::Random.SamplerType{TOrRef},
+    n::Random.Repetition,
+) where {TOrRef<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
+    T = _nonreftype(TOrRef)
+    # return Random.SamplerSimple(
+    #     Random.SamplerType{T}(),
+    #     Random.SamplerBigFloat(precision(T)),
+    # )
+    res = setprecision(BigFloat, precision(T)) do
+        Random.SamplerSimple(Random.SamplerType{T}(), Random.Sampler(RNG, BigFloat, n))
     end
+    return res
 end
 
 Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arf}) where {A,B} =

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,0 +1,65 @@
+import Random
+
+const MagOrRef = Union{Mag,MagRef}
+const ArfOrRef = Union{Arf,ArfRef}
+const ArbOrRef = Union{Arb,ArbRef}
+const AcbOrRef = Union{Acb,AcbRef}
+
+for (T, RefT) in ((Arf, ArfOrRef), (Arb, ArbOrRef), (Acb, AcbOrRef))
+    @eval begin
+        function Random.Sampler(
+            RNG::Type{<:Random.AbstractRNG},
+            st::Random.SamplerType{<:$RefT},
+            n::Random.Repetition,
+        )
+            #     TODO: SamplerBigFloat(precision(Arf))
+            #     return Random.SamplerSimple(
+            #         Random.SamplerType{Arf}(),
+            #         Random.SamplerBigFloat(precision(Arf))
+            #     )
+            res = setprecision(BigFloat, precision($T)) do
+                Random.SamplerSimple(Random.SamplerType{$T}(), Random.Sampler(RNG, BigFloat, n))
+            end
+            return res
+        end
+    end
+end
+
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arf}) where {A,B} =
+    Arf(rand(rng, sp.data), prec = sp.data.prec)
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arb}) where {A,B} =
+    Arb(rand(rng, sp.data), prec = sp.data.prec)
+Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Acb}) where {A,B} =
+    Acb(rand(rng, sp.data), rand(rng, sp.data), prec = sp.data.prec)
+
+function Random.rand(
+    rng::Random.AbstractRNG,
+    st::Random.SamplerTrivial{A,A},
+) where {A<:ArfOrRef}
+    # TODO: Arf(Random.SamplerBigFloat(precision(st[])))
+    x = setprecision(BigFloat, precision(st[])) do
+        rand(rng, BigFloat)
+    end
+    return Arf(x, prec = precision(st[]))
+end
+
+function Random.rand(
+    rng::Random.AbstractRNG,
+    st::Random.SamplerTrivial{A,A},
+) where {A<:ArbOrRef}
+    x = setprecision(BigFloat, precision(st[])) do
+        rand(rng, BigFloat)
+    end
+    # randomize radius?
+    return Arb(x, prec = precision(st[]))
+end
+
+function Random.rand(
+    rng::Random.AbstractRNG,
+    st::Random.SamplerTrivial{A,A},
+) where {A<:AcbOrRef}
+    re, im = setprecision(BigFloat, precision(st[])) do
+        rand(rng, BigFloat, 2) # TODO: Random.SamplerBigFloat(precision(st[]))
+    end # TODO: Random.SamplerBigFloat(precision(st[]))
+    return Acb(re, im; prec = precision(st[]))
+end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,58 +1,44 @@
 import Random
 
+# TODO: remove Random.CloseOpen01{BigFloat} parameters
+# TODO: remove setprecision
+# possibly fixed by
+
 function Random.Sampler(
     RNG::Type{<:Random.AbstractRNG},
     st::Random.SamplerType{TOrRef},
     n::Random.Repetition,
 ) where {TOrRef<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
+
     T = _nonreftype(TOrRef)
-    # return Random.SamplerSimple(
-    #     Random.SamplerType{T}(),
-    #     Random.SamplerBigFloat(precision(T)),
-    # )
-    res = setprecision(BigFloat, precision(T)) do
-        Random.SamplerSimple(Random.SamplerType{T}(), Random.Sampler(RNG, BigFloat, n))
-    end
-    return res
+    return Random.SamplerSimple(
+        Random.SamplerType{T}(),
+        Random.SamplerBigFloat{Random.CloseOpen01{BigFloat}}(precision(T)),
+    )
+end
+
+function Random.Sampler(
+    RNG::Type{<:Random.AbstractRNG},
+    x::TOrRef,
+    n::Random.Repetition,
+) where {TOrRef<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}}
+    T = _nonreftype(TOrRef)
+    return Random.SamplerSimple(
+        Random.SamplerType{T}(),
+        Random.SamplerBigFloat{Random.CloseOpen01{BigFloat}}(precision(x)),
+    )
 end
 
 Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arf}) where {A,B} =
-    Arf(rand(rng, sp.data), prec = sp.data.prec)
+    setprecision(BigFloat, sp.data.prec) do
+        Arf(rand(rng, sp.data), prec = sp.data.prec)
+    end
+
 Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Arb}) where {A,B} =
-    Arb(rand(rng, sp.data), prec = sp.data.prec)
+    setprecision(BigFloat, sp.data.prec) do
+        Arb(rand(rng, sp.data), prec = sp.data.prec)
+    end
 Random.rand(rng::Random.AbstractRNG, sp::Random.SamplerSimple{A,B,Acb}) where {A,B} =
-    Acb(rand(rng, sp.data), rand(rng, sp.data), prec = sp.data.prec)
-
-function Random.rand(
-    rng::Random.AbstractRNG,
-    st::Random.SamplerTrivial{A,A},
-) where {A<:ArfOrRef}
-    # TODO: Arf(rand(rng, Random.SamplerBigFloat(precision(st[]))))
-    x = setprecision(BigFloat, precision(st[])) do
-        rand(rng, BigFloat)
+    setprecision(BigFloat, sp.data.prec) do
+        Acb(rand(rng, sp.data), rand(rng, sp.data), prec = sp.data.prec)
     end
-    return Arf(x, prec = precision(st[]))
-end
-
-function Random.rand(
-    rng::Random.AbstractRNG,
-    st::Random.SamplerTrivial{A,A},
-) where {A<:ArbOrRef}
-    # TODO: Arb(rand(rng, Random.SamplerBigFloat(precision(st[]))))
-    x = setprecision(BigFloat, precision(st[])) do
-        rand(rng, BigFloat)
-    end
-    # randomize radius?
-    return Arb(x, prec = precision(st[]))
-end
-
-function Random.rand(
-    rng::Random.AbstractRNG,
-    st::Random.SamplerTrivial{A,A},
-) where {A<:AcbOrRef}
-    # TODO: rand(rng, Random.SamplerBigFloat(precision(st[])), 2)
-    re, im = setprecision(BigFloat, precision(st[])) do
-        rand(rng, BigFloat, 2)
-    end
-    return Acb(re, im; prec = precision(st[]))
-end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,4 +1,3 @@
-
 import Random
 
 for (T, RefT) in ((Arf, ArfOrRef), (Arb, ArbOrRef), (Acb, AcbOrRef))
@@ -8,11 +7,10 @@ for (T, RefT) in ((Arf, ArfOrRef), (Arb, ArbOrRef), (Acb, AcbOrRef))
             st::Random.SamplerType{<:$RefT},
             n::Random.Repetition,
         )
-            #     TODO: SamplerBigFloat(precision(Arf))
-            #     return Random.SamplerSimple(
-            #         Random.SamplerType{Arf}(),
-            #         Random.SamplerBigFloat(precision(Arf))
-            #     )
+            # return Random.SamplerSimple(
+            #     Random.SamplerType{Arf}(),
+            #     Random.SamplerBigFloat(precision(Arf)),
+            # )
             res = setprecision(BigFloat, precision($T)) do
                 Random.SamplerSimple(Random.SamplerType{$T}(), Random.Sampler(RNG, BigFloat, n))
             end
@@ -32,7 +30,7 @@ function Random.rand(
     rng::Random.AbstractRNG,
     st::Random.SamplerTrivial{A,A},
 ) where {A<:ArfOrRef}
-    # TODO: Arf(Random.SamplerBigFloat(precision(st[])))
+    # TODO: Arf(rand(rng, Random.SamplerBigFloat(precision(st[]))))
     x = setprecision(BigFloat, precision(st[])) do
         rand(rng, BigFloat)
     end
@@ -43,6 +41,7 @@ function Random.rand(
     rng::Random.AbstractRNG,
     st::Random.SamplerTrivial{A,A},
 ) where {A<:ArbOrRef}
+    # TODO: Arb(rand(rng, Random.SamplerBigFloat(precision(st[]))))
     x = setprecision(BigFloat, precision(st[])) do
         rand(rng, BigFloat)
     end
@@ -54,8 +53,9 @@ function Random.rand(
     rng::Random.AbstractRNG,
     st::Random.SamplerTrivial{A,A},
 ) where {A<:AcbOrRef}
+    # TODO: rand(rng, Random.SamplerBigFloat(precision(st[])), 2)
     re, im = setprecision(BigFloat, precision(st[])) do
-        rand(rng, BigFloat, 2) # TODO: Random.SamplerBigFloat(precision(st[]))
-    end # TODO: Random.SamplerBigFloat(precision(st[]))
+        rand(rng, BigFloat, 2)
+    end
     return Acb(re, im; prec = precision(st[]))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -248,6 +248,8 @@ for prefix in [:mag, :arf, :arb, :acb]
         Base.convert(::Type{Ptr{$TStruct}}, x::$TRef) = cstruct(x)
         Base.cconvert(::Type{Ref{$TStruct}}, x::$TRef) = cstruct(x)
 
+        _nonreftype(::Type{<:Union{$T,$TRef}}) = $T
+
         parentstruct(x::$T) = cstruct(x)
         parentstruct(x::$TRef) = x
         parentstruct(x::$TStruct) = x

--- a/src/types.jl
+++ b/src/types.jl
@@ -254,6 +254,10 @@ for prefix in [:mag, :arf, :arb, :acb]
     end
 end
 
+const MagOrRef = Union{Mag,MagRef}
+const ArfOrRef = Union{Arf,ArfRef}
+const ArbOrRef = Union{Arb,ArbRef}
+const AcbOrRef = Union{Acb,AcbRef}
 const MagLike = Union{Mag,MagRef,cstructtype(Mag),Ptr{cstructtype(Mag)}}
 const ArfLike = Union{Arf,ArfRef,cstructtype(Arf),Ptr{cstructtype(Arf)}}
 const ArbLike = Union{Arb,ArbRef,cstructtype(Arb),Ptr{cstructtype(Arb)}}
@@ -289,7 +293,7 @@ const ArbTypes = Union{
 
 Base.setindex!(x::Union{Mag,MagRef,Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}, z::Number) =
     set!(x, z)
-Base.setindex!(x::Union{Mag,MagRef}, z::Ptr{mag_struct}) = set!(x, z)
-Base.setindex!(x::Union{Arf,ArfRef}, z::Ptr{arf_struct}) = set!(x, z)
-Base.setindex!(x::Union{Arb,ArbRef}, z::Ptr{arb_struct}) = set!(x, z)
-Base.setindex!(x::Union{Acb,AcbRef}, z::Ptr{acb_struct}) = set!(x, z)
+Base.setindex!(x::MagOrRef, z::Ptr{mag_struct}) = set!(x, z)
+Base.setindex!(x::ArfOrRef, z::Ptr{arf_struct}) = set!(x, z)
+Base.setindex!(x::ArbOrRef, z::Ptr{arb_struct}) = set!(x, z)
+Base.setindex!(x::AcbOrRef, z::Ptr{acb_struct}) = set!(x, z)

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -7,10 +7,15 @@
 
         @test precision(rand(T(prec = 128))) == 128
     end
-    a = rand(Arb)
+    a = rand(Arb(prec = 128))
     @test rand(Arblib.midref(a)) isa Arf
-    z = Acb(rand(Arb, 2)...)
+    @test precision(rand(Arblib.midref(a))) == precision(a)
+
+    z = Acb(rand(Arb(prec = 128), 2)...)
     @test rand(Arblib.realref(z)) isa Arb
-    M = AcbVector(rand(Acb, 3))
-    @test rand(Arblib.ref(M, 1)) isa Acb
+    @test precision(rand(Arblib.realref(z))) == precision(z)
+
+    V = AcbVector(rand(Acb(prec = 128), 3))
+    @test rand(Arblib.ref(V, 1)) isa Acb
+    @test precision(rand(Arblib.ref(V, 1))) == precision(V)
 end

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -1,10 +1,7 @@
 @testset "Random" begin
-    @testset "rand $T" for (T, RefT) in ((Arf, ArfRef), (Arb, ArbRef), (Acb, AcbRef))
+    @testset "rand $T" for T in (Arf, Arb, Acb)
         @test rand(T) isa T
         @test precision(rand(T)) == precision(T)
-        @test rand(RefT) isa T
-        @test precision(rand(RefT)) == precision(T)
-
         @test precision(rand(T(prec = 128))) == 128
     end
     a = rand(Arb(prec = 128))

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -1,0 +1,16 @@
+@testset "Random" begin
+    @testset "rand $T" for (T, RefT) in ((Arf, ArfRef), (Arb, ArbRef), (Acb, AcbRef))
+        @test rand(T) isa T
+        @test precision(rand(T)) == precision(T)
+        @test rand(RefT) isa T
+        @test precision(rand(RefT)) == precision(T)
+
+        @test precision(rand(T(prec = 128))) == 128
+    end
+    a = rand(Arb)
+    @test rand(Arblib.midref(a)) isa Arf
+    z = Acb(rand(Arb, 2)...)
+    @test rand(Arblib.realref(z)) isa Arb
+    M = AcbVector(rand(Acb, 3))
+    @test rand(Arblib.ref(M, 1)) isa Acb
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Arblib, Test, LinearAlgebra
     include("show-test.jl")
     include("examples.jl")
     include("arithmetic.jl")
+    include("rand.jl")
     include("vector.jl")
     include("matrix.jl")
     include("eigen.jl")


### PR DESCRIPTION
adds support for random api:
* everything goes through BigFloats
* radi are not randomized
* there is no rand for `Mag`s 

I also added `const ArbOrRef = Union{Arb, ArbRef}` but I won't insist on this change if there is some opposition to it ;)

There are couples of TODOs referencing `Random.SamplerBigFloat(precision(Arf))` which @rfourquet added/fixed very recently and probably will be in the next version. This  should simplify the code.
