### PR TITLE
Fix show+constructors

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -50,7 +50,8 @@ function Acb(re::AbstractString, im::AbstractString; prec::Integer = DEFAULT_PRE
     return res
 end
 
-Base.Int(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_si(x, rnd)
+Base.Int(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) =
+    is_int(x) ? get_si(x, rnd) : throw(InexactError(:Int64, Int64, x))
 
 Base.Float64(x::MagLike) = get(x)
 Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_d(x, rnd)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -50,6 +50,21 @@ function Acb(re::AbstractString, im::AbstractString; prec::Integer = DEFAULT_PRE
     return res
 end
 
+Base.Int(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_si(x, rnd)
+
+Base.Float64(x::MagLike) = get(x)
+Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_d(x, rnd)
+Base.Float64(x::ArbLike) = Float64(midref(x))
+
+Base.ComplexF64(z::AcbLike) = Complex(Float64(realref(z)), Float64(imagref(z)))
+
+function Base.BigFloat(x::Union{Arf,ArfRef})
+    y = BigFloat(; precision = precision(x))
+    get!(y, x)
+    y
+end
+Base.BigFloat(x::Union{Arb,ArbRef}) = BigFloat(midref(x))
+
 Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))
 Base.zero(x::T) where {T<:Union{Arf,Arb,Acb}} = T(0, prec = precision(x))

--- a/src/types.jl
+++ b/src/types.jl
@@ -293,13 +293,3 @@ Base.setindex!(x::Union{Mag,MagRef}, z::Ptr{mag_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arf,ArfRef}, z::Ptr{arf_struct}) = set!(x, z)
 Base.setindex!(x::Union{Arb,ArbRef}, z::Ptr{arb_struct}) = set!(x, z)
 Base.setindex!(x::Union{Acb,AcbRef}, z::Ptr{acb_struct}) = set!(x, z)
-
-Base.Float64(x::MagLike) = get(x)
-function Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest)
-    ccall(@libarb(arf_get_d), Cdouble, (Ref{arf_struct}, arb_rnd), x, rnd)
-end
-function Base.Int(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest)
-    ccall(@libarb(arf_get_si), Clong, (Ref{arf_struct}, arb_rnd), x, rnd)
-end
-Base.Float64(x::ArbLike) = Float64(midref(x))
-Base.ComplexF64(z::AcbLike) = Complex(Float64(realref(z)), Float64(imagref(z)))

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -124,6 +124,17 @@
         @test isequal(Acb(BigFloat(1.3), ℯ), Acb(Arb(1.3), Arb(ℯ)))
     end
 
+    @testset "Others" begin
+        @test Int(Arf(2)) == 2
+        @test Float64(Mag(2.5)) ≥ 2.5
+        @test Float64(Arf(2.5)) == 2.5
+        @test Float64(Arb(2.5)) == 2.5
+        @test ComplexF64(Acb(2.25)) == 2.25 + 0im
+        @test BigFloat(Arf(2.5)) == 2.5
+        @test BigFloat(Arb(2.5)) == 2.5
+        @test precision(BigFloat(Arf(2.5; prec = 96))) == 96
+    end
+
     @testset "zeros/ones" begin
         for T in [Arf, Arb, Acb]
             @test zeros(T, 2) == [zero(T), zero(T)]

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -22,19 +22,6 @@
 
         @test precision(zero(Arf(prec = 80))) == 80
         @test precision(one(Arf(prec = 80))) == 80
-
-        # TODO: Move these to other file
-        @test Float64(Arf(2.0)) isa Float64
-        @test Float64(Arf(2.0)) == 2.0
-        @test convert(Float64, Arf(2.0)) isa Float64
-        @test convert(Float64, Arf(2.0)) == 2.0
-        @test Int(Arf(2.0)) isa Int
-        @test Int(Arf(2.0)) == 2
-        @test convert(Int, Arf(2.0)) isa Int
-        @test convert(Int, Arf(2.0)) == 2
-        @test Int(Arf(2.0)) == 2
-        @test Int(Arf(0.5)) == 0
-        @test Int(Arf(0.5); rnd = Arblib.ArbRoundFromZero) == 1
     end
 
     @testset "Arb" begin
@@ -125,7 +112,21 @@
     end
 
     @testset "Others" begin
+        # TODO: Move these to other file
+        @test Float64(Arf(2.0)) isa Float64
+        @test Float64(Arf(2.0)) == 2.0
+        @test convert(Float64, Arf(2.0)) isa Float64
+        @test convert(Float64, Arf(2.0)) == 2.0
+        @test Int(Arf(2.0)) isa Int
+        @test Int(Arf(2.0)) == 2
+        @test convert(Int, Arf(2.0)) isa Int
+        @test convert(Int, Arf(2.0)) == 2
+        @test Int(Arf(2.0)) == 2
+        @test Arblib.get_si(Arf(0.5)) == 0
+        @test Arblib.get_si(Arf(0.5); rnd = Arblib.ArbRoundFromZero) == 1
+
         @test Int(Arf(2)) == 2
+        @test_throws InexactError Int(Arf(2.5))
         @test Float64(Mag(2.5)) ≥ 2.5
         @test Float64(Arf(2.5)) == 2.5
         @test Float64(Arb(2.5)) == 2.5

--- a/test/show-test.jl
+++ b/test/show-test.jl
@@ -2,6 +2,7 @@
     Mag = Arblib.Mag
     @testset "string" begin
         @test Arblib._string(Mag()) isa String
+        @test !isempty(Arblib._string(Mag(2.3)))
         @test Arblib.string_nice(Arb()) isa String
         @test Arblib.string_nice(Acb()) isa String
     end

--- a/test/show-test.jl
+++ b/test/show-test.jl
@@ -2,14 +2,6 @@
     Mag = Arblib.Mag
     @testset "string" begin
         @test Arblib._string(Mag()) isa String
-        @test Arblib._string(Arf()) isa String
-        @test Arblib._string(Arb()) isa String
-        @test Arblib._string(Acb()) isa String
-
-        @test Arblib.string_decimal(Arf()) isa String
-        @test Arblib.string_decimal(Arb()) isa String
-        @test Arblib.string_decimal(Acb()) isa String
-
         @test Arblib.string_nice(Arb()) isa String
         @test Arblib.string_nice(Acb()) isa String
     end
@@ -31,12 +23,12 @@
         @test "$P" == "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3"
         P = AcbPoly([Acb[1, 2, 0, π]; Acb(1, 1)], prec = prec)
         @test "$P" ==
-              "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3 + (1.00000000 + 1.00000000*I)⋅x^4"
+              "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3 + (1.00000000 + 1.00000000im)⋅x^4"
         P = ArbSeries(Arb[1, 2, 0, π], 4, prec = prec)
         @test "$P" == "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3 + 𝒪(x^5)"
         P = AcbSeries([Acb[1, 2, 0, π]; Acb(1, 1)], 5, prec = prec)
         @test "$P" ==
-              "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3 + (1.00000000 + 1.00000000*I)⋅x^4 + 𝒪(x^6)"
+              "1.00000000 + 2.00000000⋅x + [3.14159265 +/- 3.59e-9]⋅x^3 + (1.00000000 + 1.00000000im)⋅x^4 + 𝒪(x^6)"
 
         @test "$(ArbPoly())" == "$(AcbPoly())" == "0"
         @test "$(ArbSeries())" == "$(AcbSeries())" == "𝒪(x)"


### PR DESCRIPTION
This fixes the very annoying #87.
There seems no way to make our current `show` strategy work in IJulia.
The strategy is fundamentally flawed for IJulia since we don't have a guarantee that the C-std is actually flushed when we end the stdout redirect (e.g. https://github.com/JuliaLang/IJulia.jl/issues/238).

Thus I used the `arb_get_str` method for `Arb`, convert to BigFloat for `Arf` and, if we are in IJulia, to Float64 for `Mag`.
For `Acb` we need to define the printing manually. Here I ommited the imaginary part if it is zero which is conistent with Arb but not Julia.

I also added a `BigFloat(::Arf)` since I needed it and moved the `Float64/BigFloat` constructors to `constructors.jl` where they seemed to belong better.

I hope we can merge this quickly and get a new release out since my new certification code in HomotopyContinuation.jl is barely usable in IJulia right now (in the sense that if you print the wrong thing your session is over).