### PR TITLE
Set version to v0.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"


### PR DESCRIPTION
I hope to tag a version with this commit to have a fix for #87 out. 
I guess 0.1.1 is the correct version number since we didn't break something (intentionally).