### PR TITLE
Fix set rational

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -46,7 +46,6 @@ Base.@propagate_inbounds function Base.setindex!(
     j::Integer,
 )
     @boundscheck checkbounds(A, i, j)
-    # A.arb_mat[i, j] = x
     ref(A, i, j)[] = x
     return x
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -46,7 +46,8 @@ Base.@propagate_inbounds function Base.setindex!(
     j::Integer,
 )
     @boundscheck checkbounds(A, i, j)
-    A.arb_mat[i, j] = x
+    # A.arb_mat[i, j] = x
+    ref(A, i, j)[] = x
     return x
 end
 
@@ -98,7 +99,7 @@ Base.@propagate_inbounds function Base.setindex!(
     j::Integer,
 )
     @boundscheck checkbounds(A, i, j)
-    A.acb_mat[i, j] = x
+    ref(A, i, j)[] = x
     return x
 end
 

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -39,7 +39,7 @@ Base.@propagate_inbounds function Base.setindex!(
     i::Integer,
 )
     @boundscheck checkbounds(v, i)
-    v.arb_vec[i] = x
+    ref(v, i)[] = x
     return x
 end
 
@@ -85,7 +85,7 @@ Base.@propagate_inbounds function Base.setindex!(
     i::Integer,
 )
     @boundscheck checkbounds(v, i)
-    v.acb_vec[i] = x
+    ref(v, i)[] = x
     return x
 end
 

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -114,6 +114,11 @@
         end
     end
 
+    @testset "set Rational" begin
+        A = TMat(2, 2)
+        A[1, 1] = 5 // 8
+        @test !iszero(A[1, 1])
+    end
 end
 
 

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -77,6 +77,12 @@
             @test precision(a) == precision(A)
         end
     end
+
+    @testset "set Rational" begin
+        A = TVec(2)
+        A[1, 1] = 5 // 8
+        @test !iszero(A[1, 1])
+    end
 end
 
 @testset "VectorRef: $T" for (T, TRef) in


### PR DESCRIPTION
#76 broke the assignment of Rationals to Vectors/Matrices.
I think previously the computation was also not fully correct in the sense that the conversion of `Rational` to `Arb` used always the global precision and not the precision of the target.
I changed the `setindex!` methods to always create first an `ArbRef` resp. `AcbRef` and to perform `set!` on these. By this way we carry around the precision of the target.