### PR TITLE
add "scalar" to jlfname prefixes

### DIFF
--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -146,7 +146,7 @@ end
 
 function jlfname(
     arbfname,
-    prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly"),
+    prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly", "scalar"),
     suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpfr", "str");
     inplace = false,
 )
@@ -169,7 +169,7 @@ end
 
 function jlfname(
     af::Arbfunction,
-    prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly"),
+    prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly", "scalar"),
     suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpfr", "str");
     inplace = inplace(af),
 )

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -124,6 +124,9 @@
             # Underscore methods
             ("_acb_vec_set", :set),
 
+            # Removing scalar
+            ("_arb_vec_scalar_mul", :mul),
+
             # Some special cases to be aware of and maybe change
             ("mag_set_d_lower", :set_d_lower),
             ("arb_ui_div", :ui_div),


### PR DESCRIPTION
this applies to
```julia
julia> Arblib.scalar_

scalar_addmul!   scalar_mul!       scalar_mul_onei!
scalar_div!      scalar_mul_2exp!  scalar_submul!
```
and just adds new methods to the existing (unprefixed) functions.

As far as I can see all `scalar_*` functions apply to `VectorLike`, `MatrixLike`, `Poly` or `Series` only.

