### PR TITLE
New constructors for intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ are renamed to `set!` and rely on multiple dispatch to choose the
 correct one. In addition to the ones defined in Arb there is a number
 of methods of `set!` added in Arblib to make it more convenient to
 work with. For example there are setters for `Rational` and all
-irrationals defined in `Base.MathConstants`.
+irrationals defined in `Base.MathConstants`. For `Arb` there is also a
+setter which takes a tuple `(a, b)` representing an interval and
+returns a ball containing this interval.
 
 Almost all of the constructors are simple wrappers around these
 setters. This means that it's usually more informative to look at the
@@ -133,6 +135,9 @@ y = Arb(π)
 
 x = Arblib.set!(Arb(), 5//13)
 y = Arb(5//13)
+
+x = Arblib.set!(Arb(), (0, π))
+y = Arb((0, π))
 ```
 
 ## Example

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -30,7 +30,6 @@ Acb(
     prec::Integer = max(_precision(re), _precision(im)),
 ) = set!(Acb(prec = prec), re, im)
 
-Acb(z::NTuple{2,AcbLike}; prec::Integer = _precision(z)) = set!(Acb(prec = prec), z)
 Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
     set!(Acb(prec = prec), z)
 Acb(x::AcbLike; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -30,9 +30,7 @@ Acb(
     prec::Integer = max(_precision(re), _precision(im)),
 ) = set!(Acb(prec = prec), re, im)
 
-Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
-    set!(Acb(prec = prec), z)
-Acb(x::AcbLike; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
+Acb(z::Union{AcbLike,Complex}; prec::Integer = _precision(z)) = set!(Acb(prec = prec), z)
 # disambiguation
 Acb(x::Acb; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -20,14 +20,17 @@ function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
 end
 
 ## Acb
-Acb(x::Union{Real,arb_struct,arf_struct}; prec::Integer = _precision(x)) =
-    set!(Acb(prec = prec), x)
 Acb(
-    re::Union{Real,arb_struct,arf_struct},
-    im::Union{Real,arb_struct,arf_struct};
+    x::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}};
+    prec::Integer = _precision(x),
+) = set!(Acb(prec = prec), x)
+Acb(
+    re::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}},
+    im::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}};
     prec::Integer = max(_precision(re), _precision(im)),
 ) = set!(Acb(prec = prec), re, im)
 
+Acb(z::NTuple{2,AcbLike}; prec::Integer = _precision(z)) = set!(Acb(prec = prec), z)
 Acb(z::Complex; prec::Integer = max(_precision(real(z)), _precision(imag(z)))) =
     set!(Acb(prec = prec), z)
 Acb(x::AcbLike; prec::Integer = precision(x)) = set!(Acb(prec = prec), x)

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -20,6 +20,7 @@ Base.precision(::MagOrRef) = DEFAULT_PRECISION[]
 
 @inline _precision(x::ArbTypes) = precision(x)
 @inline _precision(x::BigFloat) = precision(x)
+@inline _precision((a, b)::Tuple{S,T}) where {S,T} = max(_precision(a), _precision(b))
 @inline _precision(@nospecialize _) = DEFAULT_PRECISION[]
 
 """

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -20,6 +20,7 @@ Base.precision(::MagOrRef) = DEFAULT_PRECISION[]
 
 @inline _precision(x::ArbTypes) = precision(x)
 @inline _precision(x::BigFloat) = precision(x)
+@inline _precision(z::Complex) = max(_precision(real(z)), _precision(imag(z)))
 @inline _precision((a, b)::Tuple{S,T}) where {S,T} = max(_precision(a), _precision(b))
 @inline _precision(@nospecialize _) = DEFAULT_PRECISION[]
 

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -118,7 +118,7 @@ Base.isless(x::MagLike, y::MagLike) = cmp(x, y) < 0
 Base.:(<)(x::MagLike, y::MagLike) = cmp(x, y) < 0
 Base.:(<=)(x::MagLike, y::MagLike) = cmp(x, y) <= 0
 
-for jltype in (Arf, Integer, Unsigned, Base.GMP.CdoubleMax)
+for jltype in (ArfLike, Integer, Unsigned, Base.GMP.CdoubleMax)
     @eval begin
         Base.isless(x::ArfLike, y::$jltype) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
         Base.:(<)(x::ArfLike, y::$jltype) = !isnan(x) && !isnan(y) && cmp(x, y) < 0

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -61,9 +61,5 @@ function set!(
     return res
 end
 
-# TODO: Should we check a < b (or whatever that means for complex
-# values)?
-set!(res::AcbLike, (a, b)::NTuple{2,AcbLike}) = union!(res, a, b)
-
 set!(res::AcbLike, z::Complex) = set!(res, real(z), imag(z))
 set!(res::AcbLike, ::Irrational{:π}) = const_pi!(res)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -28,8 +28,24 @@ function set!(res::ArbLike, ::Irrational{:φ}; prec::Integer = precision(res))
     return div!(res, res, 2, prec)
 end
 
+function set!(
+    res::ArbLike,
+    (a, b)::NTuple{2,Union{MagLike,ArfLike,BigFloat}};
+    prec::Integer = precision(res),
+)
+    a <= b || throw(ArgumentError("must have a <= b, got a = $a and b = $b"))
+    return set_interval!(res, a, b, prec = prec)
+end
+
+function set!(res::ArbLike, (a, b)::Tuple{<:Real,<:Real}; prec::Integer = precision(res))
+    # TODO: This is not strictly required to check.
+    a > b && throw(ArgumentError("must have a <= b, got a = $a and b = $b"))
+    # TODO: If we really want to we could avoid one allocation by reusing res
+    return union!(res, Arb(a, prec = prec), Arb(b, prec = prec), prec = prec)
+end
+
 # Acb
-function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct})
+function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct,Tuple{<:Real,<:Real}})
     set!(realref(res), x)
     set!(imagref(res), 0)
     return res
@@ -37,13 +53,17 @@ end
 
 function set!(
     res::AcbLike,
-    re::Union{Real,arb_struct,arf_struct,mag_struct},
-    im::Union{Real,arb_struct,arf_struct,mag_struct},
+    re::Union{Real,arb_struct,arf_struct,mag_struct,Tuple{<:Real,<:Real}},
+    im::Union{Real,arb_struct,arf_struct,mag_struct,Tuple{<:Real,<:Real}},
 )
     set!(realref(res), re)
     set!(imagref(res), im)
     return res
 end
+
+# TODO: Should we check a < b (or whatever that means for complex
+# values)?
+set!(res::AcbLike, (a, b)::NTuple{2,AcbLike}) = union!(res, a, b)
 
 set!(res::AcbLike, z::Complex) = set!(res, real(z), imag(z))
 set!(res::AcbLike, ::Irrational{:π}) = const_pi!(res)

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -31,6 +31,10 @@
             @test precision(Arb(zero(T), prec = 80)) == 80
         end
 
+        @test Arb((0, 0)) == zero(Arb)
+        @test Arb((one(Arf), one(Arf))) == one(Arb)
+        @test isequal(Arb((Arf(1), Arf(2))), Arb((1, 2)))
+
         @test Arb(zero(Arb).arb) == Arb("0.0") == zero(Arb)
         @test Arb(one(Arb).arb) == Arb("1.0") == one(Arb)
         @test precision(Arb(zero(Arb).arb, prec = 80)) ==
@@ -54,6 +58,8 @@
         @test precision(Arb(MathConstants.γ, prec = 80)) == 80
         @test precision(Arb(MathConstants.catalan, prec = 80)) == 80
         @test precision(Arb(MathConstants.φ, prec = 80)) == 80
+
+
     end
 
     @testset "Acb" begin
@@ -109,6 +115,9 @@
 
         @test isequal(Acb(π, -1), Acb(Arb(π), Arb(-1)))
         @test isequal(Acb(BigFloat(1.3), ℯ), Acb(Arb(1.3), Arb(ℯ)))
+
+        @test isequal(Acb((1, 2)), Acb(Arb((1, 2))))
+        @test isequal(Acb((1, 2), (3, 4)), Acb(Arb((1, 2)), Arb((3, 4))))
     end
 
     @testset "Others" begin

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -58,8 +58,6 @@
         @test precision(Arb(MathConstants.γ, prec = 80)) == 80
         @test precision(Arb(MathConstants.catalan, prec = 80)) == 80
         @test precision(Arb(MathConstants.φ, prec = 80)) == 80
-
-
     end
 
     @testset "Acb" begin

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -8,6 +8,7 @@
     end
 
     @testset "Arb" begin
+        # MagLike and BigFloat
         @test Arblib.set!(Arb(), BigFloat(1.0)) == one(Arb)
         @test Arblib.set!(Arblib.realref(Acb()), BigFloat(1.0)) == one(Arb)
         @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigFloat(1.0)), one(Arb))
@@ -15,10 +16,12 @@
         @test Arblib.set!(Arblib.realref(Acb()), one(Mag)) == one(Arb)
         @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), one(Mag).mag), one(Arb))
 
+        # Rational
         @test Arblib.set!(Arb(), 1 // 2) == one(Arb) / 2
         @test Arblib.set!(Arblib.realref(Acb()), 1 // 2) == one(Arb) / 2
         @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), 1 // 2), one(Arb) / 2)
 
+        # Irrationals
         @test Arb(3) < Arblib.set!(Arb(), π) < Arb(4)
         @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.realref(Acb()), π))
         @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.arb_struct(), π))
@@ -59,6 +62,43 @@
             Arblib.set!(Arb(), MathConstants.φ),
             Arblib.set!(Arblib.arb_struct(), MathConstants.φ),
         )
+
+        # Intervals: MagLike, ArfLike, BigFloat
+        @test Arblib.overlaps(
+            Arblib.set!(Arb(), (Mag(UInt64(1)), Mag(UInt64(2)))),
+            Arblib.set!(Arb(), (Arf(1), Arf(2))),
+        )
+
+        @test Arblib.equal(
+            Arblib.set!(Arb(), (Arf(1), Arf(2))),
+            Arblib.set!(Arb(), (BigFloat(1), BigFloat(2))),
+        )
+
+        @test Arblib.radref(Arblib.set!(Arb(), (Arf(1), Arf(3)))) >= Mag(UInt64(1))
+        @test Arblib.midref(Arblib.set!(Arb(), (Arf(1), Arf(3)))) >= Arf(1)
+
+        @test Arblib.radref(Arblib.set!(Arb(prec = 64), (BigFloat(π), BigFloat(π)))) >
+              Mag(UInt(0))
+        @test iszero(Arblib.radref(Arblib.set!(
+            Arb(prec = 64),
+            (BigFloat(π), BigFloat(π)),
+            prec = precision(BigFloat),
+        )))
+
+        @test_throws ArgumentError Arblib.set!(Arb(), (Arf(2), Arf(1)))
+
+        # Intervals: General
+        @test Arblib.contains(Arblib.set!(Arb(), (1, π)), Arb(π))
+        @test Arblib.contains(Arblib.set!(Arb(), (ℯ, Arb(4))), Arb(π))
+        @test Arblib.equal(
+            Arblib.set!(Arb(), (-2, 2)),
+            Arblib.set!(Arb(), (Arf(-2), Arf(2))),
+        )
+
+        @test Mag(1e-20) < Arblib.radref(Arblib.set!(Arb(prec = 64), (π, π))) < Mag(1e-10)
+        @test Mag(1e-80) <
+              Arblib.radref(Arblib.set!(Arb(prec = 64), (π, π), prec = 256)) <
+              Mag(1e-70)
     end
 
     @testset "Acb" begin

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -99,6 +99,8 @@
         @test Mag(1e-80) <
               Arblib.radref(Arblib.set!(Arb(prec = 64), (π, π), prec = 256)) <
               Mag(1e-70)
+
+        @test_throws ArgumentError Arblib.set!(Arb(), (2, 1))
     end
 
     @testset "Acb" begin
@@ -129,6 +131,12 @@
         x = Arblib.set!(Arblib.acb_struct(), π)
         @test Arblib.equal(Arblib.realref(x), Arb(π))
         @test Arblib.equal(Arblib.imagref(x), zero(Arb))
+
+        @test Arblib.equal(Arblib.set!(Acb(), (1, 2)), Arblib.set!(Acb(), Arb((1, 2))))
+        @test Arblib.equal(
+            Arblib.set!(Acb(), (1, 2), (3, 4)),
+            Arblib.set!(Acb(), Arb((1, 2)), Arb((3, 4))),
+        )
     end
 
     @testset "Set Rational" begin


### PR DESCRIPTION
I have wanted to add some type of constructor for intervals. After thinking about it for a while I believe having tuples correspond to intervals would make the most sense. With this change you can construct the ball containing `a` and `b` with `Arb((1, 2))`. For example
```julia
julia> Arb((1, 2))
[+/- 2.01]

julia> Arb((1, π))
[+/- 3.15]

julia> Arb((3.141592, π))
[3.141592 +/- 6.54e-7]

julia> Arb((ℯ, π))
[3e+0 +/- 0.282]
```
As for the other constructors it uses a `set!` method, `Arblib.set!(Arb(), (5, 6))` for example. No matter what types you give in it the resulting ball should always include both the inputs. It works for `Acb` as well
```julia
julia> Acb((1, 2))
[+/- 2.01]

julia> Acb((1, 2), (float(π), π))
[+/- 2.01] + [3.1415926535897932 +/- 8.41e-17]im

julia> Acb((Acb(1, 1), Acb(2, 2)))
[+/- 2.01] + [+/- 2.01]im
```
I have yet to add tests for the constructors (the setters have tests) and information about it to the readme.