### PR TITLE
Fix specific FLINT version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.2.1"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"
+FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Arb_jll = "~2.18.1"
+Arb_jll = "2.18.1"
+FLINT_jll = "2.6.3"
 julia = "1.3"


### PR DESCRIPTION
The package broke with the newest `FLINT_JLL` against which `Arb_jll@2.18.0+1` seemingly got compiled:

```
(Arblib) pkg> up
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Installed FLINT_jll ─ v200.700.0+0
Downloading artifact: FLINT
Updating `~/code/Arblib.jl/Project.toml`
  [d9960996] ↑ Arb_jll v2.18.1+0 ⇒ v2.18.1+1
Updating `~/code/Arblib.jl/Manifest.toml`
  [d9960996] ↑ Arb_jll v2.18.1+0 ⇒ v2.18.1+1
  [e134572f] ↑ FLINT_jll v2.6.3+1 ⇒ v200.700.0+0
  [692b3bcd] ↑ JLLWrappers v1.1.2 ⇒ v1.1.3

julia> using Arb

Arb_jll Arblib
julia> using Arblib
[ Info: Precompiling Arblib [fb37089c-8514-4489-9461-98f9c8763369]
ERROR: LoadError: InitError: could not load library "/Users/sascha/.julia/artifacts/ddb3fe2bd525c675f14cc3ec2afb5c943dda93a0/lib/libarb.dylib"
dlopen(/Users/sascha/.julia/artifacts/ddb3fe2bd525c675f14cc3ec2afb5c943dda93a0/lib/libarb.dylib, 1): Library not loaded: @rpath/libflint-14.dylib
  Referenced from: /Users/sascha/.julia/artifacts/ddb3fe2bd525c675f14cc3ec2afb5c943dda93a0/lib/libarb-2.9.1.dylib
  Reason: image not found
Stacktrace:
 [1] dlopen(::String, ::UInt32; throw_error::Bool) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
 [2] dlopen(::String, ::UInt32) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
 [3] macro expansion at /Users/sascha/.julia/packages/JLLWrappers/KuIwt/src/products/library_generators.jl:61 [inlined]
 [4] __init__() at /Users/sascha/.julia/packages/Arb_jll/aXvJT/src/wrappers/x86_64-apple-darwin.jl:11
 [5] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:697
 [6] _require_from_serialized(::String) at ./loading.jl:749
 [7] _require(::Base.PkgId) at ./loading.jl:1040
 [8] require(::Base.PkgId) at ./loading.jl:928
 [9] require(::Module, ::Symbol) at ./loading.jl:923
 [10] include(::Function, ::Module, ::String) at ./Base.jl:380
 [11] include(::Module, ::String) at ./Base.jl:368
 [12] top-level scope at none:2
 [13] eval at ./boot.jl:331 [inlined]
 [14] eval(::Expr) at ./client.jl:467
 [15] top-level scope at ./none:3
during initialization of module Arb_jll
in expression starting at /Users/sascha/code/Arblib.jl/src/Arblib.jl:3
ERROR: Failed to precompile Arblib [fb37089c-8514-4489-9461-98f9c8763369] to /Users/sascha/.julia/compiled/v1.5/Arblib/npOCv_Kfwn2.ji.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] compilecache(::Base.PkgId, ::String) at ./loading.jl:1305
 [3] _require(::Base.PkgId) at ./loading.jl:1030
 [4] require(::Base.PkgId) at ./loading.jl:928
 [5] require(::Module, ::Symbol) at ./loading.jl:923
```

Hardcode to a working FLINT_jll version for now... 