### PR TITLE
Make Arf and Arb subtypes of Abstractfloat

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -49,6 +49,7 @@ include("setters.jl")
 include("constructors.jl")
 include("predicates.jl")
 include("show.jl")
+include("promotion.jl")
 include("arithmetic.jl")
 include("rand.jl")
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,24 +1,3 @@
-Base.promote_rule(::Type{<:MagLike}, ::Type{<:Union{Float64,MagLike}}) = Mag
-Base.promote_rule(::Type{<:ArfLike}, ::Type{<:Union{AbstractFloat,Integer,MagLike}}) = Arf
-Base.promote_rule(
-    ::Type{<:ArbLike},
-    ::Type{<:Union{AbstractFloat,Integer,Rational,ArfLike,ArbRef}},
-) = Arb
-Base.promote_rule(
-    ::Type{<:AcbLike},
-    ::Type{
-        <:Union{
-            AbstractFloat,
-            Integer,
-            Rational,
-            Complex{<:Union{AbstractFloat,Integer,Rational}},
-            ArfLike,
-            ArbLike,
-            AcbRef,
-        },
-    },
-) = Acb
-
 for (jf, af) in [(:+, :add!), (:-, :sub!), (:*, :mul!), (:/, :div!)]
     @eval function Base.$jf(x::T, y::T) where {T<:MagOrRef}
         z = T()

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -11,6 +11,7 @@ Arf(x::Arf; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
 Arb(x; prec::Integer = _precision(x)) = set!(Arb(prec = prec), x)
 # disambiguation
 Arb(x::Arb; prec::Integer = precision(x)) = set!(Arb(prec = prec), x)
+Arb(x::Rational; prec::Integer = _precision(x)) = set!(Arb(prec = prec), x)
 
 function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     res = Arb(prec = prec)

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -1,0 +1,39 @@
+### Internal ###
+Base.promote_rule(::Type{<:MagOrRef}, ::Type{T}) where {T<:Union{MagOrRef}} = Mag
+Base.promote_rule(::Type{<:ArfOrRef}, ::Type{T}) where {T<:Union{MagOrRef,ArfOrRef}} = Arf
+Base.promote_rule(
+    ::Type{<:ArbOrRef},
+    ::Type{T},
+) where {T<:Union{MagOrRef,ArfOrRef,ArbOrRef}} = Arb
+Base.promote_rule(
+    ::Type{<:AcbOrRef},
+    ::Type{T},
+) where {T<:Union{MagOrRef,ArfOrRef,ArbOrRef,AcbOrRef}} = Acb
+
+Base.promote_rule(
+    ::Type{<:MagOrRef},
+    ::Type{T},
+) where {T<:Union{ArfOrRef,ArbOrRef,AcbOrRef}} = _nonreftype(T)
+Base.promote_rule(::Type{<:ArfOrRef}, ::Type{T}) where {T<:Union{ArbOrRef,AcbOrRef}} =
+    _nonreftype(T)
+Base.promote_rule(::Type{<:ArbOrRef}, ::Type{T}) where {T<:Union{AcbOrRef}} = _nonreftype(T)
+
+### External ###
+# TODO: How should we handle promotions for Mag? The type is very
+# limited so it's likely not a good idea to promote everything to it.
+
+# Always prioritise Arb types
+Base.promote_rule(::Type{<:MagOrRef}, ::Type{<:Base.GMP.CdoubleMax}) = Mag
+Base.promote_rule(::Type{<:ArfOrRef}, ::Type{<:Real}) = Arf
+Base.promote_rule(::Type{<:ArbOrRef}, ::Type{<:Real}) = Arb
+Base.promote_rule(::Type{<:AcbOrRef}, ::Type{<:Number}) = Acb
+
+# Handle BigFloat separately since it also defines a catch all case
+Base.promote_rule(
+    ::Type{BigFloat},
+    ::Type{T},
+) where {T<:Union{ArfOrRef,ArbOrRef,AcbOrRef}} = _nonreftype(T)
+
+# Arb should be promoted to Acb together with complex values. Note
+# that Arf is promoted to Complex{Arf}.
+Base.promote_rule(::Type{<:ArbOrRef}, ::Type{<:Complex}) = Acb

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -6,9 +6,20 @@ import Random
 
 function Random.Sampler(
     RNG::Type{<:Random.AbstractRNG},
-    st::Random.SamplerType{T},
+    st::Random.SamplerType{Acb},
     n::Random.Repetition,
-) where {T<:Union{Arf,Arb,Acb}}
+)
+    return Random.SamplerSimple(
+        Random.SamplerType{Acb}(),
+        Random.SamplerBigFloat{Random.CloseOpen01{BigFloat}}(precision(Acb)),
+    )
+end
+
+function Random.Sampler(
+    ::Type{<:Random.AbstractRNG},
+    ::Random.CloseOpen01{T},
+    ::Random.Repetition,
+) where {T<:Union{Arf,Arb}}
     return Random.SamplerSimple(
         Random.SamplerType{T}(),
         Random.SamplerBigFloat{Random.CloseOpen01{BigFloat}}(precision(T)),

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,7 @@
 """
-    Arf <: Real
+    Arf <: AbstractFloat
 """
-struct Arf <: Real
+struct Arf <: AbstractFloat
     arf::arf_struct
     prec::Int
 
@@ -24,9 +24,9 @@ struct Mag <: Real
 end
 
 """
-    Arb <: Real
+    Arb <: AbstractFloat
 """
-struct Arb <: Real
+struct Arb <: AbstractFloat
     arb::arb_struct
     prec::Int
 
@@ -54,18 +54,18 @@ struct AcbRef <: Number
 end
 
 """
-    ArbRef <: Real
+    ArbRef <: AbstractFloat
 """
-struct ArbRef <: Real
+struct ArbRef <: AbstractFloat
     arb_ptr::Ptr{arb_struct}
     prec::Int
     parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_mat_struct}
 end
 
 """
-    ArfRef <: Real
+    ArfRef <: AbstractFloat
 """
-struct ArfRef <: Real
+struct ArfRef <: AbstractFloat
     arf_ptr::Ptr{arf_struct}
     prec::Int
     parent::Union{arb_struct,ArbRef}

--- a/test/promotion.jl
+++ b/test/promotion.jl
@@ -1,0 +1,33 @@
+@testset "Promotion" begin
+    for T in [Mag, MagRef]
+        @test promote_type(T, Arf) == promote_type(T, ArfRef) == Arf
+        @test promote_type(T, Arb) == promote_type(T, ArbRef) == Arb
+        @test promote_type(T, Acb) == promote_type(T, AcbRef) == Acb
+    end
+    @test promote_type(MagRef, Mag) == promote_type(Mag, MagRef) == Mag
+
+    for T in [Arf, ArfRef]
+        @test promote_type(T, Mag) == promote_type(T, MagRef) == Arf
+        @test promote_type(T, Arb) == promote_type(T, ArbRef) == Arb
+        @test promote_type(T, Acb) == promote_type(T, AcbRef) == Acb
+    end
+    @test promote_type(ArfRef, Arf) == promote_type(Arf, ArfRef) == Arf
+
+    for T in [Arb, ArbRef]
+        @test promote_type(T, Mag) == promote_type(T, MagRef) == Arb
+        @test promote_type(T, Arf) == promote_type(T, ArfRef) == Arb
+        @test promote_type(T, Acb) == promote_type(T, AcbRef) == Acb
+    end
+    @test promote_type(ArbRef, Arb) == promote_type(Arb, ArbRef) == Arb
+
+    for T in [Acb, AcbRef]
+        @test promote_type(T, Mag) == promote_type(T, MagRef) == Acb
+        @test promote_type(T, Arf) == promote_type(T, ArfRef) == Acb
+        @test promote_type(T, Arb) == promote_type(T, ArbRef) == Acb
+    end
+    @test promote_type(AcbRef, Acb) == promote_type(Acb, AcbRef) == Acb
+
+    for T in [Mag, MagRef, Arf, ArfRef, Arb, ArbRef, Acb, AcbRef]
+        @test promote_type(T, Float64) == Arblib._nonreftype(T)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Arblib, Test, LinearAlgebra
     include("constructors-test.jl")
     include("predicates-test.jl")
     include("show-test.jl")
+    include("promotion.jl")
     include("examples.jl")
     include("arithmetic.jl")
     include("rand.jl")


### PR DESCRIPTION
I made `Arb` and `Acb` subtypes of `AbstractFloat`, this made some tests fail and I have tried to fix them as well. There are three things I have fixed:
- Adding a `Arb(::Rational)` for disambiguation
- Slightly change `Random.Sample`, it works slightly different for `AbstractFloat`. It should not have affected any functionality
- Rewrite the promotion system. This is the one change I have made which changes functionality, more comments about it below

I have factored out the promotions to `promote.jl` and changed them slightly. I have differentiated between promotion of internal types and external types. For the internal types I feel quite confident, we have a clear ordering of types `Mag < Arf < Arb < Acb` so it's clear how the promotions should work. `Ref`-types are promoted to non-ref types. For external types it's not a trivial what to do. Now I have implemented the following promotions
```julia
Base.promote_rule(::Type{<:ArfOrRef}, ::Type{<:Real}) = Arf
Base.promote_rule(::Type{<:ArbOrRef}, ::Type{<:Real}) = Arb
Base.promote_rule(::Type{<:AcbOrRef}, ::Type{<:Number}) = Acb
```
which I think makes sense in most cases, `Arf`, `Arb` and `Acb` are more general than any built in type in Julia at least. For `Mag` I'm not sure, the type is very limited and doesn't even convert `Float64´ properly, for now I have only implemented
```julia
Base.promote_rule(::Type{<:MagOrRef}, ::Type{<:Base.GMP.CdoubleMax}) = Mag
```
but maybe integers should be added as well? I have also added 
```julia
Base.promote_rule(::Type{<:ArbOrRef}, ::Type{<:Complex}) = Acb
```
so that `Arb` is promoted to `Acb` when used with other complex types. In hindsight changing the promotion should maybe have been done in a different pull request. 