### PR TITLE
Update Arb_jll and Flint_jll to version 2.19 and 2.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Arb_jll = "=2.18.1"
-FLINT_jll = "=2.6.3"
+Arb_jll = "~200.1900"
+FLINT_jll = "~200.700"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/test/calc_integrate.jl
+++ b/test/calc_integrate.jl
@@ -25,26 +25,17 @@
     # https://github.com/kalmarek/Arblib.jl/issues/70. Once Arb is
     # updated so that they start to produce identical results this can
     # be updated and the issue closed.
-    res3 = "[0.50000000000000000 +/- 2.68e-18]"
-    res3! = "[0.50000000000000000 +/- 2.73e-18]"
+    res3 = "[0.50000000000000000 +/- 2.73e-18]"
     @test string(Arblib.integrate(f3, a, b, check_analytic = true, prec = prec)) == res3
-    @test_broken string(Arblib.integrate!(
-        f3!,
-        Acb(prec = prec),
-        a,
-        b,
-        check_analytic = true,
-    )) == res3
     @test string(Arblib.integrate!(f3!, Acb(prec = prec), a, b, check_analytic = true)) ==
-          res3!
+          res3
 
     # Test with a method that accepts both precision and analytic as
     # a keyword arguments
     f4 = (x; analytic, prec) -> Arblib.real_abs!(Acb(), x, analytic, prec = prec)
     f4! = (res, x; analytic, prec) -> Arblib.real_abs!(res, x, analytic, prec = prec)
     # FIXME: See above
-    res4 = "[0.50000000000000000 +/- 2.68e-18]"
-    res4! = "[0.50000000000000000 +/- 2.73e-18]"
+    res4 = "[0.50000000000000000 +/- 2.73e-18]"
     @test string(Arblib.integrate(
         f4,
         a,
@@ -53,14 +44,6 @@
         take_prec = true,
         prec = prec,
     )) == res4
-    @test_broken string(Arblib.integrate!(
-        f4!,
-        Acb(prec = prec),
-        a,
-        b,
-        check_analytic = true,
-        take_prec = true,
-    )) == res4
     @test string(Arblib.integrate!(
         f4!,
         Acb(prec = prec),
@@ -68,7 +51,7 @@
         b,
         check_analytic = true,
         take_prec = true,
-    )) == res4!
+    )) == res4
 
     # Test with set tolerance
     f5 = x -> sin(exp(x))

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -38,11 +38,9 @@
 
         @test all(Arblib.containszero, λs1 - λs2)
 
-        # λs1, _ = Arblib.eig_simple_rump(M, side = :right)
-        # segfaults in acb_mat_solve at /workspace/srcdir/arb-2.18.1/acb_mat/solve.c:17
-        # Issue #321 in Arblib (fixed by #330)
-        # λs2, _ = Arblib.eig_simple_rump(M, side=:left)
-        # @test all(Arblib.containszero, λs1 - λs2)
+        λs1, _ = Arblib.eig_simple_rump(M, side = :right)
+        λs2, _ = Arblib.eig_simple_rump(M, side = :left)
+        @test all(Arblib.containszero, λs1 - λs2)
 
         λs1, _ = Arblib.eig_simple(M, side = :right)
         λs2, _ = Arblib.eig_simple(M, side = :left)


### PR DESCRIPTION
This updates the versions used for Arb and Flint. The versioning number used in Julia has changed since the last release. [Here](https://github.com/JuliaPackaging/Yggdrasil/commit/1dc032884d96731f436f947c0753af4f3b25cdb8#diff-3f11581a12a8c59f140797f715d880bb90d8a70ab81db84768bf8ee5fcde26c4) we can read
```julia
# Arb_jll versions are decoupled from the upstream versions.
# Whenever we package a new official Arb release, we initially map its
# version X.Y.Z to X00.Y00.Z00 (i.e., multiply each component by 100).
# So for example version 2.19.0 would become 200.1900.000.
#
# Moreover, all our packages using Arb_jll use `~` in their compat ranges.
#
# Together, this allows us to increment the patch level of the JLL for minor tweaks.
# If a rebuild of the JLL is needed which keeps the upstream version identical
# but breaks ABI compatibility for any reason, we can increment the minor version
# e.g. go from 200.600.300 to 200.601.300.
# To package prerelease versions, we can also adjust the minor version; e.g. we may
# map a prerelease of 2.7.0 to 200.690.000.
#
# There is currently no plan to change the major version (except when Arb itself
# changes its major version. It simply seemed sensible to apply the same transformation
# to all components.
```
So the new version are `200.1900.0` and `200.700.0`. Now I have pinned those version exactly, but I'm not sure that is the best idea. Then we would have to make a new release every time a fix in `Arb_jll` or `Flint_jll` comes up, which seems unnecessary. We could allow the patch version to change I think, which would be
```
Arb_jll = "~200.1900"
FLINT_jll = "~200.700"
```
Then we are sure to use the same version of Arb but maybe a different packaging in Julia. What do you think?