### PR TITLE
Fix multiplication with Arf

### DIFF
--- a/parse/parse.jl
+++ b/parse/parse.jl
@@ -177,6 +177,8 @@ function parse_and_generate_arbdoc(arb_doc_dir, out_dir = "src/arbcalls/")
         "double arf_get_d(const arf_t x, arf_rnd_t rnd)" => "clashes with arf_get_si",
         "slong arf_get_si(const arf_t x, arf_rnd_t rnd)" => "clashes with arf_get_d",
         "void arf_print(const arf_t x)" => "clashes with Base.print",
+        "int arf_mul(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)" =>
+            "defined using #DEFINE in C which doesn't work in Julia",
         "arb_ptr _arb_vec_init(slong n)" => "clashes with similar method for acb",
         "double _arb_vec_estimate_allocated_bytes(slong len, slong prec)" =>
             "clashes with similar method for acb",

--- a/src/arbcalls/arf.jl
+++ b/src/arbcalls/arf.jl
@@ -57,6 +57,7 @@ arbcall"int arf_get_mpfr(mpfr_t res, const arf_t x, mpfr_rnd_t rnd)"
 #ni arbcall"int arf_get_fmpz_fixed_si(fmpz_t res, const arf_t x, slong e)"
 arbcall"void arf_floor(arf_t res, const arf_t x)"
 arbcall"void arf_ceil(arf_t res, const arf_t x)"
+#ni arbcall"void arf_get_fmpq(fmpq_t res, const arf_t x)"
 
 ### Comparisons and bounds
 arbcall"int arf_equal(const arf_t x, const arf_t y)"
@@ -128,7 +129,7 @@ arbcall"int arf_sub_ui(arf_t res, const arf_t x, ulong y, slong prec, arf_rnd_t 
 #ni arbcall"int arf_sub_fmpz(arf_t res, const arf_t x, const fmpz_t y, slong prec, arf_rnd_t rnd)"
 arbcall"void arf_mul_2exp_si(arf_t res, const arf_t x, slong e)"
 #ni arbcall"void arf_mul_2exp_fmpz(arf_t res, const arf_t x, const fmpz_t e)"
-arbcall"int arf_mul(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)"
+#mo arbcall"int arf_mul(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)" # defined using #DEFINE in C which doesn't work in Julia
 arbcall"int arf_mul_ui(arf_t res, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)"
 arbcall"int arf_mul_si(arf_t res, const arf_t x, slong y, slong prec, arf_rnd_t rnd)"
 arbcall"int arf_mul_mpz(arf_t res, const arf_t x, const mpz_t y, slong prec, arf_rnd_t rnd)"

--- a/src/manual_overrides.jl
+++ b/src/manual_overrides.jl
@@ -7,3 +7,20 @@ get_si(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_si(x, 
 function get_si(x::ArfLike, rnd::Union{arb_rnd,RoundingMode})
     ccall(@libarb(arf_get_si), Int, (Ref{arf_struct}, arb_rnd), x, rnd)
 end
+
+# arf_mul is given using a #DEFINE which doesn't work in Julia, implement this manually
+arbcall"int arf_mul_rnd_any(arf_t z, arf_t x, arf_t y, slong prec, arf_rnd_t rnd)"
+mul!(
+    res::ArfLike,
+    x::ArfLike,
+    y::ArfLike,
+    prec::Integer,
+    rnd::Union{arb_rnd,RoundingMode},
+) = mul_rnd_any!(res, x, y, prec, rnd)
+mul!(
+    res::ArfLike,
+    x::ArfLike,
+    y::ArfLike;
+    prec::Integer = precision(res),
+    rnd::Union{arb_rnd,RoundingMode} = RoundNearest,
+) = mul!(res, x, y, prec, rnd)


### PR DESCRIPTION
Turns out that multiplication with `Arf` has never worked, so much for our testing... The reason is that
`arf_mul` is defined using `#DEFINE` in C through
```C
#define arf_mul(z, x, y, prec, rnd)              \
    ((rnd == FMPR_RND_DOWN)                      \
        ? arf_mul_rnd_down(z, x, y, prec)        \
        : arf_mul_rnd_any(z, x, y, prec, rnd))
```
which doesn't work from Julia. It's now rewritten to use
`arf_mul_rnd_any` directly. I have not added any tests for this now, the reason is that I'm rewriting the `Arf` part in `arithmetic.jl` completely and that will introduce tests for it (that's how I noticed it).