### PR TITLE
Enh/improve arithmetic support

### DIFF
--- a/src/arbcalls/acb.jl
+++ b/src/arbcalls/acb.jl
@@ -194,7 +194,7 @@ arbcall"void acb_sinh_cosh(acb_t s, acb_t c, const acb_t z, slong prec)"
 arbcall"void acb_tanh(acb_t s, const acb_t z, slong prec)"
 arbcall"void acb_coth(acb_t s, const acb_t z, slong prec)"
 arbcall"void acb_sech(acb_t res, const acb_t z, slong prec)"
-arbcall"void acb_csch(acb_t res, const arb_t z, slong prec)"
+arbcall"void acb_csch(acb_t res, const acb_t z, slong prec)"
 
 ### Inverse hyperbolic functions
 arbcall"void acb_asinh(acb_t res, const acb_t z, slong prec)"

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -101,6 +101,13 @@ end
 Base.:(^)(x::AcbOrRef, y::Union{AcbOrRef,ArbOrRef,_BitInteger}) =
     pow!(Acb(prec = _precision((x, y))), x, y)
 
+# We define the same special cases as Arb does, this avoids some
+# overhead
+Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{-2}) =
+    (y = inv(x); sqr!(y, y))
+#Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{-1}) - implemented in Base.intfuncs.jl
+Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{0}) = one(x)
+Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{1}) = copy(x)
 Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{2}) = sqr(x)
 
 Base.hypot(x::ArbOrRef, y::ArbOrRef) = hypot!(Arb(prec = _precision((x, y))), x, y)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -101,6 +101,8 @@ end
 Base.:(^)(x::AcbOrRef, y::Union{AcbOrRef,ArbOrRef,_BitInteger}) =
     pow!(Acb(prec = _precision((x, y))), x, y)
 
+Base.literal_pow(::typeof(^), x::Union{ArbOrRef,AcbOrRef}, ::Val{2}) = sqr(x)
+
 Base.hypot(x::ArbOrRef, y::ArbOrRef) = hypot!(Arb(prec = _precision((x, y))), x, y)
 
 root(x::Union{ArbOrRef,AcbOrRef}, k::Integer) = root!(zero(x), x, convert(UInt, k))

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -92,9 +92,12 @@ Base.:(-)(x::Union{ArbOrRef,AcbOrRef}) = neg!(zero(x), x)
 Base.abs(x::ArbOrRef) = abs!(zero(x), x)
 Base.:(/)(x::_BitUnsigned, y::ArbOrRef) = ui_div!(zero(y), x, y)
 
-# TODO: Should we convert Int to UInt for performance reasons?
-Base.:(^)(x::ArbOrRef, y::Union{ArbOrRef,_BitUnsigned}) =
-    pow!(Arb(prec = _precision((x, y))), x, y)
+Base.:(^)(x::ArbOrRef, y::ArbOrRef) = pow!(Arb(prec = _precision((x, y))), x, y)
+function Base.:(^)(x::ArbOrRef, y::_BitInteger)
+    z = zero(x)
+    x, n = (y >= 0 ? (x, y) : (inv!(z, x), -y))
+    return pow!(z, x, convert(UInt, n))
+end
 Base.:(^)(x::AcbOrRef, y::Union{AcbOrRef,ArbOrRef,_BitInteger}) =
     pow!(Acb(prec = _precision((x, y))), x, y)
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -18,18 +18,11 @@ for f in [:inv, :sqrt, :log, :log1p, :exp, :expm1, :atan, :cosh, :sinh]
     @eval Base.$f(x::MagOrRef) = $(Symbol(f, :!))(zero(x), x)
 end
 
-Base.min(x::MagOrRef, y::MagOrRef) = min!(zero(x), x, y)
-Base.max(x::MagOrRef, y::MagOrRef) = max!(zero(x), x, y)
-Base.minmax(x::MagOrRef, y::MagOrRef) = (min(x, y), max(x, y))
-
 ### Arf
 function Base.sign(x::ArfOrRef)
     isnan(x) && return Arf(NaN) # Follow Julia and return NaN
     return Arf(sgn(x))
 end
-Base.min(x::ArfOrRef, y::ArfOrRef) = min!(Arf(prec = _precision((x, y))), x, y)
-Base.max(x::ArfOrRef, y::ArfOrRef) = max!(Arf(prec = _precision((x, y))), x, y)
-Base.minmax(x::ArfOrRef, y::ArfOrRef) = (min(x, y), max(x, y))
 
 Base.abs(x::ArfOrRef) = abs!(zero(x), x)
 Base.:(-)(x::ArfOrRef) = neg!(zero(x), x)
@@ -183,3 +176,11 @@ Base.real(z::AcbLike; prec = _precision(z)) = get_real!(Arb(prec = prec), z)
 Base.imag(z::AcbLike; prec = _precision(z)) = get_imag!(Arb(prec = prec), z)
 Base.conj(z::AcbLike) = conj!(Acb(prec = _precision(z)), z)
 Base.abs(z::AcbLike) = abs!(Arb(prec = _precision(z)), z)
+
+### min and max
+for T in [MagOrRef, ArfOrRef, ArbOrRef]
+    for op in [:min, :max]
+        @eval Base.$op(x::$T, y::$T) = $(Symbol(op, :!))(zero(x), x, y)
+    end
+    @eval Base.minmax(x::$T, y::$T) = (min(x, y), max(x, y))
+end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -7,6 +7,7 @@ Mag(x, y) = set!(Mag(), x, y)
 Arf(x; prec::Integer = _precision(x)) = set!(Arf(prec = prec), x)
 # disambiguation
 Arf(x::Arf; prec::Integer = precision(x)) = set!(Arf(prec = prec), x)
+Arf(x::Rational; prec::Integer = _precision(x)) = set!(Arf(prec = prec), x)
 
 #Arb
 Arb(x; prec::Integer = _precision(x)) = set!(Arb(prec = prec), x)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -19,6 +19,12 @@ function set!(res::ArfLike, x::Int128)
     return x < 0 ? neg!(res, res) : res
 end
 
+function set!(res::ArfLike, x::Rational; prec::Integer = precision(res))
+    set!(res, numerator(x))
+    div!(res, res, denominator(x), prec = prec)
+    return res
+end
+
 # Arb
 function set!(res::ArbLike, x::Union{UInt128,Int128})
     set!(radref(res), UInt64(0))

--- a/src/types.jl
+++ b/src/types.jl
@@ -253,6 +253,7 @@ for prefix in [:mag, :arf, :arb, :acb]
         parentstruct(x::$T) = cstruct(x)
         parentstruct(x::$TRef) = x
         parentstruct(x::$TStruct) = x
+        Base.copy(x::Union{$T,$TRef}) = $T(x)
     end
 end
 

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -97,6 +97,7 @@
               T(6)
         @test T(6) / T(2) == T(6) / 2 == T(6) / UInt(2) == T(3)
 
+        @test Base.literal_pow(^, T(3), Val(2)) == T(3)^2 == Arblib.sqr(T(3)) == T(9)
         @test Arblib.root(T(8), 3) == T(2)
 
         for f in [
@@ -152,13 +153,13 @@
         @test Arb(2) * Arf(3) == Arf(3) * Arb(2) == Arb(6)
         @test Arb(6) / Arf(2) == UInt(6) / Arb(2) == UInt8(6) / Arb(2) == Arb(3)
 
-        @test Arb(2)^Arb(2) ==
-              Arb(2)^2 ==
-              Arb(2)^Int8(2) ==
-              Arb(2)^UInt(2) ==
-              Arb(2)^UInt8(2) ==
-              (Arb(2)^-2)^-1 ==
-              Arb(4)
+        @test Arb(2)^Arb(3) ==
+              Arb(2)^3 ==
+              Arb(2)^Int8(3) ==
+              Arb(2)^UInt(3) ==
+              Arb(2)^UInt8(3) ==
+              (Arb(2)^-3)^-1 ==
+              Arb(8)
         @test hypot(Arb(3), Arb(4)) == Arb(5)
 
         @test Arblib.sqrtpos(Arb(4)) == Arb(2)
@@ -203,14 +204,14 @@
         @test Acb(2) * Arb(3) == Arb(3) * Acb(2) == Acb(6)
         @test Acb(6) / Arb(2) == Acb(3)
 
-        @test Acb(2)^Acb(2) ==
-              Acb(2)^Arb(2) ==
-              Acb(2)^2 ==
-              Acb(2)^Int8(2) ==
-              Acb(2)^UInt(2) ==
-              Acb(2)^UInt8(2) ==
-              (Acb(2)^-2)^-1 ==
-              Acb(4)
+        @test Acb(2)^Acb(3) ==
+              Acb(2)^Arb(3) ==
+              Acb(2)^3 ==
+              Acb(2)^Int8(3) ==
+              Acb(2)^UInt(3) ==
+              Acb(2)^UInt8(3) ==
+              (Acb(2)^-3)^-1 ==
+              Acb(8)
 
         @test Acb(2, 3) * Complex{Bool}(0, 0) ==
               Complex{Bool}(0, 0) * Acb(2, 3) ==

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -152,7 +152,13 @@
         @test Arb(2) * Arf(3) == Arf(3) * Arb(2) == Arb(6)
         @test Arb(6) / Arf(2) == UInt(6) / Arb(2) == UInt8(6) / Arb(2) == Arb(3)
 
-        @test Arb(2)^Arb(2) == Arb(2)^UInt(2) == Arb(2)^UInt8(2) == Arb(4)
+        @test Arb(2)^Arb(2) ==
+              Arb(2)^2 ==
+              Arb(2)^Int8(2) ==
+              Arb(2)^UInt(2) ==
+              Arb(2)^UInt8(2) ==
+              (Arb(2)^-2)^-1 ==
+              Arb(4)
         @test hypot(Arb(3), Arb(4)) == Arb(5)
 
         @test Arblib.sqrtpos(Arb(4)) == Arb(2)
@@ -203,6 +209,7 @@
               Acb(2)^Int8(2) ==
               Acb(2)^UInt(2) ==
               Acb(2)^UInt8(2) ==
+              (Acb(2)^-2)^-1 ==
               Acb(4)
 
         @test Acb(2, 3) * Complex{Bool}(0, 0) ==

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -35,9 +35,6 @@
         @test sign(Arf(2)) == Arf(1)
         @test sign(Arf(-2)) == Arf(-1)
         @test sign(Arf(0)) == Arf(0)
-        @test min(Arf(1), Arf(2)) == Arf(1)
-        @test max(Arf(1), Arf(2)) == Arf(2)
-        @test minmax(Arf(1), Arf(2)) == minmax(Arf(2), Arf(1)) == (Arf(1), Arf(2))
 
         @test abs(Arf(-2)) == abs(Arf(2)) == Arf(2)
         @test -Arf(2) == Arf(-2)
@@ -65,6 +62,10 @@
         @test sqrt(Arf(4)) == Arf(2)
         @test Arblib.rsqrt(Arf(4)) == Arf(1 // 2)
         @test Arblib.root(Arf(8), 3) == Arf(2)
+
+        @test min(Arf(1), Arf(2)) == Arf(1)
+        @test max(Arf(1), Arf(2)) == Arf(2)
+        @test minmax(Arf(1), Arf(2)) == minmax(Arf(2), Arf(1)) == (Arf(1), Arf(2))
     end
 
     @testset "$T" for T in [Arb, Acb]
@@ -147,6 +148,19 @@
 
         # TODO: Replace with ≈
         @test abs(atan(Arb(2), Arb(3)) - atan(2, 3)) <= 1e-15
+
+        @test min(Arb(1), Arb(2)) == Arb(1)
+        @test max(Arb(1), Arb(2)) == Arb(2)
+        @test minmax(Arb(1), Arb(2)) == minmax(Arb(2), Arb(1)) == (Arb(1), Arb(2))
+        @test Arblib.contains(min(Arb((0, 2)), Arb((-1, 3))), -1)
+        @test Arblib.contains(min(Arb((0, 2)), Arb((-1, 3))), 2)
+        @test !Arblib.contains(min(Arb((0, 2)), Arb((-1, 3))), 3)
+        @test Arblib.contains(max(Arb((0, 2)), Arb((-1, 3))), 0)
+        @test Arblib.contains(max(Arb((0, 2)), Arb((-1, 3))), 3)
+        @test !Arblib.contains(max(Arb((0, 2)), Arb((-1, 3))), -1)
+        @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (-1, 0)))
+        @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (2, 3)))
+        @test all(.!Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (3, -1)))
     end
 
     @testset "Acb - specific" begin

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -67,7 +67,7 @@
         @test Arblib.root(Arf(8), 3) == Arf(2)
     end
 
-    @testset "basic arithmetic: $T" for T in [Arb, Acb]
+    @testset "$T" for T in [Arb, Acb]
         @test T(3) + 1 == 4
         @test T(3) + 1 isa T
         @test T(2) + T(3) == 5
@@ -84,53 +84,15 @@
         @test T(3) / T(1) isa T
     end
 
-    @testset "promote: $T" for (T, TMat) in [(Arb, ArbMatrix), (Acb, AcbMatrix)]
-        A = TMat(3, 3)
-        # promotion of TRef to T
-        a = A[1, 1]
-        promote(a, 1) isa Tuple{T,T}
-        promote(a, T(1)) isa Tuple{T,T}
-        @test a + 3 == 3
-        @test a + 3 isa T
-    end
+    @testset "Acb - specific" begin
+        @test real(Acb(1, 2)) isa Arb
+        @test real(Acb(1, 2)) == Arb(1)
+        @test imag(Acb(1, 2)) isa Arb
+        @test imag(Acb(1, 2)) == Arb(2)
 
-    @testset "real/imag" begin
-        x, y = Arb(rand()), Arb(rand())
-        z = Acb(x, y)
+        @test conj(Acb(1, 2)) == Acb(1, -2)
 
-        @test Arblib.realref(z) isa ArbRef
-        @test Arblib.realref(z) == x
-        @test real(z) == x
-        @test Arblib.imagref(z) isa ArbRef
-        @test Arblib.imagref(z) == y
-        @test imag(z) == y
-    end
-
-    @testset "midref" begin
-        x = Arb(0.25)
-        @test Arblib.midref(x) isa ArfRef
-        @test startswith(sprint(show, x), "0.250")
-        @test Float64(Arblib.midref(x)) isa Float64
-        @test Float64(Arblib.midref(x)) == 0.25
-        @test Float64(x) == 0.25
-        @test sprint(show, x) == sprint(show, x[])
-    end
-
-    @testset "radref" begin
-        x = Arb(0.25)
-        m = Arblib.radref(x)
-        @test m isa MagRef
-        m[] = 1.0
-        @test Float64(m) ≥ 1.0
-        @test sprint(show, m) == sprint(show, m[])
-    end
-
-    @testset "convert to Float64/ComplexF64" begin
-        x = Arb(0.25)
-        @test Float64(x) isa Float64
-        @test Float64(x) == 0.25
-        z = Acb(2.0 + 0.125im)
-        @test ComplexF64(z) isa ComplexF64
-        @test ComplexF64(z) == 2.0 + 0.125im
+        @test abs(Acb(3, 4)) isa Arb
+        @test abs(Acb(3, 4)) == Arb(5)
     end
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -97,7 +97,14 @@
               T(6)
         @test T(6) / T(2) == T(6) / 2 == T(6) / UInt(2) == T(3)
 
-        @test Base.literal_pow(^, T(3), Val(2)) == T(3)^2 == Arblib.sqr(T(3)) == T(9)
+        @test Base.literal_pow(^, T(2), Val(-2)) ==
+              T(2)^-2 ==
+              Arblib.sqr(inv(T(2))) ==
+              T(1 // 4)
+        @test Base.literal_pow(^, T(2), Val(0)) == T(2)^0 == one(T)
+        @test Base.literal_pow(^, T(2), Val(1)) == T(2)^1 == T(2)
+        @test Base.literal_pow(^, T(2), Val(2)) == T(2)^2 == Arblib.sqr(T(2)) == T(4)
+
         @test Arblib.root(T(8), 3) == T(2)
 
         for f in [

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -47,6 +47,9 @@
               2 + Arf(1) ==
               Arf(1) + UInt(2) ==
               UInt(2) + Arf(1) ==
+              Arf(1) + UInt8(2) ==
+              Arf(1) + UInt8(2) ==
+              UInt8(2) + Arf(1) ==
               Arf(3)
         @test Arf(1) - Arf(2) == Arf(1) - 2 == Arf(1) - UInt(2) == Arf(-1)
         @test Arf(2) * Arf(3) ==
@@ -60,6 +63,8 @@
               6 / Arf(2) ==
               Arf(6) / UInt(2) ==
               UInt(6) / Arf(2) ==
+              Arf(6) / UInt8(2) ==
+              UInt8(6) / Arf(2) ==
               Arf(3)
 
         @test sqrt(Arf(4)) == Arf(2)
@@ -80,6 +85,8 @@
               2 + T(1) ==
               T(1) + UInt(2) ==
               UInt(2) + T(1) ==
+              T(1) + UInt8(2) ==
+              UInt8(2) + T(1) ==
               T(3)
         @test T(1) - T(2) == T(1) - 2 == T(1) - UInt(2) == T(-1)
         @test T(2) * T(3) ==
@@ -143,9 +150,9 @@
         @test Arb(1) + Arf(2) == Arf(2) + Arb(1) == Arb(3)
         @test Arb(1) - Arf(2) == Arb(-1)
         @test Arb(2) * Arf(3) == Arf(3) * Arb(2) == Arb(6)
-        @test Arb(6) / Arf(2) == UInt(6) / Arb(2) == Arb(3)
+        @test Arb(6) / Arf(2) == UInt(6) / Arb(2) == UInt8(6) / Arb(2) == Arb(3)
 
-        @test Arb(2)^Arb(2) == Arb(2)^UInt(2) == Arb(4)
+        @test Arb(2)^Arb(2) == Arb(2)^UInt(2) == Arb(2)^UInt8(2) == Arb(4)
         @test hypot(Arb(3), Arb(4)) == Arb(5)
 
         @test Arblib.sqrtpos(Arb(4)) == Arb(2)
@@ -190,7 +197,13 @@
         @test Acb(2) * Arb(3) == Arb(3) * Acb(2) == Acb(6)
         @test Acb(6) / Arb(2) == Acb(3)
 
-        @test Acb(2)^Acb(2) == Acb(2)^Arb(2) == Acb(2)^2 == Acb(2)^UInt(2) == Acb(4)
+        @test Acb(2)^Acb(2) ==
+              Acb(2)^Arb(2) ==
+              Acb(2)^2 ==
+              Acb(2)^Int8(2) ==
+              Acb(2)^UInt(2) ==
+              Acb(2)^UInt8(2) ==
+              Acb(4)
 
         @test Acb(2, 3) * Complex{Bool}(0, 0) ==
               Complex{Bool}(0, 0) * Acb(2, 3) ==

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -68,23 +68,108 @@
     end
 
     @testset "$T" for T in [Arb, Acb]
-        @test T(3) + 1 == 4
-        @test T(3) + 1 isa T
-        @test T(2) + T(3) == 5
-        @test T(2) + T(3) isa T
-        @test T(3) - 1 == 2
-        @test T(3) - 1 isa T
-        @test T(2) - T(3) == -1
-        @test T(2) - T(3) isa T
-        @test T(3) * 1 == 3
-        @test T(3) * 1 isa T
-        @test Bool(Arblib.contains(T(3) / 1, T(3)))
-        @test T(3) / 1 isa T
-        @test Bool(Arblib.contains(T(3) / T(1), T(3)))
-        @test T(3) / T(1) isa T
+        @test T(1) + T(2) ==
+              T(1) + 2 ==
+              2 + T(1) ==
+              T(1) + UInt(2) ==
+              UInt(2) + T(1) ==
+              T(3)
+        @test T(1) - T(2) == T(1) - 2 == T(1) - UInt(2) == T(-1)
+        @test T(2) * T(3) ==
+              T(2) * 3 ==
+              3 * T(2) ==
+              T(2) * UInt(3) ==
+              UInt(3) * T(2) ==
+              T(6)
+        @test T(6) / T(2) == T(6) / 2 == T(6) / UInt(2) == T(3)
+
+        @test Arblib.root(T(8), 3) == T(2)
+
+        for f in [
+            inv,
+            sqrt,
+            log,
+            log1p,
+            exp,
+            expm1,
+            sin,
+            cos,
+            tan,
+            cot,
+            sec,
+            csc,
+            atan,
+            asin,
+            acos,
+            sinh,
+            cosh,
+            tanh,
+            coth,
+            sech,
+            csch,
+            atanh,
+            asinh,
+        ]
+            # TODO: Replace with ≈
+            @test abs(f(T(0.5)) - f(0.5)) <= 1e-15
+        end
+        # TODO: Replace with ≈
+        @test abs(acosh(T(2)) - acosh(2)) <= 1e-15
+
+        @test Arblib.rsqrt(T(1 // 4)) == T(2)
+        @test Arblib.sqr(T(3)) == T(9)
+
+        @test sinpi(T(1)) == T(0)
+        @test cospi(T(1)) == T(-1)
+        @test Arblib.tanpi(T(1)) == T(0)
+        # TODO: Replace with ≈
+        @test abs(Arblib.cotpi(T(0.5))) <= 1e-15
+        @test abs(Arblib.cscpi(T(0.5)) - 1) <= 1e-15
+        @test abs(sinc(T(0.5)) - sinc(0.5)) <= 1e-15
+
+        @test isequal(sincos(T(1)), (sin(T(1)), cos(T(1))))
+        @test isequal(Arblib.sincospi(T(1)), (sinpi(T(1)), cospi(T(1))))
+        @test isequal(Arblib.sinhcosh(T(1)), (sinh(T(1)), cosh(T(1))))
+    end
+
+    @testset "Arb - specific" begin
+        @test Arb(1) + Arf(2) == Arf(2) + Arb(1) == Arb(3)
+        @test Arb(1) - Arf(2) == Arb(-1)
+        @test Arb(2) * Arf(3) == Arf(3) * Arb(2) == Arb(6)
+        @test Arb(6) / Arf(2) == UInt(6) / Arb(2) == Arb(3)
+
+        @test Arb(2)^Arb(2) == Arb(2)^UInt(2) == Arb(4)
+        @test hypot(Arb(3), Arb(4)) == Arb(5)
+
+        @test Arblib.sqrtpos(Arb(4)) == Arb(2)
+        @test Arblib.sqrtpos(Arb(-4)) == Arb(0)
+        @test Arblib.sqrt1pm1(Arb(3)) == Arb(1)
+
+        # TODO: Replace with ≈
+        @test abs(atan(Arb(2), Arb(3)) - atan(2, 3)) <= 1e-15
     end
 
     @testset "Acb - specific" begin
+        @test Acb(1) + Arb(2) == Arb(2) + Acb(1) == Acb(3)
+        @test Acb(1) - Arb(2) == Acb(-1)
+        @test Acb(2) * Arb(3) == Arb(3) * Acb(2) == Acb(6)
+        @test Acb(6) / Arb(2) == Acb(3)
+
+        @test Acb(2)^Acb(2) == Acb(2)^Arb(2) == Acb(2)^2 == Acb(2)^UInt(2) == Acb(4)
+
+        @test Acb(2, 3) * Complex{Bool}(0, 0) ==
+              Complex{Bool}(0, 0) * Acb(2, 3) ==
+              Acb(2, 3) * (0 + 0im)
+        @test Acb(2, 3) * Complex{Bool}(0, 1) ==
+              Complex{Bool}(0, 1) * Acb(2, 3) ==
+              Acb(2, 3) * (0 + 1im)
+        @test Acb(2, 3) * Complex{Bool}(1, 0) ==
+              Complex{Bool}(1, 0) * Acb(2, 3) ==
+              Acb(2, 3) * (1 + 0im)
+        @test Acb(2, 3) * Complex{Bool}(1, 1) ==
+              Complex{Bool}(1, 1) * Acb(2, 3) ==
+              Acb(2, 3) * (1 + 1im)
+
         @test real(Acb(1, 2)) isa Arb
         @test real(Acb(1, 2)) == Arb(1)
         @test imag(Acb(1, 2)) isa Arb

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -28,8 +28,43 @@
 
         @test min(Mag(1), Mag(2)) == Mag(1)
         @test max(Mag(1), Mag(2)) == Mag(2)
-        @test minmax(Mag(1), Mag(2)) == (Mag(1), Mag(2))
-        @test minmax(Mag(2), Mag(1)) == (Mag(1), Mag(2))
+        @test minmax(Mag(1), Mag(2)) == minmax(Mag(2), Mag(1)) == (Mag(1), Mag(2))
+    end
+
+    @testset "Arf" begin
+        @test sign(Arf(2)) == Arf(1)
+        @test sign(Arf(-2)) == Arf(-1)
+        @test sign(Arf(0)) == Arf(0)
+        @test min(Arf(1), Arf(2)) == Arf(1)
+        @test max(Arf(1), Arf(2)) == Arf(2)
+        @test minmax(Arf(1), Arf(2)) == minmax(Arf(2), Arf(1)) == (Arf(1), Arf(2))
+
+        @test abs(Arf(-2)) == abs(Arf(2)) == Arf(2)
+        @test -Arf(2) == Arf(-2)
+
+        @test Arf(1) + Arf(2) ==
+              Arf(1) + 2 ==
+              2 + Arf(1) ==
+              Arf(1) + UInt(2) ==
+              UInt(2) + Arf(1) ==
+              Arf(3)
+        @test Arf(1) - Arf(2) == Arf(1) - 2 == Arf(1) - UInt(2) == Arf(-1)
+        @test Arf(2) * Arf(3) ==
+              Arf(2) * 3 ==
+              3 * Arf(2) ==
+              Arf(2) * UInt(3) ==
+              UInt(3) * Arf(2) ==
+              Arf(6)
+        @test Arf(6) / Arf(2) ==
+              Arf(6) / 2 ==
+              6 / Arf(2) ==
+              Arf(6) / UInt(2) ==
+              UInt(6) / Arf(2) ==
+              Arf(3)
+
+        @test sqrt(Arf(4)) == Arf(2)
+        @test Arblib.rsqrt(Arf(4)) == Arf(1 // 2)
+        @test Arblib.root(Arf(8), 3) == Arf(2)
     end
 
     @testset "basic arithmetic: $T" for T in [Arb, Acb]

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -29,6 +29,9 @@
         @test min(Mag(1), Mag(2)) == Mag(1)
         @test max(Mag(1), Mag(2)) == Mag(2)
         @test minmax(Mag(1), Mag(2)) == minmax(Mag(2), Mag(1)) == (Mag(1), Mag(2))
+        @test minimum(Mag[10:20; 0:9]) == Mag(0)
+        @test maximum(Mag[10:20; 0:9]) == Mag(20)
+        @test extrema(Mag[10:20; 0:9]) == (Mag(0), Mag(20))
     end
 
     @testset "Arf" begin
@@ -66,6 +69,9 @@
         @test min(Arf(1), Arf(2)) == Arf(1)
         @test max(Arf(1), Arf(2)) == Arf(2)
         @test minmax(Arf(1), Arf(2)) == minmax(Arf(2), Arf(1)) == (Arf(1), Arf(2))
+        @test minimum(Arf[10:20; 0:9]) == Arf(0)
+        @test maximum(Arf[10:20; 0:9]) == Arf(20)
+        @test extrema(Arf[10:20; 0:9]) == (Arf(0), Arf(20))
     end
 
     @testset "$T" for T in [Arb, Acb]
@@ -161,6 +167,21 @@
         @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (-1, 0)))
         @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (2, 3)))
         @test all(.!Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (3, -1)))
+        @test minimum(Arb[10:20; 0:9]) == Arb(0)
+        @test maximum(Arb[10:20; 0:9]) == Arb(20)
+        @test extrema(Arb[10:20; 0:9]) == (Arb(0), Arb(20))
+        A = [Arb((i, i + 1)) for i = 0:10]
+        @test Arblib.contains(minimum(A), Arb((0, 1)))
+        @test Arblib.contains(minimum(reverse(A)), Arb((0, 1)))
+        @test Arblib.contains(maximum(A), Arb((10, 11)))
+        @test Arblib.contains(maximum(reverse(A)), Arb((10, 11)))
+        @test all(Arblib.contains.(extrema(A), (Arb((0, 1)), Arb((10, 11)))))
+        # These fails with the default implementation
+        @test Arblib.contains(
+            minimum([Arb((-i, -i + 1)) for i = 0:1000]),
+            Arb((-1000, -999)),
+        )
+        @test Arblib.contains(maximum([Arb((i, i + 1)) for i = 0:1000]), Arb((1000, 1001)))
     end
 
     @testset "Acb - specific" begin

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -119,29 +119,26 @@
         @test isequal(Acb((1, 2), (3, 4)), Acb(Arb((1, 2)), Arb((3, 4))))
     end
 
-    @testset "Others" begin
-        # TODO: Move these to other file
-        @test Float64(Arf(2.0)) isa Float64
-        @test Float64(Arf(2.0)) == 2.0
-        @test convert(Float64, Arf(2.0)) isa Float64
-        @test convert(Float64, Arf(2.0)) == 2.0
+    @testset "Conversion" begin
         @test Int(Arf(2.0)) isa Int
         @test Int(Arf(2.0)) == 2
-        @test convert(Int, Arf(2.0)) isa Int
-        @test convert(Int, Arf(2.0)) == 2
-        @test Int(Arf(2.0)) == 2
+        @test_throws InexactError Int(Arf(2.5))
+
+        @test Float64(Mag(2)) isa Float64
+        @test Float64(Mag(2)) == 2.0
+        @test Float64(Arf(2)) isa Float64
+        @test Float64(Arf(2)) == 2.0
+        @test Float64(Arb(2)) isa Float64
+        @test Float64(Arb(2)) == 2.0
+
+        @test ComplexF64(Acb(2 + 3im)) isa ComplexF64
+        @test ComplexF64(Acb(2 + 3im)) == 2.0 + 3.0im
+
         @test Arblib.get_si(Arf(0.5)) == 0
         @test Arblib.get_si(Arf(0.5); rnd = Arblib.ArbRoundFromZero) == 1
 
-        @test Int(Arf(2)) == 2
-        @test_throws InexactError Int(Arf(2.5))
-        @test Float64(Mag(2.5)) ≥ 2.5
-        @test Float64(Arf(2.5)) == 2.5
-        @test Float64(Arb(2.5)) == 2.5
-        @test ComplexF64(Acb(2.25)) == 2.25 + 0im
         @test BigFloat(Arf(2.5)) == 2.5
         @test BigFloat(Arb(2.5)) == 2.5
-        @test precision(BigFloat(Arf(2.5; prec = 96))) == 96
     end
 
     @testset "zeros/ones" begin

--- a/test/types-test.jl
+++ b/test/types-test.jl
@@ -3,6 +3,11 @@
         @test Mag() isa Mag
         @test Mag(Mag()) isa Mag
         @test Mag(Arf()) isa Mag
+        x = Mag()
+        y = copy(x)
+        Arblib.set!(x, 1)
+        @test x == Mag(1)
+        @test y == Mag(0)
     end
 
     @testset "Arf" begin
@@ -12,16 +17,31 @@
         @test precision(Arf(UInt64(1), prec = 80)) == 80
         @test Arf(1) isa Arf
         @test precision(Arf(1, prec = 80)) == 80
+        x = Arf()
+        y = copy(x)
+        Arblib.set!(x, 1)
+        @test x == Arf(1)
+        @test y == Arf(0)
     end
 
     @testset "Arb" begin
         @test Arb() isa Arb
         @test precision(Arb(prec = 80)) == 80
+        x = Arb()
+        y = copy(x)
+        Arblib.set!(x, 1)
+        @test x == Arb(1)
+        @test y == Arb(0)
     end
 
     @testset "Acb" begin
         @test Acb() isa Acb
         @test precision(Acb(prec = 80)) == 80
+        x = Acb()
+        y = copy(x)
+        Arblib.set!(x, 1)
+        @test x == Acb(1)
+        @test y == Acb(0)
     end
 
     @testset "ArbPoly" begin


### PR DESCRIPTION
This pull request rewrites most of `artihmetic.jl`. It adds new methods, removes some which never existed, and adds tests for all of them. It also implements `minimum` and `maximum` and in relation to this I added a section to the README about common pitfalls when working with the Julia ecosystem, the issues with the default implementations of `minimum` and `maximum` are mentioned there.

The tests are failing for now but should start to work once #113 is merged and this is rebased on top of that.