### PR TITLE
Enh/special functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,11 @@ Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Arb_jll = "~200.1900"
 FLINT_jll = "~200.700"
 julia = "1.3"
+SpecialFunctions = "1.0"

--- a/README.md
+++ b/README.md
@@ -247,3 +247,18 @@ let prec = 64
     end
 end
 ```
+
+## Special functions
+Arblib extends the methods from
+[SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl)
+with versions from Arb. In some cases the Arb version is more general
+than the version in SpecialFunctions, for example `ellipk` is not
+implemented for complex arguments in SpecialFunctions but it is in
+Arb. We refer to the Arb documentation for details about the
+Arb-versions.
+
+Some methods from SpecialFunctions are however not implemented in Arb
+and does are not extended, these are mostly scaled version of methods.
+Arb does however implement many special functions that are not in
+SpecialFunction and at the moment there is no user friendly interface
+for most of them.

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -2,6 +2,7 @@ module Arblib
 
 using Arb_jll
 import LinearAlgebra
+import SpecialFunctions
 
 if VERSION >= v"1.5.0-DEV.639"
     import Base: contains
@@ -61,6 +62,7 @@ include("array_common.jl")
 include("eigen.jl")
 include("poly.jl")
 include("calc_integrate.jl")
+include("special-functions.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -1,0 +1,301 @@
+# TODO: How to handle scaled (or in some other way simply modified)
+# version not implemented by Arb? Should we just make a naive
+# implementation? The user might assume that they are optimized for
+# the scaled version, on the other hand the user will always get a
+# bound on the error so knows if more precision is needed. Discuss
+# with the developers of SpecialFunctions?
+
+# TODO: Which input to take precision from?
+
+# TODO: Should we handle promotion in any way? Would be better if
+# SpecialFunctions could handle this directly.
+
+# TODO: Some (which?) Arb functions are more general than those in
+# SpecialFunctions. How should we handle that?
+
+# TODO: I have not checked that the branch cuts are the same for
+# SpecialFunctions and Arb, I believe in most cases they are.
+
+# TODO: Should we add documentation for the methods which are not
+# identical to those in SpecialFunctions (which are these?)? Should we
+# just refer to Arbs documentation?
+
+##
+## Gamma Function
+##
+
+SpecialFunctions.gamma(z::Union{ArbOrRef,AcbOrRef}) = gamma!(zero(z), z)
+
+SpecialFunctions.digamma(x::Union{ArbOrRef,AcbOrRef}) = digamma!(zero(x), x)
+
+#SpecialFunctions.invdigamma(x)
+# Not implemented by Arb
+
+SpecialFunctions.trigamma(x::AcbOrRef) =
+    polygamma(3one(x), x)
+
+SpecialFunctions.polygamma(s::AcbOrRef, x::AcbOrRef) =
+    polygamma!(zero(x), s, x)
+
+function SpecialFunctions.gamma_inc(a::ArbOrRef, x::ArbOrRef)
+    Γ = hypgeom_gamma_upper!(zero(x), a, x, 1)
+    γ = 1 - Γ
+    return (Γ, γ)
+end
+function SpecialFunctions.gamma_inc(a::AcbOrRef, x::AcbOrRef)
+    Γ = hypgeom_gamma_upper!(zero(x), a, x, 1)
+    γ = 1 - Γ
+    return (Γ, γ)
+end
+
+#gamma_inc_inv(a, p, q)
+# Not implemented by Arb
+
+function SpecialFunctions.beta_inc(a::ArbOrRef, b::ArbOrRef, x::ArbOrRef)
+    β = hypgeom_beta_lower!(zero(x), a, b, x, 1)
+    B = 1 - β
+    return (β, B)
+end
+function SpecialFunctions.beta_inc(a::AcbOrRef, b::AcbOrRef, x::AcbOrRef)
+    β = hypgeom_beta_lower!(zero(x), a, b, x, 1)
+    B = 1 - β
+    return (β, B)
+end
+
+#loggamma(x)
+SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) =
+    lgamma!(zero(x), x)
+
+#logabsgamma(x)
+# Not implemented by Arb
+
+#logfactorial(x)
+# Only relevant for integers, which doesn't apply to Arblib
+
+#beta(x,y)
+# Not implemented directly by Arb, could use beta_inc or gamma to implement it?
+
+#logbeta(x,y)
+#Not implemented by Arb
+
+#logabsbeta(x,y)
+#Not implemented by Arb
+
+#logabsbinomial(x,y)
+#Not implemented by Arb
+
+##
+## Trigonometric Integrals
+##
+
+# The version when ν is not specified could be defined directly, but
+# it would likely be better if it was defined in SpecialFunctions
+# directly.
+SpecialFunctions.expint(ν::ArbOrRef, x::ArbOrRef) =
+    hypgeom_expint!(zero(x), ν, x)
+SpecialFunctions.expint(ν::AcbOrRef, x::AcbOrRef) =
+    hypgeom_expint!(zero(x), ν, x)
+
+SpecialFunctions.expinti(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_ei!(zero(x), x)
+
+SpecialFunctions.sinint(x::Union{ArbOrRef,AcbOrRef}) = hypgeom!(zero(x), x)
+
+SpecialFunctions.cosint(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_ci!(zero(x), x)
+
+##
+## Error Functions, Dawson’s and Fresnel Integrals
+##
+
+#SpecialFunctions.erf(x)
+SpecialFunctions.erf(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erf!(zero(x), x)
+
+#SpecialFunctions.erf(x,y)
+#Not implemented by Arb
+
+#SpecialFunctions.erfc(x)
+SpecialFunctions.erfc(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erc!(zero(x), x)
+
+#SpecialFunctions.erfcinv(x)
+#Not implemented by Arb
+
+#SpecialFunctions.erfcx(x)
+#Not implemented by Arb
+
+#SpecialFunctions.logerfc(x)
+#Not implemented by Arb
+
+#SpecialFunctions.logerfcx(x)
+#Not implemented by Arb
+
+#SpecialFunctions.erfi(x)
+#Not implemented by Arb
+
+#SpecialFunctions.erfinv(x)
+#Not implemented by Arb
+
+#SpecialFunctions.dawson(x)
+#Not implemented by Arb
+
+##
+## Airy and Related Functions
+##
+
+#SpecialFunctions.airyai(z)
+# TODO: If we could pass NULL for the three unused values we could
+# speed up the computation.
+function SpecialFunctions.airyai(z::Union{ArbOrRef,AcbOrRef})
+    ai = zero(z)
+    hypgeom_airy!(ai, zero(z), zero(z), zero(z), z)
+    return ai
+end
+
+#SpecialFunctions.airyaiprime(z)
+# TODO: If we could pass NULL for the three unused values we could
+# speed up the computation.
+function SpecialFunctions.airyaiprime(z::Union{ArbOrRef,AcbOrRef})
+    ai_prime = zero(z)
+    hypgeom_airy!(zero(z), ai_prime, zero(z), zero(z), z)
+    return ai_prime
+end
+
+#SpecialFunctions.airybi(z)
+# TODO: If we could pass NULL for the three unused values we could
+# speed up the computation.
+function SpecialFunctions.airybi(z::Union{ArbOrRef,AcbOrRef})
+    bi = zero(z)
+    hypgeom_airy!(zero(z), zero(z), bi, zero(z), z)
+    return bi
+end
+
+#SpecialFunctions.airybiprime(z)
+# TODO: If we could pass NULL for the three unused values we could
+# speed up the computation.
+function SpecialFunctions.airybiprime(z::Union{ArbOrRef,AcbOrRef})
+    bi_prime = zero(z)
+    hypgeom_airy!(zero(z), zero(z), zero(z), bi_prime, z)
+    return bi_prime
+end
+
+#SpecialFunctions.airyaix(z)
+#Not implemented by Arb
+
+#SpecialFunctions.airyaiprimex(z)
+#Not implemented by Arb
+
+#SpecialFunctions.airybix(z)
+#Not implemented by Arb
+
+#SpecialFunctions.airybiprimex(z)
+#Not implemented by Arb
+
+##
+## Bessel Functions
+##
+
+#SpecialFunctions.besselj(nu, z)
+SpecialFunctions.besselj(ν::ArbOrRef, z::ArbOrRef) =
+    hypgeom_bessel_j!(zero(z), ν, z)
+SpecialFunctions.besselj(ν::AcbOrRef, z::AcbOrRef) =
+    hypgeom_bessel_j!(zero(z), ν, z)
+
+#SpecialFunctions.besselj0(z)
+SpecialFunctions.besselj0(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_j!(zero(z), zero(z), z)
+
+#SpecialFunctions.besselj1(z)
+SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_j!(zero(z), one(z), z)
+
+#SpecialFunctions.besseljx(nu,z)
+# Arb doesn't implement a scaled version
+
+#SpecialFunctions.sphericalbesselj(nu,z)
+# The general method implemented by SpecialFunctions is not completely
+# rigorous since it makes a cutoff for small values
+sphericalbesselj(ν::ArbOrRef, x::ArbOrRef) = √((float(T))(π)/2x) * besselj(nu + one(nu)/2, x)
+
+#SpecialFunctions.bessely(nu,z)
+SpecialFunctions.bessely(ν::ArbOrRef, z::ArbOrRef) =
+    hypgeom_bessel_y!(zero(z), ν, z)
+SpecialFunctions.bessely(ν::AcbOrRef, z::AcbOrRef) =
+    hypgeom_bessel_y!(zero(z), ν, z)
+
+#SpecialFunctions.bessely0(z)
+SpecialFunctions.bessely0(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_y!(zero(z), zero(z), z)
+
+#SpecialFunctions.bessely1(z)
+SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_y!(zero(z), one(z), z)
+
+#SpecialFunctions.besselyx(nu,z)
+# Arb doesn't implement a scaled version
+
+#SpecialFunctions.sphericalbessely(nu,z)
+
+#SpecialFunctions.besselh(nu,k,z)
+function SpecialFunctions.besselh(ν::AcbOrRef, k, z::AcbOrRef)
+    J = zero(z), Y = zero(z)
+    hypgeom_bessel_jy!(J, Y, ν, z)
+    if k == 1
+        return J + im*Y
+    elseif k == 2
+        return J - im*Y
+    else
+        throw(SpecialFunctions.AmosException(1)) # This is what SpecialFunctions throw
+    end
+end
+
+#SpecialFunctions.hankelh1(nu,z)
+# Aliased to besselh(nu, 1, z)
+
+#SpecialFunctions.hankelh1x(nu,z)
+# Aliased to besselhx(nu, 1, z)
+
+#SpecialFunctions.hankelh2(nu,z)
+# Aliased to besselh(nu, 2, z)
+
+#SpecialFunctions.hankelh2x(nu,z)
+# Aliased to besselhx(nu, 2, z)
+
+#SpecialFunctions.besseli(nu,z)
+SpecialFunctions.besseli(ν::ArbOrRef, z::ArbOrRef) =
+    hypgeom_bessel_i!(zero(z), ν, z)
+SpecialFunctions.besseli(ν::AcbOrRef, z::AcbOrRef) =
+    hypgeom_bessel_i!(zero(z), ν, z)
+
+#SpecialFunctions.besselix(nu,z)
+# The scaling used by Arb seems to be different from that used by
+# SpecialFunctions.
+
+#SpecialFunctions.besselk(nu,z)
+SpecialFunctions.besselk(ν::ArbOrRef, z::ArbOrRef) =
+    hypgeom_bessel_k!(zero(z), ν, z)
+SpecialFunctions.besselk(ν::AcbOrRef, z::AcbOrRef) =
+    hypgeom_bessel_k!(zero(z), ν, z)
+
+#SpecialFunctions.besselkx(nu,z)
+SpecialFunctions.besselkx(ν::ArbOrRef, z::ArbOrRef) =
+    hypgeom_bessel_k_scaled!(zero(z), ν, z)
+SpecialFunctions.besselkx(ν::AcbOrRef, z::AcbOrRef) =
+    hypgeom_bessel_k_scaled!(zero(z), ν, z)
+
+#jinc(x)
+# Aliased to 2 * besselj1(π*x) / (π*x) which works fine
+
+##
+## Elliptic Integrals
+##
+
+#SpecialFunctions.ellipk(m)
+SpecialFunctions.ellipk(m::AcbOrRef) = elliptic_k!(zero(m), m)
+
+#SpecialFunctions.ellipe(m)
+SpecialFunctions.ellipe(m::AcbOrRef) = elliptic_e!(zero(m), m)
+
+##
+## Zeta and Related Functions
+##
+
+#SpecialFunctions.eta(x)
+SpecialFunctions.eta(x::AcbOrRef) = dirichlet_eta!(zero(x), x)
+
+SpecialFunctions.zeta(s::Union{ArbOrRef,AcbOrRef}) = zeta!(zero(s), s)
+SpecialFunctions.zeta(s::ArbOrRef, z::ArbOrRef) = hurwitz_zeta!(zero(s), s, z)
+SpecialFunctions.zeta(s::AcbOrRef, z::AcbOrRef) = hurwitz_zeta!(zero(s), s, z)

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -4,6 +4,14 @@
 
 SpecialFunctions.gamma(z::Union{ArbOrRef,AcbOrRef}) = gamma!(zero(z), z)
 
+SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) = lgamma!(zero(x), x)
+
+#SpecialFunctions.logabsgamma(x)
+# Not implemented by Arb
+
+#SpecialFunctions.logfactorial(x)
+# Only relevant for Arblib
+
 SpecialFunctions.digamma(x::Union{ArbOrRef,AcbOrRef}) = digamma!(zero(x), x)
 
 #SpecialFunctions.invdigamma(x)
@@ -15,6 +23,14 @@ function SpecialFunctions.trigamma(x::AcbOrRef)
 end
 
 SpecialFunctions.polygamma(s::AcbOrRef, x::AcbOrRef) = polygamma!(zero(x), s, x)
+
+SpecialFunctions.gamma(a::ArbOrRef, z::ArbOrRef) =
+    hypgeom_gamma_upper!(Arb(0, prec = _precision((a, z))), a, z, 0)
+SpecialFunctions.gamma(a::AcbOrRef, z::AcbOrRef) =
+    hypgeom_gamma_upper!(Acb(0, prec = _precision((a, z))), a, z, 0)
+
+#loggamma(a,z)
+# Not implemented by Arb
 
 function SpecialFunctions.gamma_inc(a::ArbOrRef, x::ArbOrRef)
     Γ = hypgeom_gamma_upper!(Arb(0, prec = _precision((a, x))), a, x, 1)
@@ -31,9 +47,6 @@ function SpecialFunctions.gamma_inc(a::AcbOrRef, x::AcbOrRef)
     return (γ, Γ)
 end
 
-#gamma_inc_inv(a, p, q)
-# Not implemented by Arb
-
 function SpecialFunctions.beta_inc(a::ArbOrRef, b::ArbOrRef, x::ArbOrRef)
     β = hypgeom_beta_lower!(Arb(prec = _precision((a, x))), a, b, x, 1)
     # Β = 1 - β
@@ -49,14 +62,8 @@ function SpecialFunctions.beta_inc(a::AcbOrRef, b::AcbOrRef, x::AcbOrRef)
     return (β, Β)
 end
 
-#loggamma(x)
-SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) = lgamma!(zero(x), x)
-
-#logabsgamma(x)
+#gamma_inc_inv(a, p, q)
 # Not implemented by Arb
-
-#logfactorial(x)
-# Only relevant for integers, which doesn't apply to Arblib
 
 #beta(x,y)
 # Not implemented directly by Arb, could use beta_inc or gamma to implement it?
@@ -71,7 +78,7 @@ SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) = lgamma!(zero(x), x)
 #Not implemented by Arb
 
 ##
-## Trigonometric Integrals
+## Exponential and Trigonometric Integrals
 ##
 
 # The version when ν is not specified could be defined directly, but
@@ -82,7 +89,15 @@ SpecialFunctions.expint(ν::ArbOrRef, x::ArbOrRef) =
 SpecialFunctions.expint(ν::AcbOrRef, x::AcbOrRef) =
     hypgeom_expint!(Acb(prec = _precision((ν, x))), ν, x)
 
+function SpecialFunctions.expint(x::Union{ArbOrRef,AcbOrRef})
+    ν = one(x)
+    return hypgeom_expint!(ν, ν, x)
+end
+
 SpecialFunctions.expinti(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_ei!(zero(x), x)
+
+#expintx(x)
+# Not implemented by arb
 
 SpecialFunctions.sinint(x::Union{ArbOrRef,AcbOrRef}) = hypgeom!(zero(x), x)
 
@@ -92,41 +107,38 @@ SpecialFunctions.cosint(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_ci!(zero(x), x)
 ## Error Functions, Dawson’s and Fresnel Integrals
 ##
 
-#SpecialFunctions.erf(x)
 SpecialFunctions.erf(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erf!(zero(x), x)
 
 #SpecialFunctions.erf(x,y)
-#Not implemented by Arb
+# Not implemented by Arb
 
-#SpecialFunctions.erfc(x)
 SpecialFunctions.erfc(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erfc!(zero(x), x)
 
 #SpecialFunctions.erfcinv(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.erfcx(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.logerfc(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.logerfcx(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.erfi(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.erfinv(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.dawson(x)
-#Not implemented by Arb
+# Not implemented by Arb
 
 ##
 ## Airy and Related Functions
 ##
 
-#SpecialFunctions.airyai(z)
 function SpecialFunctions.airyai(z::ArbOrRef)
     ai = zero(z)
     ccall(
@@ -158,9 +170,6 @@ function SpecialFunctions.airyai(z::AcbOrRef)
     return ai
 end
 
-#SpecialFunctions.airyaiprime(z)
-# TODO: If we could pass NULL for the three unused values we could
-# speed up the computation.
 function SpecialFunctions.airyaiprime(z::ArbOrRef)
     ai_prime = zero(z)
     ccall(
@@ -192,9 +201,6 @@ function SpecialFunctions.airyaiprime(z::AcbOrRef)
     return ai_prime
 end
 
-#SpecialFunctions.airybi(z)
-# TODO: If we could pass NULL for the three unused values we could
-# speed up the computation.
 function SpecialFunctions.airybi(z::ArbOrRef)
     bi = zero(z)
     ccall(
@@ -226,9 +232,6 @@ function SpecialFunctions.airybi(z::AcbOrRef)
     return bi
 end
 
-#SpecialFunctions.airybiprime(z)
-# TODO: If we could pass NULL for the three unused values we could
-# speed up the computation.
 function SpecialFunctions.airybiprime(z::ArbOrRef)
     bi_prime = zero(z)
     ccall(
@@ -261,41 +264,38 @@ function SpecialFunctions.airybiprime(z::AcbOrRef)
 end
 
 #SpecialFunctions.airyaix(z)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.airyaiprimex(z)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.airybix(z)
-#Not implemented by Arb
+# Not implemented by Arb
 
 #SpecialFunctions.airybiprimex(z)
-#Not implemented by Arb
+# Not implemented by Arb
 
 ##
 ## Bessel Functions
 ##
 
-#SpecialFunctions.besselj(nu, z)
 SpecialFunctions.besselj(ν::ArbOrRef, z::ArbOrRef) =
     hypgeom_bessel_j!(Arb(0, prec = _precision((ν, z))), ν, z)
 SpecialFunctions.besselj(ν::AcbOrRef, z::AcbOrRef) =
     hypgeom_bessel_j!(Acb(0, prec = _precision((ν, z))), ν, z)
 
-#SpecialFunctions.besselj0(z)
 function SpecialFunctions.besselj0(z::Union{ArbOrRef,AcbOrRef})
     res = zero(z)
     return hypgeom_bessel_j!(res, res, z)
 end
 
-#SpecialFunctions.besselj1(z)
 function SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef})
     res = one(z)
     return hypgeom_bessel_j!(res, res, z)
 end
 
 #SpecialFunctions.besseljx(nu,z)
-# Arb doesn't implement a scaled version
+# Not implemented by Arb
 
 #SpecialFunctions.sphericalbesselj(nu,z)
 # The general method implemented by SpecialFunctions is not completely
@@ -316,31 +316,27 @@ function SpecialFunctions.sphericalbesselj(ν::ArbOrRef, x::ArbOrRef)
     return mul!(res, factor, res)
 end
 
-#SpecialFunctions.bessely(nu,z)
 SpecialFunctions.bessely(ν::ArbOrRef, z::ArbOrRef) =
     hypgeom_bessel_y!(Arb(0, prec = _precision((ν, z))), ν, z)
 SpecialFunctions.bessely(ν::AcbOrRef, z::AcbOrRef) =
     hypgeom_bessel_y!(Acb(0, prec = _precision((ν, z))), ν, z)
 
-#SpecialFunctions.bessely0(z)
 function SpecialFunctions.bessely0(z::Union{ArbOrRef,AcbOrRef})
     res = zero(z)
     return hypgeom_bessel_y!(res, res, z)
 end
 
-#SpecialFunctions.bessely1(z)
 function SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef})
     res = one(z)
     return hypgeom_bessel_y!(res, res, z)
 end
 
 #SpecialFunctions.besselyx(nu,z)
-# Arb doesn't implement a scaled version
+# Not implemented by Arb
 
 #SpecialFunctions.sphericalbessely(nu,z)
 # Aliased to √((float(T))(π)/2x) * bessely(nu + one(nu)/2, x) which works fine
 
-#SpecialFunctions.besselh(nu,k,z)
 SpecialFunctions.besselh(ν::ArbOrRef, k::Integer, z::ArbOrRef) =
     SpecialFunctions.besselh(Acb(ν), k, Acb(z))
 function SpecialFunctions.besselh(ν::AcbOrRef, k::Integer, z::AcbOrRef)
@@ -356,6 +352,9 @@ function SpecialFunctions.besselh(ν::AcbOrRef, k::Integer, z::AcbOrRef)
     end
 end
 
+#SpecialFunctions.besselhx(nu,k,z)
+# Not implemented by Arb
+
 #SpecialFunctions.hankelh1(nu,z)
 # Aliased to besselh(nu, 1, z)
 
@@ -368,7 +367,6 @@ end
 #SpecialFunctions.hankelh2x(nu,z)
 # Aliased to besselhx(nu, 2, z)
 
-#SpecialFunctions.besseli(nu,z)
 SpecialFunctions.besseli(ν::ArbOrRef, z::ArbOrRef) =
     hypgeom_bessel_i!(Arb(prec = _precision((ν, z))), ν, z)
 SpecialFunctions.besseli(ν::AcbOrRef, z::AcbOrRef) =
@@ -378,13 +376,11 @@ SpecialFunctions.besseli(ν::AcbOrRef, z::AcbOrRef) =
 # The scaling used by Arb seems to be different from that used by
 # SpecialFunctions.
 
-#SpecialFunctions.besselk(nu,z)
 SpecialFunctions.besselk(ν::ArbOrRef, z::ArbOrRef) =
     hypgeom_bessel_k!(Arb(prec = _precision((ν, z))), ν, z)
 SpecialFunctions.besselk(ν::AcbOrRef, z::AcbOrRef) =
     hypgeom_bessel_k!(Acb(prec = _precision((ν, z))), ν, z)
 
-#SpecialFunctions.besselkx(nu,z)
 SpecialFunctions.besselkx(ν::ArbOrRef, z::ArbOrRef) =
     hypgeom_bessel_k_scaled!(Arb(prec = _precision((ν, z))), ν, z)
 SpecialFunctions.besselkx(ν::AcbOrRef, z::AcbOrRef) =
@@ -397,20 +393,16 @@ SpecialFunctions.besselkx(ν::AcbOrRef, z::AcbOrRef) =
 ## Elliptic Integrals
 ##
 
-#SpecialFunctions.ellipk(m)
 SpecialFunctions.ellipk(m::AcbOrRef) = elliptic_k!(zero(m), m)
 
-#SpecialFunctions.ellipe(m)
 SpecialFunctions.ellipe(m::AcbOrRef) = elliptic_e!(zero(m), m)
 
 ##
 ## Zeta and Related Functions
 ##
 
-#SpecialFunctions.eta(x)
 SpecialFunctions.eta(x::AcbOrRef) = dirichlet_eta!(zero(x), x)
 
-#SpecialFunctions.zeta(x)
 SpecialFunctions.zeta(s::Union{ArbOrRef,AcbOrRef}) = zeta!(zero(s), s)
 SpecialFunctions.zeta(s::ArbOrRef, z::ArbOrRef) =
     hurwitz_zeta!(Arb(prec = _precision((s, z))), s, z)

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -9,7 +9,8 @@ SpecialFunctions.digamma(x::Union{ArbOrRef,AcbOrRef}) = digamma!(zero(x), x)
 #SpecialFunctions.invdigamma(x)
 # Not implemented by Arb
 
-SpecialFunctions.trigamma(x::AcbOrRef) = polygamma(Acb(3, prec = precision(x)), x)
+SpecialFunctions.trigamma(x::AcbOrRef) =
+    SpecialFunctions.polygamma(Acb(1, prec = precision(x)), x)
 
 SpecialFunctions.polygamma(s::AcbOrRef, x::AcbOrRef) = polygamma!(zero(x), s, x)
 

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -1,25 +1,3 @@
-# TODO: How to handle scaled (or in some other way simply modified)
-# version not implemented by Arb? Should we just make a naive
-# implementation? The user might assume that they are optimized for
-# the scaled version, on the other hand the user will always get a
-# bound on the error so knows if more precision is needed. Discuss
-# with the developers of SpecialFunctions?
-
-# TODO: Which input to take precision from?
-
-# TODO: Should we handle promotion in any way? Would be better if
-# SpecialFunctions could handle this directly.
-
-# TODO: Some (which?) Arb functions are more general than those in
-# SpecialFunctions. How should we handle that?
-
-# TODO: I have not checked that the branch cuts are the same for
-# SpecialFunctions and Arb, I believe in most cases they are.
-
-# TODO: Should we add documentation for the methods which are not
-# identical to those in SpecialFunctions (which are these?)? Should we
-# just refer to Arbs documentation?
-
 ##
 ## Gamma Function
 ##
@@ -204,7 +182,8 @@ SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef}) =
 
 #SpecialFunctions.sphericalbesselj(nu,z)
 # The general method implemented by SpecialFunctions is not completely
-# rigorous since it makes a cutoff for small values
+# rigorous since it makes a cutoff for small values.
+# TODO: We could check for the special case x = 0
 SpecialFunctions.sphericalbesselj(ν::ArbOrRef, x::ArbOrRef) =
     sqrt(π / 2x) * SpecialFunctions.besselj(ν + 1 // 2, x)
 
@@ -224,6 +203,7 @@ SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef}) =
 # Arb doesn't implement a scaled version
 
 #SpecialFunctions.sphericalbessely(nu,z)
+# Aliased to √((float(T))(π)/2x) * bessely(nu + one(nu)/2, x) which works fine
 
 #SpecialFunctions.besselh(nu,k,z)
 SpecialFunctions.besselh(ν::ArbOrRef, k::Integer, z::ArbOrRef) =
@@ -290,6 +270,7 @@ SpecialFunctions.ellipe(m::AcbOrRef) = elliptic_e!(zero(m), m)
 #SpecialFunctions.eta(x)
 SpecialFunctions.eta(x::AcbOrRef) = dirichlet_eta!(zero(x), x)
 
+#SpecialFunctions.zeta(x)
 SpecialFunctions.zeta(s::Union{ArbOrRef,AcbOrRef}) = zeta!(zero(s), s)
 SpecialFunctions.zeta(s::ArbOrRef, z::ArbOrRef) = hurwitz_zeta!(zero(s), s, z)
 SpecialFunctions.zeta(s::AcbOrRef, z::AcbOrRef) = hurwitz_zeta!(zero(s), s, z)

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -31,21 +31,19 @@ SpecialFunctions.digamma(x::Union{ArbOrRef,AcbOrRef}) = digamma!(zero(x), x)
 #SpecialFunctions.invdigamma(x)
 # Not implemented by Arb
 
-SpecialFunctions.trigamma(x::AcbOrRef) =
-    polygamma(3one(x), x)
+SpecialFunctions.trigamma(x::AcbOrRef) = polygamma(Acb(3, prec = precision(x)), x)
 
-SpecialFunctions.polygamma(s::AcbOrRef, x::AcbOrRef) =
-    polygamma!(zero(x), s, x)
+SpecialFunctions.polygamma(s::AcbOrRef, x::AcbOrRef) = polygamma!(zero(x), s, x)
 
 function SpecialFunctions.gamma_inc(a::ArbOrRef, x::ArbOrRef)
     Γ = hypgeom_gamma_upper!(zero(x), a, x, 1)
     γ = 1 - Γ
-    return (Γ, γ)
+    return (γ, Γ)
 end
 function SpecialFunctions.gamma_inc(a::AcbOrRef, x::AcbOrRef)
     Γ = hypgeom_gamma_upper!(zero(x), a, x, 1)
     γ = 1 - Γ
-    return (Γ, γ)
+    return (γ, Γ)
 end
 
 #gamma_inc_inv(a, p, q)
@@ -63,8 +61,7 @@ function SpecialFunctions.beta_inc(a::AcbOrRef, b::AcbOrRef, x::AcbOrRef)
 end
 
 #loggamma(x)
-SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) =
-    lgamma!(zero(x), x)
+SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) = lgamma!(zero(x), x)
 
 #logabsgamma(x)
 # Not implemented by Arb
@@ -91,10 +88,8 @@ SpecialFunctions.loggamma(x::Union{ArbOrRef,AcbOrRef}) =
 # The version when ν is not specified could be defined directly, but
 # it would likely be better if it was defined in SpecialFunctions
 # directly.
-SpecialFunctions.expint(ν::ArbOrRef, x::ArbOrRef) =
-    hypgeom_expint!(zero(x), ν, x)
-SpecialFunctions.expint(ν::AcbOrRef, x::AcbOrRef) =
-    hypgeom_expint!(zero(x), ν, x)
+SpecialFunctions.expint(ν::ArbOrRef, x::ArbOrRef) = hypgeom_expint!(zero(x), ν, x)
+SpecialFunctions.expint(ν::AcbOrRef, x::AcbOrRef) = hypgeom_expint!(zero(x), ν, x)
 
 SpecialFunctions.expinti(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_ei!(zero(x), x)
 
@@ -113,7 +108,7 @@ SpecialFunctions.erf(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erf!(zero(x), x)
 #Not implemented by Arb
 
 #SpecialFunctions.erfc(x)
-SpecialFunctions.erfc(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erc!(zero(x), x)
+SpecialFunctions.erfc(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erfc!(zero(x), x)
 
 #SpecialFunctions.erfcinv(x)
 #Not implemented by Arb
@@ -193,16 +188,16 @@ end
 ##
 
 #SpecialFunctions.besselj(nu, z)
-SpecialFunctions.besselj(ν::ArbOrRef, z::ArbOrRef) =
-    hypgeom_bessel_j!(zero(z), ν, z)
-SpecialFunctions.besselj(ν::AcbOrRef, z::AcbOrRef) =
-    hypgeom_bessel_j!(zero(z), ν, z)
+SpecialFunctions.besselj(ν::ArbOrRef, z::ArbOrRef) = hypgeom_bessel_j!(zero(z), ν, z)
+SpecialFunctions.besselj(ν::AcbOrRef, z::AcbOrRef) = hypgeom_bessel_j!(zero(z), ν, z)
 
 #SpecialFunctions.besselj0(z)
-SpecialFunctions.besselj0(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_j!(zero(z), zero(z), z)
+SpecialFunctions.besselj0(z::Union{ArbOrRef,AcbOrRef}) =
+    hypgeom_bessel_j!(zero(z), zero(z), z)
 
 #SpecialFunctions.besselj1(z)
-SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_j!(zero(z), one(z), z)
+SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef}) =
+    hypgeom_bessel_j!(zero(z), one(z), z)
 
 #SpecialFunctions.besseljx(nu,z)
 # Arb doesn't implement a scaled version
@@ -210,19 +205,20 @@ SpecialFunctions.besselj1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_j!(zero(
 #SpecialFunctions.sphericalbesselj(nu,z)
 # The general method implemented by SpecialFunctions is not completely
 # rigorous since it makes a cutoff for small values
-sphericalbesselj(ν::ArbOrRef, x::ArbOrRef) = √((float(T))(π)/2x) * besselj(nu + one(nu)/2, x)
+SpecialFunctions.sphericalbesselj(ν::ArbOrRef, x::ArbOrRef) =
+    sqrt(π / 2x) * SpecialFunctions.besselj(ν + 1 // 2, x)
 
 #SpecialFunctions.bessely(nu,z)
-SpecialFunctions.bessely(ν::ArbOrRef, z::ArbOrRef) =
-    hypgeom_bessel_y!(zero(z), ν, z)
-SpecialFunctions.bessely(ν::AcbOrRef, z::AcbOrRef) =
-    hypgeom_bessel_y!(zero(z), ν, z)
+SpecialFunctions.bessely(ν::ArbOrRef, z::ArbOrRef) = hypgeom_bessel_y!(zero(z), ν, z)
+SpecialFunctions.bessely(ν::AcbOrRef, z::AcbOrRef) = hypgeom_bessel_y!(zero(z), ν, z)
 
 #SpecialFunctions.bessely0(z)
-SpecialFunctions.bessely0(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_y!(zero(z), zero(z), z)
+SpecialFunctions.bessely0(z::Union{ArbOrRef,AcbOrRef}) =
+    hypgeom_bessel_y!(zero(z), zero(z), z)
 
 #SpecialFunctions.bessely1(z)
-SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_y!(zero(z), one(z), z)
+SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef}) =
+    hypgeom_bessel_y!(zero(z), one(z), z)
 
 #SpecialFunctions.besselyx(nu,z)
 # Arb doesn't implement a scaled version
@@ -230,13 +226,15 @@ SpecialFunctions.bessely1(z::Union{ArbOrRef,AcbOrRef}) = hypgeom_bessel_y!(zero(
 #SpecialFunctions.sphericalbessely(nu,z)
 
 #SpecialFunctions.besselh(nu,k,z)
-function SpecialFunctions.besselh(ν::AcbOrRef, k, z::AcbOrRef)
-    J = zero(z), Y = zero(z)
+SpecialFunctions.besselh(ν::ArbOrRef, k::Integer, z::ArbOrRef) =
+    SpecialFunctions.besselh(Acb(ν), k, Acb(z))
+function SpecialFunctions.besselh(ν::AcbOrRef, k::Integer, z::AcbOrRef)
+    J, Y = zero(z), zero(z)
     hypgeom_bessel_jy!(J, Y, ν, z)
     if k == 1
-        return J + im*Y
+        return J + im * Y
     elseif k == 2
-        return J - im*Y
+        return J - im * Y
     else
         throw(SpecialFunctions.AmosException(1)) # This is what SpecialFunctions throw
     end
@@ -255,20 +253,16 @@ end
 # Aliased to besselhx(nu, 2, z)
 
 #SpecialFunctions.besseli(nu,z)
-SpecialFunctions.besseli(ν::ArbOrRef, z::ArbOrRef) =
-    hypgeom_bessel_i!(zero(z), ν, z)
-SpecialFunctions.besseli(ν::AcbOrRef, z::AcbOrRef) =
-    hypgeom_bessel_i!(zero(z), ν, z)
+SpecialFunctions.besseli(ν::ArbOrRef, z::ArbOrRef) = hypgeom_bessel_i!(zero(z), ν, z)
+SpecialFunctions.besseli(ν::AcbOrRef, z::AcbOrRef) = hypgeom_bessel_i!(zero(z), ν, z)
 
 #SpecialFunctions.besselix(nu,z)
 # The scaling used by Arb seems to be different from that used by
 # SpecialFunctions.
 
 #SpecialFunctions.besselk(nu,z)
-SpecialFunctions.besselk(ν::ArbOrRef, z::ArbOrRef) =
-    hypgeom_bessel_k!(zero(z), ν, z)
-SpecialFunctions.besselk(ν::AcbOrRef, z::AcbOrRef) =
-    hypgeom_bessel_k!(zero(z), ν, z)
+SpecialFunctions.besselk(ν::ArbOrRef, z::ArbOrRef) = hypgeom_bessel_k!(zero(z), ν, z)
+SpecialFunctions.besselk(ν::AcbOrRef, z::AcbOrRef) = hypgeom_bessel_k!(zero(z), ν, z)
 
 #SpecialFunctions.besselkx(nu,z)
 SpecialFunctions.besselkx(ν::ArbOrRef, z::ArbOrRef) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Arblib, Test, LinearAlgebra
+using Arblib, Test, LinearAlgebra, SpecialFunctions
 
 @testset "Arblib" begin
     include("arb_types-test.jl")
@@ -21,4 +21,5 @@ using Arblib, Test, LinearAlgebra
     include("ref-test.jl")
     include("poly.jl")
     include("series.jl")
+    include("special-functions.jl")
 end

--- a/test/special-functions.jl
+++ b/test/special-functions.jl
@@ -5,6 +5,11 @@
         @test gamma(Acb(2 + 2im)) ≈ gamma(2 + 2im)
         @test gamma(Acb(3 + 3im)) ≈ gamma(3 + 3im)
 
+        @test loggamma(Arb(2)) ≈ loggamma(2)
+        @test loggamma(Arb(3)) ≈ loggamma(3)
+        @test loggamma(Acb(2 + 2im)) ≈ loggamma(2 + 2im)
+        @test loggamma(Acb(3 + 3im)) ≈ loggamma(3 + 3im)
+
         @test digamma(Arb(2)) ≈ digamma(2)
         @test digamma(Arb(3)) ≈ digamma(3)
         @test digamma(Acb(2 + 2im)) ≈ digamma(2 + 2im)
@@ -16,6 +21,11 @@
         @test polygamma(Acb(2), Acb(3 + 3im)) ≈ polygamma(2, 3 + 3im)
         @test polygamma(Acb(3), Acb(4 + 4im)) ≈ polygamma(3, 4 + 4im)
 
+        @test gamma(Arb(2), Arb(3)) ≈ gamma(2, 3)
+        @test gamma(Arb(3), Arb(4)) ≈ gamma(3, 4)
+        @test gamma(Acb(2 + 2im), Acb(3 + 3im)) ≈ gamma(2 + 2im, 3 + 3im)
+        @test gamma(Acb(3 + 3im), Acb(4 + 4im)) ≈ gamma(3 + 3im, 4 + 4im)
+
         @test all(gamma_inc(Arb(2), Arb(3)) .≈ gamma_inc(2, 3))
         @test all(gamma_inc(Arb(3), Arb(4)) .≈ gamma_inc(3, 4))
         @test all(gamma_inc(Acb(2), Acb(3)) .≈ gamma_inc(2, 3))
@@ -24,11 +34,6 @@
         @test all(beta_inc(Arb(3), Arb(4), Arb(1 // 4)) .≈ beta_inc(3.0, 4.0, 0.25))
         @test all(beta_inc(Acb(2), Acb(3), Acb(1 // 2)) .≈ beta_inc(2.0, 3.0, 0.5))
         @test all(beta_inc(Acb(3), Acb(4), Acb(1 // 4)) .≈ beta_inc(3.0, 4.0, 0.25))
-
-        @test loggamma(Arb(2)) ≈ loggamma(2)
-        @test loggamma(Arb(3)) ≈ loggamma(3)
-        @test loggamma(Acb(2 + 2im)) ≈ loggamma(2 + 2im)
-        @test loggamma(Acb(3 + 3im)) ≈ loggamma(3 + 3im)
     end
 
     @testset "Trigonometric Integrals" begin
@@ -36,6 +41,11 @@
         @test expint(Arb(3), Arb(4)) ≈ expint(3, 4)
         @test expint(Acb(2 + 2im), Acb(3 + 3im)) ≈ expint(2 + 2im, 3 + 3im)
         @test expint(Acb(3 + 3im), Acb(4 + 4im)) ≈ expint(3 + 3im, 4 + 4im)
+
+        @test expint(Arb(2)) ≈ expint(2)
+        @test expint(Arb(3)) ≈ expint(3)
+        @test expint(Acb(2 + 2im)) ≈ expint(2 + 2im)
+        @test expint(Acb(3 + 3im)) ≈ expint(3 + 3im)
 
         @test expinti(Arb(2)) ≈ expinti(2)
         @test expinti(Arb(3)) ≈ expinti(3)

--- a/test/special-functions.jl
+++ b/test/special-functions.jl
@@ -10,6 +10,9 @@
         @test digamma(Acb(2 + 2im)) ≈ digamma(2 + 2im)
         @test digamma(Acb(3 + 3im)) ≈ digamma(3 + 3im)
 
+        @test trigamma(Acb(2 + 2im)) ≈ trigamma(2 + 2im)
+        @test trigamma(Acb(3 + 3im)) ≈ trigamma(3 + 3im)
+
         @test polygamma(Acb(2), Acb(3 + 3im)) ≈ polygamma(2, 3 + 3im)
         @test polygamma(Acb(3), Acb(4 + 4im)) ≈ polygamma(3, 4 + 4im)
 

--- a/test/special-functions.jl
+++ b/test/special-functions.jl
@@ -1,0 +1,173 @@
+@testset "Special Functions" begin
+    @testset "Gamma Function" begin
+        @test gamma(Arb(2)) ≈ gamma(2)
+        @test gamma(Arb(3)) ≈ gamma(3)
+        @test gamma(Acb(2 + 2im)) ≈ gamma(2 + 2im)
+        @test gamma(Acb(3 + 3im)) ≈ gamma(3 + 3im)
+
+        @test digamma(Arb(2)) ≈ digamma(2)
+        @test digamma(Arb(3)) ≈ digamma(3)
+        @test digamma(Acb(2 + 2im)) ≈ digamma(2 + 2im)
+        @test digamma(Acb(3 + 3im)) ≈ digamma(3 + 3im)
+
+        @test polygamma(Acb(2), Acb(3 + 3im)) ≈ polygamma(2, 3 + 3im)
+        @test polygamma(Acb(3), Acb(4 + 4im)) ≈ polygamma(3, 4 + 4im)
+
+        @test all(gamma_inc(Arb(2), Arb(3)) .≈ gamma_inc(2, 3))
+        @test all(gamma_inc(Arb(3), Arb(4)) .≈ gamma_inc(3, 4))
+        @test all(gamma_inc(Acb(2), Acb(3)) .≈ gamma_inc(2, 3))
+
+        @test all(beta_inc(Arb(2), Arb(3), Arb(1 // 2)) .≈ beta_inc(2.0, 3.0, 0.5))
+        @test all(beta_inc(Arb(3), Arb(4), Arb(1 // 4)) .≈ beta_inc(3.0, 4.0, 0.25))
+        @test all(beta_inc(Acb(2), Acb(3), Acb(1 // 2)) .≈ beta_inc(2.0, 3.0, 0.5))
+        @test all(beta_inc(Acb(3), Acb(4), Acb(1 // 4)) .≈ beta_inc(3.0, 4.0, 0.25))
+
+        @test loggamma(Arb(2)) ≈ loggamma(2)
+        @test loggamma(Arb(3)) ≈ loggamma(3)
+        @test loggamma(Acb(2 + 2im)) ≈ loggamma(2 + 2im)
+        @test loggamma(Acb(3 + 3im)) ≈ loggamma(3 + 3im)
+    end
+
+    @testset "Trigonometric Integrals" begin
+        @test expint(Arb(2), Arb(3)) ≈ expint(2, 3)
+        @test expint(Arb(3), Arb(4)) ≈ expint(3, 4)
+        @test expint(Acb(2 + 2im), Acb(3 + 3im)) ≈ expint(2 + 2im, 3 + 3im)
+        @test expint(Acb(3 + 3im), Acb(4 + 4im)) ≈ expint(3 + 3im, 4 + 4im)
+
+        @test expinti(Arb(2)) ≈ expinti(2)
+        @test expinti(Arb(3)) ≈ expinti(3)
+        @test expinti(Acb(2)) ≈ expinti(2)
+        @test expinti(Acb(3)) ≈ expinti(3)
+
+        @test sinint(Arb(2)) ≈ sinint(2)
+        @test sinint(Arb(3)) ≈ sinint(3)
+        @test sinint(Acb(2)) ≈ sinint(2)
+        @test sinint(Acb(3)) ≈ sinint(3)
+
+        @test cosint(Arb(2)) ≈ cosint(2)
+        @test cosint(Arb(3)) ≈ cosint(3)
+        @test cosint(Acb(2)) ≈ cosint(2)
+        @test cosint(Acb(3)) ≈ cosint(3)
+    end
+
+    @testset "Error Functions" begin
+        @test erf(Arb(2)) ≈ erf(2)
+        @test erf(Arb(3)) ≈ erf(3)
+        @test erf(Acb(2 + 2im)) ≈ erf(2 + 2im)
+        @test erf(Acb(3 + 3im)) ≈ erf(3 + 3im)
+
+        @test erfc(Arb(2)) ≈ erfc(2)
+        @test erfc(Arb(3)) ≈ erfc(3)
+        @test erfc(Acb(2 + 2im)) ≈ erfc(2 + 2im)
+        @test erfc(Acb(3 + 3im)) ≈ erfc(3 + 3im)
+    end
+
+    @testset "Airy Functions" begin
+        @test airyai(Arb(2)) ≈ airyai(2)
+        @test airyai(Arb(3)) ≈ airyai(3)
+        @test airyai(Acb(2 + 2im)) ≈ airyai(2 + 2im)
+        @test airyai(Acb(3 + 3im)) ≈ airyai(3 + 3im)
+
+        @test airyaiprime(Arb(2)) ≈ airyaiprime(2)
+        @test airyaiprime(Arb(3)) ≈ airyaiprime(3)
+        @test airyaiprime(Acb(2 + 2im)) ≈ airyaiprime(2 + 2im)
+        @test airyaiprime(Acb(3 + 3im)) ≈ airyaiprime(3 + 3im)
+
+        @test airybi(Arb(2)) ≈ airybi(2)
+        @test airybi(Arb(3)) ≈ airybi(3)
+        @test airybi(Acb(2 + 2im)) ≈ airybi(2 + 2im)
+        @test airybi(Acb(3 + 3im)) ≈ airybi(3 + 3im)
+
+        @test airybiprime(Arb(2)) ≈ airybiprime(2)
+        @test airybiprime(Arb(3)) ≈ airybiprime(3)
+        @test airybiprime(Acb(2 + 2im)) ≈ airybiprime(2 + 2im)
+        @test airybiprime(Acb(3 + 3im)) ≈ airybiprime(3 + 3im)
+    end
+
+    @testset "Bessel Functions" begin
+        @test besselj(Arb(2), Arb(3)) ≈ besselj(2, 3)
+        @test besselj(Arb(3), Arb(4)) ≈ besselj(3, 4)
+        @test besselj(Acb(2), Acb(3 + 3im)) ≈ besselj(2, 3 + 3im)
+        @test besselj(Acb(3), Acb(4 + 4im)) ≈ besselj(3, 4 + 4im)
+
+        @test besselj0(Arb(2)) ≈ besselj0(2)
+        @test besselj0(Arb(3)) ≈ besselj0(3)
+        @test besselj0(Acb(2 + 2im)) ≈ besselj0(2 + 2im)
+        @test besselj0(Acb(3 + 3im)) ≈ besselj0(3 + 3im)
+
+        @test besselj1(Arb(2)) ≈ besselj1(2)
+        @test besselj1(Arb(3)) ≈ besselj1(3)
+        @test besselj1(Acb(2 + 2im)) ≈ besselj1(2 + 2im)
+        @test besselj1(Acb(3 + 3im)) ≈ besselj1(3 + 3im)
+
+        @test sphericalbesselj(Arb(2), Arb(3)) ≈ sphericalbesselj(2, 3)
+        @test sphericalbesselj(Arb(3), Arb(4)) ≈ sphericalbesselj(3, 4)
+
+        @test bessely(Arb(2), Arb(3)) ≈ bessely(2, 3)
+        @test bessely(Arb(3), Arb(4)) ≈ bessely(3, 4)
+        @test bessely(Acb(2), Acb(3 + 3im)) ≈ bessely(2, 3 + 3im)
+        @test bessely(Acb(3), Acb(4 + 4im)) ≈ bessely(3, 4 + 4im)
+
+        @test bessely0(Arb(2)) ≈ bessely0(2)
+        @test bessely0(Arb(3)) ≈ bessely0(3)
+        @test bessely0(Acb(2 + 2im)) ≈ bessely0(2 + 2im)
+        @test bessely0(Acb(3 + 3im)) ≈ bessely0(3 + 3im)
+
+        @test bessely1(Arb(2)) ≈ bessely1(2)
+        @test bessely1(Arb(3)) ≈ bessely1(3)
+        @test bessely1(Acb(2 + 2im)) ≈ bessely1(2 + 2im)
+        @test bessely1(Acb(3 + 3im)) ≈ bessely1(3 + 3im)
+
+        @test besselh(Arb(2), Arb(3)) ≈ besselh(2, 3)
+        @test besselh(Arb(3), Arb(4)) ≈ besselh(3, 4)
+        @test besselh(Acb(2), Acb(3)) ≈ besselh(2, 3)
+        @test besselh(Acb(3), Acb(4)) ≈ besselh(3, 4)
+        @test besselh(Arb(2), 1, Arb(3)) ≈ besselh(2, 1, 3)
+        @test besselh(Arb(3), 1, Arb(4)) ≈ besselh(3, 1, 4)
+        @test besselh(Acb(2), 1, Acb(3)) ≈ besselh(2, 1, 3)
+        @test besselh(Acb(3), 1, Acb(4)) ≈ besselh(3, 1, 4)
+        @test besselh(Arb(2), 2, Arb(3)) ≈ besselh(2, 2, 3)
+        @test besselh(Arb(3), 2, Arb(4)) ≈ besselh(3, 2, 4)
+        @test besselh(Acb(2), 2, Acb(3)) ≈ besselh(2, 2, 3)
+        @test besselh(Acb(3), 2, Acb(4)) ≈ besselh(3, 2, 4)
+        @test_throws SpecialFunctions.AmosException(1) besselh(Arb(2), 3, Arb(3))
+        @test_throws SpecialFunctions.AmosException(1) besselh(Acb(2), 3, Acb(3))
+
+        @test besseli(Arb(2), Arb(3)) ≈ besseli(2, 3)
+        @test besseli(Arb(3), Arb(4)) ≈ besseli(3, 4)
+        @test besseli(Acb(2), Acb(3 + 3im)) ≈ besseli(2, 3 + 3im)
+        @test besseli(Acb(3), Acb(4 + 4im)) ≈ besseli(3, 4 + 4im)
+
+        @test besselk(Arb(2), Arb(3)) ≈ besselk(2, 3)
+        @test besselk(Arb(3), Arb(4)) ≈ besselk(3, 4)
+        @test besselk(Acb(2), Acb(3 + 3im)) ≈ besselk(2, 3 + 3im)
+        @test besselk(Acb(3), Acb(4 + 4im)) ≈ besselk(3, 4 + 4im)
+
+        @test besselkx(Arb(2), Arb(3)) ≈ besselkx(2, 3)
+        @test besselkx(Arb(3), Arb(4)) ≈ besselkx(3, 4)
+        @test besselkx(Acb(2), Acb(3 + 3im)) ≈ besselkx(2, 3 + 3im)
+        @test besselkx(Acb(3), Acb(4 + 4im)) ≈ besselkx(3, 4 + 4im)
+    end
+
+    @testset "Elliptic Integrals" begin
+        @test ellipk(Acb(-1)) ≈ ellipk(-1)
+        @test ellipk(Acb(-2)) ≈ ellipk(-2)
+
+        @test ellipe(Acb(-1)) ≈ ellipe(-1)
+        @test ellipe(Acb(-2)) ≈ ellipe(-2)
+    end
+
+    @testset "Zeta Functions" begin
+        @test eta(Acb(2 + 2im)) ≈ eta(2 + 2im)
+        @test eta(Acb(3 + 3im)) ≈ eta(3 + 3im)
+
+        @test zeta(Arb(2)) ≈ zeta(2)
+        @test zeta(Arb(3)) ≈ zeta(3)
+        @test zeta(Acb(2 + 2im)) ≈ zeta(2 + 2im)
+        @test zeta(Acb(3 + 3im)) ≈ zeta(3 + 3im)
+        @test zeta(Arb(2), Arb(3)) ≈ zeta(2, 3)
+        @test zeta(Arb(3), Arb(4)) ≈ zeta(3, 4)
+        @test zeta(Acb(2 + 2im), Acb(3 + 3im)) ≈ zeta(2 + 2im, 3 + 3im)
+        @test zeta(Acb(3 + 3im), Acb(4 + 4im)) ≈ zeta(3 + 3im, 4 + 4im)
+    end
+end


### PR DESCRIPTION
I have added an interface to [SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl/). All of the code is in `special-functions.jl` where I have written down all the special functions implemented by `SpecialFunction`. For each one I have either given a corresponding Arb implementation or written a small comment about why that one is not handled. Some thinks I though about when doing this:

- How to handle scaled version not implemented by Arb? Should we just make a naive implementation or skip it? If we do implement them the user might assume that they are optimized for the scaled version, on the other hand the user will always get a bound on the error so knows if more precision is needed. If you write generic code with the scaled version it would be nice if it just worked. Maybe we should talk to the developers of `SpecialFunctions` about implementing fallback versions for generic scaled functions?
- Many of the functions take more than one argument, which one should we take the precision from? In most other cases we have taken the maximum of all the inputs so I guess that makes sense here as well? The current implementation doesn't take this into account.
- Should we handle promotion in any way? It would probably be better if this was implemented in `SpecialFunctions` directly.
- Some (which?) Arb functions are more general than those in `SpecialFunctions`. How should we handle that?
- I have not checked that the branch cuts are the same for `SpecialFunctions` and Arb, I believe in most cases they are. 
- Should we add documentation for the methods which are not identical to those in SpecialFunctions (which are these?)? Should we just refer to Arbs documentation?

Do you have any thoughts about these?
