### PR TITLE
Add methods related to intervals

### DIFF
--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -54,6 +54,7 @@ include("promotion.jl")
 include("arithmetic.jl")
 include("rand.jl")
 include("float.jl")
+include("interval.jl")
 
 include("ref.jl")
 include("vector.jl")

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -88,7 +88,7 @@ end
 abs_ubound(x::Union{ArbOrRef,AcbOrRef}) = abs_ubound(Arf, x)
 
 """
-    getinterval([T, ] x::Union{ArbOrRef,AcbOrRef})
+    getinterval([T, ] x::ArbOrRef)
 
 Returns a tuple `(l, u)` representing an interval `[l, u]` enclosing
 the ball `x`, both of them are of type `Arf`. If `T` is given convert
@@ -114,11 +114,11 @@ end
 getinterval(x::ArbOrRef) = getinterval(Arf, x)
 
 """
-    getinterval([T, ] x::Union{ArbOrRef,AcbOrRef})
+    getball([T, ] x::ArbOrRef)
 
-Returns a tuple `(m, r)` where `m` is the midpoint of the ball and `r`
-is the radius, `m` is of type `Arf` and `r` of type `Mag`. If `T` is
-given convert both `m` and `r` to this type, supports `Arb`.
+Returns a tuple `(m::Arf, r::Mag)` where `m` is the midpoint of the
+ball and `r` is the radius. If `T` is given convert both `m` and `r`
+to this type, supports `Arb`.
 """
 getball(x::ArbOrRef) = (Arf(midref(x)), Mag(radref(x)))
 getball(::Type{Arb}, x::ArbOrRef) = (Arb(midref(x)), Arb(radref(x), prec = precision(x)))
@@ -132,7 +132,6 @@ getball(::Type{Arb}, x::ArbOrRef) = (Arb(midref(x)), Arb(radref(x), prec = preci
 
 `union(x, y, z...)` returns a ball containing the union of all given
 balls.
-
 """
 Base.union(x::ArbOrRef, y::ArbOrRef) = union!(Arb(prec = _precision((x, y))), x, y)
 Base.union(x::AcbOrRef, y::AcbOrRef) = union!(Acb(prec = _precision((x, y))), x, y)

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -1,5 +1,4 @@
-export radius,
-    midpoint, lbound, ubound, abs_lbound, abs_ubound, getinterval, getball, intersection
+export radius, midpoint, lbound, ubound, abs_lbound, abs_ubound, getinterval, getball
 
 """
     radius([T, ] x::ArbOrRef)
@@ -144,19 +143,19 @@ Base.union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...) =
     foldl(union, xs, init = union(union(x, y), z))
 
 """
-    intersection(x::ArbOrRef, y::ArbOrRef)
-    intersection(x::AcbOrRef, y::AcbOrRef)
-    intersection(x, y, z...)
+    intersect(x::ArbOrRef, y::ArbOrRef)
+    intersect(x::AcbOrRef, y::AcbOrRef)
+    intersect(x, y, z...)
 
-`intersection(x, y)` returns a ball containing the intersection of `x`
+`intersect(x, y)` returns a ball containing the intersection of `x`
 and `y`. If `x` and `y` do not overlap (as given by `overlaps(a, b)`)
 throws an `ArgumentError`.
 
-`intersection(x, y, z...)` returns a ball containing the intersection of
+`intersect(x, y, z...)` returns a ball containing the intersection of
 all given balls. If all the balls do not overlap throws an
 `ArgumentError`.
 """
-function intersection(x::ArbOrRef, y::ArbOrRef)
+function Base.intersect(x::ArbOrRef, y::ArbOrRef)
     overlaps(x, y) ||
         throw(ArgumentError("intersection of non-intersecting balls not allowed"))
     res = Arb(prec = _precision((x, y)))
@@ -164,5 +163,5 @@ function intersection(x::ArbOrRef, y::ArbOrRef)
     return res
 end
 # TODO: Could be optimized, both for performance and enclosure
-intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
-    foldl(intersection, xs, init = intersection(intersection(x, y), z))
+Base.intersect(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
+    foldl(intersect, xs, init = intersect(intersect(x, y), z))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -1,0 +1,168 @@
+export radius,
+    midpoint, lbound, ubound, abs_lbound, abs_ubound, getinterval, getball, intersection
+
+"""
+    radius([T, ] x::ArbOrRef)
+
+Returns the radius of `x` as a `Mag`. If `T` is given convert to this
+type, supports `Mag`, `Arf` and `Arb`.
+"""
+radius(::Type{Mag}, x::ArbOrRef) = Mag(radref(x))
+radius(::Type{Arf}, x::ArbOrRef) = Arf(radref(x), prec = precision(x))
+radius(::Type{Arb}, x::ArbOrRef) = Arb(radref(x), prec = precision(x))
+radius(x::ArbOrRef) = radius(Mag, x)
+
+"""
+    midpoint([T, ] x::ArbOrRef)
+
+Returns the midpoint of `x` as an `Arf`. If `T` is given convert to this
+type, supports `Arf` and `Arb`.
+"""
+midpoint(::Type{Arf}, x::ArbOrRef) = Arf(midref(x))
+midpoint(::Type{Arb}, x::ArbOrRef) = Arb(midref(x))
+midpoint(x::ArbOrRef) = midpoint(Arf, x)
+
+"""
+    lbound([T, ] x::ArbOrRef)
+
+Returns a lower bound of `x` as an `Arf`. If `T` is given convert to
+this type, supports `Arf` and `Arb`.
+
+If `x` contains `NaN` it returns `NaN`.
+"""
+lbound(::Type{Arf}, x::ArbOrRef) = get_lbound!(Arf(prec = precision(x)), x)
+function lbound(::Type{Arb}, x::ArbOrRef)
+    res = zero(x)
+    get_lbound!(midref(res), x)
+    return res
+end
+lbound(x::ArbOrRef) = lbound(Arf, x)
+
+"""
+    ubound([T, ] x::ArbOrRef)
+
+Returns an upper bound of `x` as an `Arf`. If `T` is given convert to
+this type, supports `Arf` and `Arb`.
+
+If `x` contains `NaN` it returns `NaN`.
+"""
+ubound(::Type{Arf}, x::ArbOrRef) = get_ubound!(Arf(prec = precision(x)), x)
+function ubound(::Type{Arb}, x::ArbOrRef)
+    res = zero(x)
+    get_ubound!(midref(res), x)
+    return res
+end
+ubound(x::ArbOrRef) = ubound(Arf, x)
+
+"""
+    abs_lbound([T, ] x::Union{ArbOrRef,AcbOrRef})
+
+Returns a lower bound of `abs(x)` as an `Arf`. If `T` is given convert
+to this type, supports `Arf` and `Arb`.
+
+If `x` contains `NaN` it returns `NaN`.
+"""
+abs_lbound(::Type{Arf}, x::Union{ArbOrRef,AcbOrRef}) =
+    get_abs_lbound!(Arf(prec = precision(x)), x)
+function abs_lbound(::Type{Arb}, x::Union{ArbOrRef,AcbOrRef})
+    res = Arb(prec = precision(x))
+    get_abs_lbound!(midref(res), x)
+    return res
+end
+abs_lbound(x::Union{ArbOrRef,AcbOrRef}) = abs_lbound(Arf, x)
+
+"""
+    abs_ubound([T, ] x::Union{ArbOrRef,AcbOrRef})
+
+Returns an upper bound of `abs(x)` as an `Arf`. If `T` is given
+convert to this type, supports `Arf` and `Arb`.
+
+If `x` contains `NaN` it returns `NaN`.
+"""
+abs_ubound(::Type{Arf}, x::Union{ArbOrRef,AcbOrRef}) =
+    get_abs_ubound!(Arf(prec = precision(x)), x)
+function abs_ubound(::Type{Arb}, x::Union{ArbOrRef,AcbOrRef})
+    res = Arb(prec = precision(x))
+    get_abs_ubound!(midref(res), x)
+    return res
+end
+abs_ubound(x::Union{ArbOrRef,AcbOrRef}) = abs_ubound(Arf, x)
+
+"""
+    getinterval([T, ] x::Union{ArbOrRef,AcbOrRef})
+
+Returns a tuple `(l, u)` representing an interval `[l, u]` enclosing
+the ball `x`, both of them are of type `Arf`. If `T` is given convert
+to this type, supports `Arf`, `BigFloat` and `Arb`.
+
+If `x` contains `NaN` both `l` and `u` will be `NaN`.
+"""
+function getinterval(::Type{Arf}, x::ArbOrRef)
+    l, u = Arf(prec = precision(x)), Arf(prec = precision(x))
+    get_interval!(l, u, x)
+    return (l, u)
+end
+function getinterval(::Type{BigFloat}, x::ArbOrRef)
+    l, u = BigFloat(precision = precision(x)), BigFloat(precision = precision(x))
+    get_interval!(l, u, x)
+    return (l, u)
+end
+function getinterval(::Type{Arb}, x::ArbOrRef)
+    l, u = zero(x), zero(x)
+    get_interval!(midref(l), midref(u), x)
+    return (l, u)
+end
+getinterval(x::ArbOrRef) = getinterval(Arf, x)
+
+"""
+    getinterval([T, ] x::Union{ArbOrRef,AcbOrRef})
+
+Returns a tuple `(m, r)` where `m` is the midpoint of the ball and `r`
+is the radius, `m` is of type `Arf` and `r` of type `Mag`. If `T` is
+given convert both `m` and `r` to this type, supports `Arb`.
+"""
+getball(x::ArbOrRef) = (Arf(midref(x)), Mag(radref(x)))
+getball(::Type{Arb}, x::ArbOrRef) = (Arb(midref(x)), Arb(radref(x), prec = precision(x)))
+
+"""
+    union(x::ArbOrRef, y::ArbOrRef)
+    union(x::AcbOrRef, y::AcbOrRef)
+    union(x, y, z...)
+
+`union(x, y)` returns a ball containing the union of `x` and `y`.
+
+`union(x, y, z...)` returns a ball containing the union of all given
+balls.
+
+"""
+Base.union(x::ArbOrRef, y::ArbOrRef) = union!(Arb(prec = _precision((x, y))), x, y)
+Base.union(x::AcbOrRef, y::AcbOrRef) = union!(Acb(prec = _precision((x, y))), x, y)
+# TODO: Could be optimized, both for performance and enclosure
+Base.union(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
+    foldl(union, xs, init = union(union(x, y), z))
+Base.union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...) =
+    foldl(union, xs, init = union(union(x, y), z))
+
+"""
+    intersection(x::ArbOrRef, y::ArbOrRef)
+    intersection(x::AcbOrRef, y::AcbOrRef)
+    intersection(x, y, z...)
+
+`intersection(x, y)` returns a ball containing the intersection of `x`
+and `y`. If `x` and `y` do not overlap (as given by `overlaps(a, b)`)
+throws an `ArgumentError`.
+
+`intersection(x, y, z...)` returns a ball containing the intersection of
+all given balls. If all the balls do not overlap throws an
+`ArgumentError`.
+"""
+function intersection(x::ArbOrRef, y::ArbOrRef)
+    overlaps(x, y) ||
+        throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+    res = Arb(prec = _precision((x, y)))
+    intersection!(res, x, y)
+    return res
+end
+# TODO: Could be optimized, both for performance and enclosure
+intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
+    foldl(intersection, xs, init = intersection(intersection(x, y), z))

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,0 +1,212 @@
+@testset "interval" begin
+    # TODO: Remove this once we decide what to export
+    import Arblib:
+        radius,
+        midpoint,
+        lbound,
+        ubound,
+        abs_lbound,
+        abs_ubound,
+        getinterval,
+        getball,
+        intersection
+    # TODO: Add test checking precision is preserved
+
+    @testset "radius" begin
+        x = Arb(2)
+        y = Arb(2)
+        Arblib.set!(Arblib.radref(y), one(Mag))
+
+        @test radius(x) == radius(Mag, x) == radius(Arf, x) == radius(Arb, x) == zero(Mag)
+        @test radius(y) == radius(Mag, y) == radius(Arf, y) == radius(Arb, y) == one(Mag)
+
+        @test radius(x) isa Mag
+        @test radius(Mag, x) isa Mag
+        @test radius(Arf, x) isa Arf
+        @test radius(Arb, x) isa Arb
+
+        @test precision(radius(Arf, Arb(prec = 80))) == 80
+        @test precision(radius(Arb, Arb(prec = 80))) == 80
+    end
+
+    @testset "midpoint" begin
+        x = zero(Arb)
+        y = one(Arb)
+
+        @test midpoint(x) == midpoint(Arf, x) == midpoint(Arb, x) == zero(Arf)
+        @test midpoint(y) == midpoint(Arf, y) == midpoint(Arb, y) == one(Arf)
+        @test midpoint(x) isa Arf
+        @test midpoint(Arf, x) isa Arf
+        @test midpoint(Arb, x) isa Arb
+
+        @test precision(midpoint(Arb(prec = 80))) == 80
+        @test precision(midpoint(Arf, Arb(prec = 80))) == 80
+        @test precision(midpoint(Arb, Arb(prec = 80))) == 80
+    end
+
+    @testset "lbound/ubound" begin
+        x = Arb(2)
+        y = Arb(0)
+        Arblib.set!(Arblib.radref(y), 1)
+
+        @test lbound(x) == lbound(Arf, x) == lbound(Arb, x) == Arf(2)
+        @test lbound(y) == lbound(Arf, y) == lbound(Arb, y) == Arf(-1)
+        @test ubound(x) == ubound(Arf, x) == ubound(Arb, x) == Arf(2)
+        @test ubound(y) == ubound(Arf, y) == ubound(Arb, y) == Arf(1)
+
+        @test typeof(lbound(x)) == typeof(ubound(x)) == Arf
+        @test typeof(lbound(Arf, x)) == typeof(ubound(Arf, x)) == Arf
+        @test typeof(lbound(Arb, x)) == typeof(ubound(Arb, x)) == Arb
+
+        @test precision(lbound(Arb(prec = 80))) == 80
+        @test precision(lbound(Arf, Arb(prec = 80))) == 80
+        @test precision(lbound(Arb, Arb(prec = 80))) == 80
+        @test precision(ubound(Arb(prec = 80))) == 80
+        @test precision(ubound(Arf, Arb(prec = 80))) == 80
+        @test precision(ubound(Arb, Arb(prec = 80))) == 80
+    end
+
+    @testset "abs_lbound/abs_ubound" begin
+        x = Arb(-2)
+        y = Arb(1)
+        Arblib.set!(Arblib.radref(x), 1)
+        Arblib.set!(Arblib.radref(y), 2)
+        xc = Acb(0, x)
+        yc = Acb(0, y)
+
+        @test abs_lbound(x) ==
+              abs_lbound(Arf, x) ==
+              abs_lbound(Arb, x) ==
+              abs_lbound(xc) ==
+              abs_lbound(Arf, xc) ==
+              abs_lbound(Arb, xc) ==
+              Arf(1)
+        @test abs_lbound(y) ==
+              abs_lbound(Arf, y) ==
+              abs_lbound(Arb, y) ==
+              abs_lbound(yc) ==
+              abs_lbound(Arf, yc) ==
+              abs_lbound(Arb, yc) ==
+              Arf(0)
+        @test abs_ubound(x) ==
+              abs_ubound(Arf, x) ==
+              abs_ubound(Arb, x) ==
+              abs_ubound(xc) ==
+              abs_ubound(Arf, xc) ==
+              abs_ubound(Arb, xc) ==
+              Arf(3)
+        @test abs_ubound(y) ==
+              abs_ubound(Arf, y) ==
+              abs_ubound(Arb, y) ==
+              abs_ubound(yc) ==
+              abs_ubound(Arf, yc) ==
+              abs_ubound(Arb, yc) ==
+              Arf(3)
+
+        @test typeof(abs_lbound(x)) ==
+              typeof(abs_ubound(x)) ==
+              typeof(abs_lbound(xc)) ==
+              typeof(abs_ubound(xc)) ==
+              Arf
+        @test typeof(abs_lbound(Arf, x)) ==
+              typeof(abs_ubound(Arf, x)) ==
+              typeof(abs_lbound(Arf, xc)) ==
+              typeof(abs_ubound(Arf, xc)) ==
+              Arf
+        @test typeof(abs_lbound(Arb, x)) ==
+              typeof(abs_ubound(Arb, x)) ==
+              typeof(abs_lbound(Arb, xc)) ==
+              typeof(abs_ubound(Arb, xc)) ==
+              Arb
+
+        @test precision(abs_lbound(Arb(prec = 80))) ==
+              precision(abs_lbound(Acb(prec = 80))) ==
+              80
+        @test precision(abs_lbound(Arf, Arb(prec = 80))) ==
+              precision(abs_lbound(Arf, Acb(prec = 80))) ==
+              80
+        @test precision(abs_lbound(Arb, Arb(prec = 80))) ==
+              precision(abs_lbound(Arb, Acb(prec = 80))) ==
+              80
+        @test precision(abs_ubound(Arb(prec = 80))) ==
+              precision(abs_ubound(Acb(prec = 80))) ==
+              80
+        @test precision(abs_ubound(Arf, Arb(prec = 80))) ==
+              precision(abs_ubound(Arf, Acb(prec = 80))) ==
+              80
+        @test precision(abs_ubound(Arb, Arb(prec = 80))) ==
+              precision(abs_ubound(Arb, Acb(prec = 80))) ==
+              80
+    end
+
+    @testset "getinterval" begin
+        x = one(Arb)
+        y = one(Arb)
+        Arblib.set!(Arblib.radref(y), 1)
+
+        @test getinterval(x) ==
+              getinterval(Arf, x) ==
+              getinterval(BigFloat, x) ==
+              getinterval(Arb, x) ==
+              (one(Arf), one(Arf))
+        @test getinterval(y) ==
+              getinterval(Arf, y) ==
+              getinterval(BigFloat, y) ==
+              getinterval(Arb, y) ==
+              (Arf(0), Arf(2))
+
+        @test getinterval(x) isa NTuple{2,Arf}
+        @test getinterval(Arf, x) isa NTuple{2,Arf}
+        @test getinterval(BigFloat, x) isa NTuple{2,BigFloat}
+        @test getinterval(Arb, x) isa NTuple{2,Arb}
+
+        @test precision.(getinterval(Arb(prec = 80))) == (80, 80)
+        @test precision.(getinterval(Arf, Arb(prec = 80))) == (80, 80)
+        @test precision.(getinterval(BigFloat, Arb(prec = 80))) == (80, 80)
+        @test precision.(getinterval(Arb, Arb(prec = 80))) == (80, 80)
+    end
+
+    @testset "getball" begin
+        x = one(Arb)
+        y = one(Arb)
+        Arblib.set!(Arblib.radref(y), 1)
+
+        @test getball(x) == getball(Arb, x) == (one(Arf), zero(Mag))
+        @test getball(y) == getball(Arb, y) == (one(Arf), one(Mag))
+
+        @test getball(x) isa Tuple{Arf,Mag}
+        @test getball(Arb, x) isa Tuple{Arb,Arb}
+
+        @test precision(getball(Arb(prec = 80))[1]) == 80
+        @test precision.(getball(Arb, Arb(prec = 80))) == (80, 80)
+    end
+
+    @testset "union" begin
+        xs = [Arb(i) for i in vcat(1:10, 10:-1:1)]
+        xsc = Acb.(xs)
+
+        @test contains(union(zero(Arb), one(Arb)), Arb(0.5))
+        @test contains(union(zero(Acb), Acb(1, 1)), Acb(0.5, 0.5))
+        @test all(i -> contains(union(xs...), i), 1:10)
+        @test all(i -> contains(union(xsc...), i), Acb.(1:10))
+
+        @test precision(union(Arb(prec = 80), Arb(prec = 90))) == 90
+        @test precision(union(Acb(prec = 80), Acb(prec = 90))) == 90
+        @test precision(union([Arb(prec = p) for p = 70:10:100]...)) == 100
+        @test precision(union([Acb(prec = p) for p = 70:10:100]...)) == 100
+    end
+
+    @testset "intersection" begin
+        xs = [Arb((0, i)) for i in vcat(1:10, 10:-1:1)]
+
+        @test contains(intersection(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
+        @test contains(intersection(xs...), Arb((0, 1)))
+        @test !contains(intersection(xs...), Arb(2))
+
+        @test precision(intersection(Arb(prec = 80), Arb(prec = 90))) == 90
+        @test precision(intersection([Arb(prec = p) for p = 70:10:100]...)) == 100
+
+        @test_throws ArgumentError Arblib.intersection(Arb(1), Arb(2))
+        @test_throws ArgumentError Arblib.intersection([xs; Arb(2)]...)
+    end
+end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -196,17 +196,17 @@
         @test precision(union([Acb(prec = p) for p = 70:10:100]...)) == 100
     end
 
-    @testset "intersection" begin
+    @testset "intersect" begin
         xs = [Arb((0, i)) for i in vcat(1:10, 10:-1:1)]
 
-        @test contains(intersection(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
-        @test contains(intersection(xs...), Arb((0, 1)))
-        @test !contains(intersection(xs...), Arb(2))
+        @test contains(intersect(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
+        @test contains(intersect(xs...), Arb((0, 1)))
+        @test !contains(intersect(xs...), Arb(2))
 
-        @test precision(intersection(Arb(prec = 80), Arb(prec = 90))) == 90
-        @test precision(intersection([Arb(prec = p) for p = 70:10:100]...)) == 100
+        @test precision(intersect(Arb(prec = 80), Arb(prec = 90))) == 90
+        @test precision(intersect([Arb(prec = p) for p = 70:10:100]...)) == 100
 
-        @test_throws ArgumentError Arblib.intersection(Arb(1), Arb(2))
-        @test_throws ArgumentError Arblib.intersection([xs; Arb(2)]...)
+        @test_throws ArgumentError intersect(Arb(1), Arb(2))
+        @test_throws ArgumentError intersect([xs; Arb(2)]...)
     end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -172,10 +172,10 @@
         xs = [Arb(i) for i in vcat(1:10, 10:-1:1)]
         xsc = Acb.(xs)
 
-        @test contains(union(zero(Arb), one(Arb)), Arb(0.5))
-        @test contains(union(zero(Acb), Acb(1, 1)), Acb(0.5, 0.5))
-        @test all(i -> contains(union(xs...), i), 1:10)
-        @test all(i -> contains(union(xsc...), i), Acb.(1:10))
+        @test Arblib.contains(union(zero(Arb), one(Arb)), Arb(0.5))
+        @test Arblib.contains(union(zero(Acb), Acb(1, 1)), Acb(0.5, 0.5))
+        @test all(i -> Arblib.contains(union(xs...), i), 1:10)
+        @test all(i -> Arblib.contains(union(xsc...), i), Acb.(1:10))
 
         @test precision(union(Arb(prec = 80), Arb(prec = 90))) == 90
         @test precision(union(Acb(prec = 80), Acb(prec = 90))) == 90
@@ -186,9 +186,9 @@
     @testset "intersect" begin
         xs = [Arb((0, i)) for i in vcat(1:10, 10:-1:1)]
 
-        @test contains(intersect(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
-        @test contains(intersect(xs...), Arb((0, 1)))
-        @test !contains(intersect(xs...), Arb(2))
+        @test Arblib.contains(intersect(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
+        @test Arblib.contains(intersect(xs...), Arb((0, 1)))
+        @test !Arblib.contains(intersect(xs...), Arb(2))
 
         @test precision(intersect(Arb(prec = 80), Arb(prec = 90))) == 90
         @test precision(intersect([Arb(prec = p) for p = 70:10:100]...)) == 100

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,17 +1,4 @@
 @testset "interval" begin
-    # TODO: Remove this once we decide what to export
-    import Arblib:
-        radius,
-        midpoint,
-        lbound,
-        ubound,
-        abs_lbound,
-        abs_ubound,
-        getinterval,
-        getball,
-        intersection
-    # TODO: Add test checking precision is preserved
-
     @testset "radius" begin
         x = Arb(2)
         y = Arb(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Arblib, Test, LinearAlgebra, SpecialFunctions
     include("arithmetic.jl")
     include("rand.jl")
     include("float.jl")
+    include("interval.jl")
     include("vector.jl")
     include("matrix.jl")
     include("eigen.jl")


### PR DESCRIPTION
I have implemented a bunch of interval related methods, these are
- radius
- midpoint
- lbound
- ubound
- abs_lbound
- abs_ubound
- getinterval
- getball
- union
- intersection
Most of them are self explanatory but I have also added documentation for them.

I have three thoughts/questions related to this
1. Which of these to export? Now I have exported all of them but maybe we should not do that?
2. What type to return? Now I have made it so that by default the methods return the most basic type, for example `Mag` for `radius` and `Arf` for `lbound`, but they also support conversion to other types with for example `lbound(Arb, x)` (similar to how `ceil` works for example). In the beginning I had them always return `Arb` by default but I changed my mind so now they return the most basic type. I think it's better to be explicit when you want it converted to `Arb`.
3. What to name intersection? Now `union` uses `Base.union` however for `intersection` there is no such base-method, instead the base method is called `intersect`. Should we keep calling it `intersection` and export that or change to using `Base.intersect`? 