### PR TITLE
Scalar multiplication and division with matrices

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -170,7 +170,7 @@ end
 
 # scalar multiplication
 function Base.:(*)(c::ArbLike, A::T) where {T <: Matrices}
-    C = T(size(A,1),size(A,2),prec = precision(A))
+    C = similar(A)
     Arblib.mul!(C,A,c)
 end
 function Base.:(*)(c::AcbLike, A::AcbMatrixLike)
@@ -179,14 +179,14 @@ function Base.:(*)(c::AcbLike, A::AcbMatrixLike)
 end
 function Base.:(*)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
-    Arblib.mul!(C,AcbMatrix(A),c)
+    Arblib.mul!(C,C,c)
 end
 Base.:(*)(A::T, c::AcbLike) where {T <: Matrices} = c*A
 Base.:(*)(A::T, c::ArbLike) where {T <: Matrices} = c*A
 
 # scalar division
 function Base.:(\)(c::ArbLike, A::T) where {T <: Matrices}
-    C = T(size(A,1),size(A,2),prec = precision(A))
+    C = similar(A)
     Arblib.div!(C,A,c)
 end
 function Base.:(\)(c::AcbLike, A::AcbMatrixLike)
@@ -195,7 +195,7 @@ function Base.:(\)(c::AcbLike, A::AcbMatrixLike)
 end
 function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
-    Arblib.div!(C,AcbMatrix(A),c)
+    Arblib.div!(C,C,c)
 end
 Base.:(/)(A::T, c::AcbLike) where {T <: Matrices} = c\A
 Base.:(/)(A::T, c::ArbLike) where {T <: Matrices} = c\A

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -169,36 +169,36 @@ function Base.:(*)(A::T, B::T) where {T<:Matrices}
 end
 
 # scalar multiplication
-function Base.:(*)(c::ArbLike, A::T) where {T <: Matrices}
+function Base.:(*)(c::ArbLike, A::T) where {T<:Matrices}
     C = similar(A)
-    Arblib.mul!(C,A,c)
+    Arblib.mul!(C, A, c)
 end
 function Base.:(*)(c::AcbLike, A::AcbMatrixLike)
     C = similar(A)
-    Arblib.mul!(C,A,c)
+    Arblib.mul!(C, A, c)
 end
 function Base.:(*)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
-    Arblib.mul!(C,C,c)
+    Arblib.mul!(C, C, c)
 end
-Base.:(*)(A::T, c::AcbLike) where {T <: Matrices} = c*A
-Base.:(*)(A::T, c::ArbLike) where {T <: Matrices} = c*A
+Base.:(*)(A::T, c::AcbLike) where {T<:Matrices} = c * A
+Base.:(*)(A::T, c::ArbLike) where {T<:Matrices} = c * A
 
 # scalar division
-function Base.:(\)(c::ArbLike, A::T) where {T <: Matrices}
+function Base.:(\)(c::ArbLike, A::T) where {T<:Matrices}
     C = similar(A)
-    Arblib.div!(C,A,c)
+    Arblib.div!(C, A, c)
 end
 function Base.:(\)(c::AcbLike, A::AcbMatrixLike)
     C = similar(A)
-    Arblib.div!(C,A,c)
+    Arblib.div!(C, A, c)
 end
 function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
-    Arblib.div!(C,C,c)
+    Arblib.div!(C, C, c)
 end
-Base.:(/)(A::T, c::AcbLike) where {T <: Matrices} = c\A
-Base.:(/)(A::T, c::ArbLike) where {T <: Matrices} = c\A
+Base.:(/)(A::T, c::AcbLike) where {T<:Matrices} = c \ A
+Base.:(/)(A::T, c::ArbLike) where {T<:Matrices} = c \ A
 
 # lu factorization
 function LinearAlgebra.lu!(A::T) where {T<:Matrices}

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -173,7 +173,7 @@ function Base.:(*)(c::ArbLike, A::T) where {T <: Matrices}
     C = T(size(A,1),size(A,2),prec = precision(A))
     Arblib.mul!(C,A,c)
 end
-function Base.:(*)(c::AcbLike, A::AcbMatLike)
+function Base.:(*)(c::AcbLike, A::AcbMatrixLike)
     C = similar(A)
     Arblib.mul!(C,A,c)
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -184,8 +184,6 @@ end
 Base.:(*)(A::T, c::AcbLike) = c*A
 Base.:(*)(A::T, c::ArbLike) = c*A
 
-
-
 # scalar division
 function Base.:(\)(c::ArbLike, A::T) where {T <: Matrices}
     C = T(size(A,1),size(A,2),prec = precision(A))
@@ -201,7 +199,6 @@ function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
 end
 Base.:(/)(A::T, c::AcbLike) = c\A
 Base.:(/)(A::T, c::ArbLike) = c\A
-
 
 # lu factorization
 function LinearAlgebra.lu!(A::T) where {T<:Matrices}

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -181,8 +181,8 @@ function Base.:(*)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
     Arblib.mul!(C,AcbMatrix(A),c)
 end
-Base.:(*)(A::T, c::AcbLike) = c*A
-Base.:(*)(A::T, c::ArbLike) = c*A
+Base.:(*)(A::T, c::AcbLike) where {T <: Matrices} = c*A
+Base.:(*)(A::T, c::ArbLike) where {T <: Matrices} = c*A
 
 # scalar division
 function Base.:(\)(c::ArbLike, A::T) where {T <: Matrices}
@@ -197,8 +197,8 @@ function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
     C = AcbMatrix(A)
     Arblib.div!(C,AcbMatrix(A),c)
 end
-Base.:(/)(A::T, c::AcbLike) = c\A
-Base.:(/)(A::T, c::ArbLike) = c\A
+Base.:(/)(A::T, c::AcbLike) where {T <: Matrices} = c\A
+Base.:(/)(A::T, c::ArbLike) where {T <: Matrices} = c\A
 
 # lu factorization
 function LinearAlgebra.lu!(A::T) where {T<:Matrices}

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -168,6 +168,41 @@ function Base.:(*)(A::T, B::T) where {T<:Matrices}
     LinearAlgebra.mul!(C, A, B)
 end
 
+# scalar multiplication
+function Base.:(*)(c::ArbLike, A::T) where {T <: Matrices}
+    C = T(size(A,1),size(A,2),prec = precision(A))
+    Arblib.mul!(C,A,c)
+end
+function Base.:(*)(c::AcbLike, A::AcbMatLike)
+    C = similar(A)
+    Arblib.mul!(C,A,c)
+end
+function Base.:(*)(c::AcbLike, A::ArbMatrixLike)
+    C = AcbMatrix(A)
+    Arblib.mul!(C,AcbMatrix(A),c)
+end
+Base.:(*)(A::T, c::AcbLike) = c*A
+Base.:(*)(A::T, c::ArbLike) = c*A
+
+
+
+# scalar division
+function Base.:(\)(c::ArbLike, A::T) where {T <: Matrices}
+    C = T(size(A,1),size(A,2),prec = precision(A))
+    Arblib.div!(C,A,c)
+end
+function Base.:(\)(c::AcbLike, A::AcbMatrixLike)
+    C = similar(A)
+    Arblib.div!(C,A,c)
+end
+function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
+    C = AcbMatrix(A)
+    Arblib.div!(C,AcbMatrix(A),c)
+end
+Base.:(/)(A::T, c::AcbLike) = c\A
+Base.:(/)(A::T, c::ArbLike) = c\A
+
+
 # lu factorization
 function LinearAlgebra.lu!(A::T) where {T<:Matrices}
     ipiv = zeros(Int, size(A, 2))

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -60,14 +60,14 @@
         @test A / c isa TMat
         @test A / c == AInt / cInt
         if TRef <: Real
-            @test Acb(c) * A is AcbMatrix
+            @test Acb(c) * A isa AcbMatrix
             @test Acb(c) * A == c * A
-            @test A * Acb(c) is AcbMatrix
+            @test A * Acb(c) isa AcbMatrix
             @test A * Acb(c) == A * c
 
-            @test Acb(c) \ A is AcbMatrix
+            @test Acb(c) \ A isa AcbMatrix
             @test Acb(c) \ A == c \ A
-            @test A / Acb(c) is AcbMatrix
+            @test A / Acb(c) isa AcbMatrix
             @test A / Acb(c) == A / c
         end
     end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -44,6 +44,17 @@
         @test A * B == AInt * BInt
         @test A * B isa TMat
     end
+    
+    @testset "scalar arithmetic" begin
+        AInt = [2 4; 6 8]
+        A = TMat(AInt; prec = 96)
+        cInt = 2
+        c = T(cInt; prec= 96)
+        @test c*A isa TMat
+        @test c*A == cInt*AInt
+        @test c\A isa TMat
+        @test c\A == cInt\AInt
+    end
 
     @testset "LinearAlgebra" begin
         A = TMat(rand(3, 3))

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -44,7 +44,7 @@
         @test A * B == AInt * BInt
         @test A * B isa TMat
     end
-    
+
     @testset "scalar arithmetic" begin
         AInt = [2 4; 6 8]
         A = TMat(AInt; prec = 96)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -50,10 +50,26 @@
         A = TMat(AInt; prec = 96)
         cInt = 2
         c = T(cInt; prec= 96)
-        @test c*A isa TMat
-        @test c*A == cInt*AInt
-        @test c\A isa TMat
-        @test c\A == cInt\AInt
+        @test c * A isa TMat
+        @test c * A == cInt * AInt
+        @test A * c isa TMat
+        @test A * c == AInt * cInt
+        
+        @test c \ A isa TMat
+        @test c \ A == cInt \ AInt
+        @test A / c isa TMat
+        @test A / c == AInt / cInt
+        if TRef <: Real
+            @test Acb(c) * A is AcbMatrix
+            @test Acb(c) * A == c * A
+            @test A * Acb(c) is AcbMatrix
+            @test A * Acb(c) == A * c
+            
+            @test Acb(c) \ A is AcbMatrix
+            @test Acb(c) \ A == c \ A
+            @test A / Acb(c) is AcbMatrix
+            @test A / Acb(c) == A / c
+        end
     end
 
     @testset "LinearAlgebra" begin

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -49,12 +49,12 @@
         AInt = [2 4; 6 8]
         A = TMat(AInt; prec = 96)
         cInt = 2
-        c = T(cInt; prec= 96)
+        c = T(cInt; prec = 96)
         @test c * A isa TMat
         @test c * A == cInt * AInt
         @test A * c isa TMat
         @test A * c == AInt * cInt
-        
+
         @test c \ A isa TMat
         @test c \ A == cInt \ AInt
         @test A / c isa TMat
@@ -64,7 +64,7 @@
             @test Acb(c) * A == c * A
             @test A * Acb(c) is AcbMatrix
             @test A * Acb(c) == A * c
-            
+
             @test Acb(c) \ A is AcbMatrix
             @test Acb(c) \ A == c \ A
             @test A / Acb(c) is AcbMatrix


### PR DESCRIPTION
Added `c*A`, `A*c`, `c\A` and `A/c` and some tests. This would close #122 
I am not sure about `Acb * ArbMatrix` (now I did, but I use explicit conversion to an `AcbMatrix`), maybe explicit conversion from the user is better there?

