### PR TITLE
Enh/minor polynomial improvements

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install JuliaFormatter and format
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.14.1"))'
-          julia  -e 'using JuliaFormatter; format(["./src", "./test"], verbose=true)'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.15.7"))'
+          julia  -e 'using JuliaFormatter; format(["./src", "./test", "./parse"], verbose=true)'
       - name: Format check
         run: |
           julia -e '

--- a/parse/parse.jl
+++ b/parse/parse.jl
@@ -178,40 +178,26 @@ function parse_and_generate_arbdoc(arb_doc_dir, out_dir = "src/arbcalls/")
         "double arf_get_d(const arf_t x, arf_rnd_t rnd)" => "clashes with arf_get_si",
         "slong arf_get_si(const arf_t x, arf_rnd_t rnd)" => "clashes with arf_get_d",
         "void arf_print(const arf_t x)" => "clashes with Base.print",
-        "int arf_mul(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)" =>
-            "defined using #DEFINE in C which doesn't work in Julia",
+        "int arf_mul(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)" => "defined using #DEFINE in C which doesn't work in Julia",
         "arb_ptr _arb_vec_init(slong n)" => "clashes with similar method for acb",
-        "double _arb_vec_estimate_allocated_bytes(slong len, slong prec)" =>
-            "clashes with similar method for acb",
+        "double _arb_vec_estimate_allocated_bytes(slong len, slong prec)" => "clashes with similar method for acb",
         "void arb_print(const arb_t x)" => "clashes with Base.print",
-        "int arb_can_round_arf(const arb_t x, slong prec, arf_rnd_t rnd)" =>
-            "clashes with arb_can_round_mpfr",
-        "int arb_can_round_mpfr(const arb_t x, slong prec, mpfr_rnd_t rnd)" =>
-            "clashes with arb_can_round_arf",
-        "void arb_root(arb_t z, const arb_t x, ulong k, slong prec)" =>
-            "alias to arb_root_ui",
+        "int arb_can_round_arf(const arb_t x, slong prec, arf_rnd_t rnd)" => "clashes with arb_can_round_mpfr",
+        "int arb_can_round_mpfr(const arb_t x, slong prec, mpfr_rnd_t rnd)" => "clashes with arb_can_round_arf",
+        "void arb_root(arb_t z, const arb_t x, ulong k, slong prec)" => "alias to arb_root_ui",
         "acb_ptr _acb_vec_init(slong n)" => "clashes with similar method for arb",
-        "double _acb_vec_estimate_allocated_bytes(slong len, slong prec)" =>
-            "clashes with similar method for arb",
+        "double _acb_vec_estimate_allocated_bytes(slong len, slong prec)" => "clashes with similar method for arb",
         "void acb_print(const acb_t x)" => "clashes with Base.print",
         "slong arb_poly_length(const arb_poly_t poly)" => "clashes with Base.length",
-        "void _arb_poly_add(arb_ptr C, arb_srcptr A, slong lenA, arb_srcptr B, slong lenB, slong prec)" =>
-            "clashes with _arb_vec_add",
-        "void _arb_poly_sub(arb_ptr C, arb_srcptr A, slong lenA, arb_srcptr B, slong lenB, slong prec)" =>
-            "clashes with _arb_vec_sub",
+        "void _arb_poly_add(arb_ptr C, arb_srcptr A, slong lenA, arb_srcptr B, slong lenB, slong prec)" => "clashes with _arb_vec_add",
+        "void _arb_poly_sub(arb_ptr C, arb_srcptr A, slong lenA, arb_srcptr B, slong lenB, slong prec)" => "clashes with _arb_vec_sub",
         "slong acb_poly_length(const acb_poly_t poly)" => "clashes with Base.length",
-        "void _acb_poly_add(acb_ptr C, acb_srcptr A, slong lenA, acb_srcptr B, slong lenB, slong prec)" =>
-            "clashes with _acb_vec_add",
-        "void _acb_poly_sub(acb_ptr C, acb_srcptr A, slong lenA, acb_srcptr B, slong lenB, slong prec)" =>
-            "clashes with _acb_vec_sub",
-        "void _acb_poly_elliptic_k_series(acb_ptr res, acb_srcptr z, slong zlen, slong len, slong prec)" =>
-            "alias to _acb_elliptic_k_series",
-        "void acb_poly_elliptic_k_series(acb_poly_t res, const acb_poly_t z, slong n, slong prec)" =>
-            "alias to acb_elliptic_k_series",
-        "void _acb_poly_elliptic_p_series(acb_ptr res, acb_srcptr z, slong zlen, const acb_t tau, slong len, slong prec)" =>
-            "alias to _acb_elliptic_p_series",
-        "void acb_poly_elliptic_p_series(acb_poly_t res, const acb_poly_t z, const acb_t tau, slong n, slong prec)" =>
-            "alias to acb_elliptic_p_series",
+        "void _acb_poly_add(acb_ptr C, acb_srcptr A, slong lenA, acb_srcptr B, slong lenB, slong prec)" => "clashes with _acb_vec_add",
+        "void _acb_poly_sub(acb_ptr C, acb_srcptr A, slong lenA, acb_srcptr B, slong lenB, slong prec)" => "clashes with _acb_vec_sub",
+        "void _acb_poly_elliptic_k_series(acb_ptr res, acb_srcptr z, slong zlen, slong len, slong prec)" => "alias to _acb_elliptic_k_series",
+        "void acb_poly_elliptic_k_series(acb_poly_t res, const acb_poly_t z, slong n, slong prec)" => "alias to acb_elliptic_k_series",
+        "void _acb_poly_elliptic_p_series(acb_ptr res, acb_srcptr z, slong zlen, const acb_t tau, slong len, slong prec)" => "alias to _acb_elliptic_p_series",
+        "void acb_poly_elliptic_p_series(acb_poly_t res, const acb_poly_t z, const acb_t tau, slong n, slong prec)" => "alias to acb_elliptic_p_series",
     )
 
     for filename in filenames

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -471,6 +471,8 @@ Base.:^(p::AcbSeries, e::Number) = pow_acb_series!(zero(p), p, convert(Acb, e), 
 # Disambiguation
 Base.:^(p::ArbSeries, e::Integer) = pow_arb_series!(zero(p), p, convert(Arb, e), length(p))
 Base.:^(p::AcbSeries, e::Integer) = pow_acb_series!(zero(p), p, convert(Acb, e), length(p))
+Base.:^(p::ArbSeries, e::Rational) = pow_arb_series!(zero(p), p, convert(Arb, e), length(p))
+Base.:^(p::AcbSeries, e::Rational) = pow_acb_series!(zero(p), p, convert(Acb, e), length(p))
 
 ##
 ## Series methods

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -465,8 +465,20 @@ function Base.:^(p::ArbSeries, e::Number)
     res = AcbSeries(p)
     return pow_acb_series!(res, res, convert(Acb, e), length(p))
 end
+function Base.:^(x::Real, p::ArbSeries)
+    res = ArbSeries(x, degree = degree(p), prec = precision(p))
+    return pow_series!(res, res, p, length(p))
+end
+function Base.:^(x::Number, p::ArbSeries)
+    res = AcbSeries(x, degree = degree(p), prec = precision(p))
+    return pow_series!(res, res, AcbSeries(p), length(p))
+end
 
 Base.:^(p::AcbSeries, e::Number) = pow_acb_series!(zero(p), p, convert(Acb, e), length(p))
+function Base.:^(x::Number, p::AcbSeries)
+    res = AcbSeries(x, degree = degree(p), prec = precision(p))
+    return pow_series!(res, res, p, length(p))
+end
 
 # Disambiguation
 Base.:^(p::ArbSeries, e::Integer) = pow_arb_series!(zero(p), p, convert(Arb, e), length(p))

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -108,6 +108,11 @@ end
 Base.isnan(x::ArbOrRef) = isnan(midref(x))
 Base.isnan(x::AcbOrRef) = isnan(midref(realref(x))) || isnan(midref(imagref(x)))
 
+Base.isnan(p::Union{ArbPoly,ArbSeries,AcbPoly,AcbSeries}) =
+    any(isnan, @inbounds p[i] for i = 0:degree(p))
+Base.isfinite(p::Union{ArbPoly,ArbSeries,AcbPoly,AcbSeries}) =
+    all(isfinite, @inbounds p[i] for i = 0:degree(p))
+
 for ArbT in (ArfLike, ArbLike, AcbLike)
     @eval begin
         Base.isequal(y::$ArbT, x::$ArbT) = !iszero(equal(x, y))

--- a/test/predicates-test.jl
+++ b/test/predicates-test.jl
@@ -53,6 +53,23 @@
         @test !isnan(zero(Acb))
         @test !isnan(one(Acb))
         @test !isnan(Acb(Inf))
+
+        for T in [ArbPoly, ArbSeries, AcbPoly, AcbSeries]
+            @test isnan(T(NaN))
+            @test isnan(T([NaN, 0]))
+            @test isnan(T([0, NaN]))
+            @test !isnan(T(1))
+            @test !isnan(T([0, 1]))
+
+            @test isfinite(T(1))
+            @test isfinite(T([0, 1]))
+            @test !isfinite(T(NaN))
+            @test !isfinite(T([NaN, 0]))
+            @test !isfinite(T([0, NaN]))
+            @test !isfinite(T(Inf))
+            @test !isfinite(T([Inf, 0]))
+            @test !isfinite(T([0, Inf]))
+        end
     end
 
     @testset "isequal" begin

--- a/test/series.jl
+++ b/test/series.jl
@@ -239,6 +239,9 @@
 
         @test p^(2 + 2im) == AcbSeries([1, 4 + 4im, 2 + 18im])
 
+        @test 2^TSeries([1, 0]) == TSeries([2, 0])
+        @test (2 + im)^TSeries([1, 0]) == AcbSeries([2 + im, 0])
+
         @test precision(setprecision(p, 80)^setprecision(q, 90)) == 90
         @test precision(setprecision(p, 80)^T(2)) == 80
     end

--- a/test/series.jl
+++ b/test/series.jl
@@ -228,8 +228,14 @@
 
         @test p^q == TSeries([1, 4, 16])
 
-        @test p^T(2) == p^Int(2) == p^UInt(2) == p^2.0 == p^2 == TSeries([1, 4, 10])
-        @test p^T(-1) == p^Int(-1) == p^-1.0 == p^-1 == TSeries([1, -2, 1])
+        @test p^T(2) ==
+              p^Int(2) ==
+              p^UInt(2) ==
+              p^(2 // 1) ==
+              p^2.0 ==
+              p^2 ==
+              TSeries([1, 4, 10])
+        @test p^T(-1) == p^Int(-1) == p^(-1 // 1) == p^-1.0 == p^-1 == TSeries([1, -2, 1])
 
         @test p^(2 + 2im) == AcbSeries([1, 4 + 4im, 2 + 18im])
 


### PR DESCRIPTION
This adds a few minor improvements to polynomials and series. It also updates the version of `JuliaFormatter` that is used and adds `./parse` to be formatted as well. The addition to the polynomials and series are
- Add `isnan` and `isfinite` methods for them. The default fallback didn't work at all.
- Add disambiguation methods for series to the power of `Rational`
- Add methods for `Real` and `Number` to the power of a series.