### PR TITLE
Fix scalar addition and subtraction for polynomials, missing special function and comparison with Rational

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -312,24 +312,35 @@ for (T, Tel, Tel_inplace) in [
 ]
     @eval function Base.:+(p::$T, c::$Tel_inplace)
         res = copy(p)
+        # Handle p being the zero polynomial
+        iszero(p) && return set_coeff!(res, 0, c)
         res0 = ref(res, 0)
         add!(res0, res0, c)
-        return res
+        return normalise!(res)
     end
     @eval Base.:+(p::$T, c::$Tel) = p + convert(eltype(p), c)
 
     @eval function Base.:-(p::$T, c::$Tel_inplace)
         res = copy(p)
+        # Handle p being the zero polynomial
+        if iszero(p)
+            set_coeff!(res, 0, c)
+            res0 = ref(res, 0)
+            neg!(res0, res0)
+            return res
+        end
         res0 = ref(res, 0)
         sub!(res0, res0, c)
-        return res
+        return normalise!(res)
     end
     @eval Base.:-(p::$T, c::$Tel) = p - convert(eltype(p), c)
     @eval function Base.:-(c::$Tel_inplace, p::$T)
         res = -p
+        # Handle p being the zero polynomial
+        iszero(p) && return set_coeff!(res, 0, c)
         res0 = ref(res, 0)
         add!(res0, res0, c)
-        return res
+        return normalise!(res)
     end
     @eval Base.:-(c::$Tel, p::$T) = convert(eltype(p), c) - p
 

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -310,6 +310,11 @@ for (T, Tel, Tel_inplace) in [
     (Union{ArbPoly,ArbSeries}, Real, Union{ArbOrRef,ArfLike,Unsigned,Integer}),
     (Union{AcbPoly,AcbSeries}, Number, Union{AcbOrRef,ArbOrRef,Unsigned,Integer}),
 ]
+    # Since we use inplace methods we need to manually normalise the
+    # polynomials after the operation. This is to make sure that it
+    # correctly recognizes the possibly new degree of the polynomial.
+    # For example for iszero(ArbPoly(1) - 1) to work.
+
     @eval function Base.:+(p::$T, c::$Tel_inplace)
         res = copy(p)
         # Handle p being the zero polynomial

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -151,6 +151,16 @@ for (ArbT, args) in (
     end
 end
 
+# Julia Base defines special methods for comparison between Rational
+# and AbstractFloat which do not work well for Arb. We redefine these
+# methods to just convert the rational number to Arb.
+Base.:<(x::Arb, y::Rational) = x < convert(Arb, y)
+Base.:<(x::Rational, y::Arb) = convert(Arb, x) < y
+Base.:<=(x::Arb, y::Rational) = x <= convert(Arb, y)
+Base.:<=(x::Rational, y::Arb) = convert(Arb, x) <= y
+Base.cmp(x::Arb, y::Rational) = Base.cmp(x, convert(Arb, y))
+Base.cmp(x::Rational, y::Arb) = Base.cmp(convert(Arb, x), y)
+
 Base.isequal(x::T, y::T) where {T<:Union{ArbPoly,AcbPoly}} = !iszero(equal(x, y))
 Base.isequal(x::T, y::T) where {T<:Union{ArbSeries,AcbSeries}} =
     degree(x) == degree(y) && !iszero(equal(x, y))

--- a/src/special-functions.jl
+++ b/src/special-functions.jl
@@ -165,7 +165,8 @@ SpecialFunctions.erfc(x::Series) = hypgeom_erfc_series!(zero(x), x, length(x))
 # Not implemented by Arb
 
 #SpecialFunctions.erfi(x)
-# Not implemented by Arb
+SpecialFunctions.erfi(x::Union{ArbOrRef,AcbOrRef}) = hypgeom_erfi!(zero(x), x)
+SpecialFunctions.erfi(x::Series) = hypgeom_erfi_series!(zero(x), x, length(x))
 
 #SpecialFunctions.erfinv(x)
 # Not implemented by Arb

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -140,6 +140,18 @@
               TPoly([2, 4, 6])
         @test p / T(2) == p / 2 == p / 2.0 == TPoly([0.5, 1, 1.5])
 
+        # Test with zero polynomial
+        @test zero(TPoly) + 1 == TPoly(1)
+        @test zero(TPoly) - 1 == TPoly(-1)
+        @test 1 - zero(TPoly) == TPoly(1)
+        @test 1 * zero(TPoly) == TPoly()
+        @test zero(TPoly) / 1 == TPoly()
+
+        # Test that the normalisation works
+        @test iszero(TPoly(-1) + 1)
+        @test iszero(TPoly(1) - 1)
+        @test iszero(1 - TPoly(1))
+
         let p = setprecision(p, 80)
             @test precision(p + T(2)) ==
                   precision(T(2) + p) ==

--- a/test/predicates-test.jl
+++ b/test/predicates-test.jl
@@ -134,6 +134,20 @@
         @test y > x
         @test y >= x
 
+        # Comparison with rationals
+        @test -1 // 2 < x < 1 // 2
+        @test -1 // 2 <= x <= 1 // 2
+        @test cmp(x, 1 // 2) == -1
+        @test cmp(-1 // 2, x) == -1
+        @test 1 // 2 > x > -1 // 2
+        @test 1 // 2 >= x >= -1 // 2
+        @test cmp(1 // 2, x) == 1
+        @test cmp(x, -1 // 2) == 1
+
+        @test !(-1 // 2 > x)
+        @test !(-1 // 2 >= x)
+        @test cmp(-1 // 2, x) == -1
+
         x, y = Acb(0), Acb(1)
         @test x == x
         @test x == 0

--- a/test/series.jl
+++ b/test/series.jl
@@ -139,6 +139,18 @@
         @test p / T(2) == p / 2 == p / 2.0 == TSeries([0.5, 1, 1.5])
         @test T(2) / p == 2 / p == 2.0 / p == TSeries([2, -4, 2])
 
+        # Test with zero polynomial
+        @test zero(TSeries) + 1 == TSeries(1)
+        @test zero(TSeries) - 1 == TSeries(-1)
+        @test 1 - zero(TSeries) == TSeries(1)
+        @test 1 * zero(TSeries) == TSeries()
+        @test zero(TSeries) / 1 == TSeries()
+
+        # Test that the normalisation works
+        @test iszero(TSeries(-1) + 1)
+        @test iszero(TSeries(1) - 1)
+        @test iszero(1 - TSeries(1))
+
         let p = setprecision(p, 80)
             @test precision(p + T(2)) ==
                   precision(T(2) + p) ==

--- a/test/special-functions.jl
+++ b/test/special-functions.jl
@@ -107,6 +107,13 @@
         @test erfc(Acb(3 + 3im)) ≈ erfc(3 + 3im)
         @test erfc(ArbSeries([2, 1]))[0] ≈ erfc(2)
         @test erfc(AcbSeries([2 + 2im, 1]))[0] ≈ erfc(2 + 2im)
+
+        @test erfi(Arb(2)) ≈ erfi(2)
+        @test erfi(Arb(3)) ≈ erfi(3)
+        @test erfi(Acb(2 + 2im)) ≈ erfi(2 + 2im)
+        @test erfi(Acb(3 + 3im)) ≈ erfi(3 + 3im)
+        @test erfi(ArbSeries([2, 1]))[0] ≈ erfi(2)
+        @test erfi(AcbSeries([2 + 2im, 1]))[0] ≈ erfi(2 + 2im)
     end
 
     @testset "Airy Functions" begin


### PR DESCRIPTION
This fixes three things
1. Some bugs in the recent update to scalar addition and subtraction for polynomials related to normalization and handling of the zero polynomial.
2. A missing method from `SpecialFunctions` which is implemented by Arb but which I had missed the first time.
3. It fixes comparison between `Rational` and `Arb`. `Julia.Base` implements a special method for comparing `Rational` and `AbstractFloat` which doesn't work well for `Arb`. I explicitly defined these methods to just convert the rational to `Arb`.

I also bumps the version to `0.5.0`. Technically this release doesn't add anything which is not backwards compatible. However the new code for threading has some potential to lead to issues so to be conservative I though it would be better to make it 0.5.0 instead of 0.4.3.