### PR TITLE
Add BigInt constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/arbcall.jl
+++ b/src/arbcall.jl
@@ -147,7 +147,7 @@ end
 function jlfname(
     arbfname,
     prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly", "scalar"),
-    suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpfr", "str");
+    suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpz", "mpfr", "str");
     inplace = false,
 )
     strs = filter(!isempty, split(arbfname, "_"))
@@ -170,7 +170,7 @@ end
 function jlfname(
     af::Arbfunction,
     prefixes = ("arf", "arb", "acb", "mag", "mat", "vec", "poly", "scalar"),
-    suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpfr", "str");
+    suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpz", "mpfr", "str");
     inplace = inplace(af),
 )
     return jlfname(arbfname(af), prefixes, suffixes, inplace = inplace)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -25,7 +25,11 @@ function set!(res::ArfLike, x::Rational; prec::Integer = precision(res))
     return res
 end
 
-function set!(res::ArfLike, x::Rational{BigInt}; prec::Integer = precision(res))
+function set!(
+    res::ArfLike,
+    x::Rational{<:Union{UInt128,Int128,BigInt}};
+    prec::Integer = precision(res),
+)
     set!(res, numerator(x))
     div!(res, res, Arf(denominator(x), prec = prec), prec = prec)
     return res
@@ -43,7 +47,11 @@ function set!(res::ArbLike, x::Rational; prec::Integer = precision(res))
     return div!(res, res, denominator(x), prec = prec)
 end
 
-function set!(res::ArbLike, x::Rational{BigInt}; prec::Integer = precision(res))
+function set!(
+    res::ArbLike,
+    x::Rational{<:Union{UInt128,Int128,BigInt}};
+    prec::Integer = precision(res),
+)
     set!(res, numerator(x))
     return div!(res, res, Arb(denominator(x), prec = prec), prec = prec)
 end

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -93,6 +93,7 @@ function set!(res::AcbLike, x::Union{UInt128,Int128,BigInt})
     return res
 end
 
+# Doesn't support aliasing between realref(res) and im
 function set!(
     res::AcbLike,
     re::Union{Real,arb_struct,arf_struct,mag_struct,Tuple{<:Real,<:Real}},

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -82,14 +82,14 @@ end
 # Acb
 function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct,Tuple{<:Real,<:Real}})
     set!(realref(res), x)
-    set!(imagref(res), 0)
+    zero!(imagref(res))
     return res
 end
 
 # This needs to be a separate function for disambiguation with Integer
 function set!(res::AcbLike, x::Union{UInt128,Int128,BigInt})
     set!(realref(res), x)
-    set!(imagref(res), 0)
+    zero!(imagref(res))
     return res
 end
 

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -25,6 +25,12 @@ function set!(res::ArfLike, x::Rational; prec::Integer = precision(res))
     return res
 end
 
+function set!(res::ArfLike, x::Rational{BigInt}; prec::Integer = precision(res))
+    set!(res, numerator(x))
+    div!(res, res, Arf(denominator(x), prec = prec), prec = prec)
+    return res
+end
+
 # Arb
 function set!(res::ArbLike, x::Union{UInt128,Int128,MagLike,BigInt,BigFloat})
     set!(midref(res), x)
@@ -35,6 +41,11 @@ end
 function set!(res::ArbLike, x::Rational; prec::Integer = precision(res))
     set!(res, numerator(x))
     return div!(res, res, denominator(x), prec = prec)
+end
+
+function set!(res::ArbLike, x::Rational{BigInt}; prec::Integer = precision(res))
+    set!(res, numerator(x))
+    return div!(res, res, Arb(denominator(x), prec = prec), prec = prec)
 end
 
 for (irr, suffix) in ((:π, "pi"), (:ℯ, "e"), (:γ, "euler"), (:catalan, "catalan"))

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -26,7 +26,7 @@ function set!(res::ArfLike, x::Rational; prec::Integer = precision(res))
 end
 
 # Arb
-function set!(res::ArbLike, x::Union{UInt128,Int128,MagLike,BigFloat})
+function set!(res::ArbLike, x::Union{UInt128,Int128,MagLike,BigInt,BigFloat})
     set!(midref(res), x)
     zero!(radref(res))
     return res

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -32,12 +32,6 @@ function set!(res::ArbLike, x::Union{UInt128,Int128,MagLike,BigInt,BigFloat})
     return res
 end
 
-#function set!(res::ArbLike, x::Union{MagLike,BigFloat})
-#    set!(midref(res), x)
-#    zero!(radref(res))
-#    return res
-#end
-
 function set!(res::ArbLike, x::Rational; prec::Integer = precision(res))
     set!(res, numerator(x))
     return div!(res, res, denominator(x), prec = prec)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -80,13 +80,14 @@ function set!(res::ArbLike, (a, b)::Tuple{<:Real,<:Real}; prec::Integer = precis
 end
 
 # Acb
-function set!(res::AcbLike, x::Union{UInt128,Int128})
+function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct,Tuple{<:Real,<:Real}})
     set!(realref(res), x)
     set!(imagref(res), 0)
     return res
 end
 
-function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct,Tuple{<:Real,<:Real}})
+# This needs to be a separate function for disambiguation with Integer
+function set!(res::AcbLike, x::Union{UInt128,Int128,BigInt})
     set!(realref(res), x)
     set!(imagref(res), 0)
     return res

--- a/test/arbcall-test.jl
+++ b/test/arbcall-test.jl
@@ -98,6 +98,7 @@
             ("arf_set_si", :set),
             ("arf_set_d", :set),
             ("arb_set", :set),
+            ("arf_set_mpz", :set),
             ("arf_set_mpfr", :set),
             ("arb_set_arf", :set),
             ("arb_set_si", :set),
@@ -118,7 +119,6 @@
             ("arb_bin_uiui", :bin_uiui),
 
             # Deprecated types
-            ("arf_set_mpz", :set_mpz),
             ("arf_set_fmpr", :set_fmpr),
 
             # Underscore methods

--- a/test/constructors-test.jl
+++ b/test/constructors-test.jl
@@ -26,7 +26,7 @@
     end
 
     @testset "Arb" begin
-        for T in [UInt, Int, Float64, Arf, Arb, BigFloat, Rational{Int}]
+        for T in [UInt, Int, Float64, Arf, Arb, BigInt, BigFloat, Rational{Int}]
             @test Arb(zero(T)) == zero(Arb)
             @test Arb(one(T)) == one(Arb)
             @test precision(Arb(zero(T), prec = 80)) == 80

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -12,6 +12,9 @@
 
     @testset "Arb" begin
         # MagLike and BigFloat
+        @test Arblib.set!(Arb(), BigInt(1)) == one(Arb)
+        @test Arblib.set!(Arblib.realref(Acb()), BigInt(1)) == one(Arb)
+        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigInt(1)), one(Arb))
         @test Arblib.set!(Arb(), BigFloat(1.0)) == one(Arb)
         @test Arblib.set!(Arblib.realref(Acb()), BigFloat(1.0)) == one(Arb)
         @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigFloat(1.0)), one(Arb))

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -130,6 +130,9 @@
     end
 
     @testset "Acb" begin
+        @test Arblib.set!(Acb(), BigInt(typemax(Int)) + 1) ==
+              Acb(BigFloat(typemax(Int)) + 1)
+
         @test Arblib.set!(Acb(), BigFloat(1.0)) == one(Acb)
         @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), BigFloat(1.0)), one(Acb))
         x = Arblib.set!(Acb(), ℯ)

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -31,6 +31,18 @@
         @test Arblib.set!(Arblib.realref(Acb()), 1 // 2) == one(Arb) / 2
         @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), 1 // 2), one(Arb) / 2)
 
+        let m = typemax(Int)
+            @test isequal(Arblib.set!(Arb(), 1 // (m + big(1))), inv(Arb(m) + 1))
+            @test isequal(
+                Arblib.set!(Arblib.realref(Acb()), 1 // (m + big(1))),
+                inv(Arb(m) + 1),
+            )
+            @test Arblib.equal(
+                Arblib.set!(Arblib.arb_struct(), 1 // (m + big(1))),
+                inv(Arb(m) + 1),
+            )
+        end
+
         # Irrationals
         @test Arb(3) < Arblib.set!(Arb(), π) < Arb(4)
         @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.realref(Acb()), π))

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -20,12 +20,20 @@
 
         # Rational
         @test Arblib.set!(T(), 2 // 3) == Arf(2) / Arf(3)
-        @test Arblib.set!(T(), big(2) // 3) == Arf(2) / Arf(3)
+        @test Arblib.set!(T(), UInt128(2) // 3) == Arf(2) / Arf(3)
+        @test Arblib.set!(T(), Int128(2) // 3) == Arf(2) / Arf(3)
+        @test Arblib.set!(T(), BigInt(2) // 3) == Arf(2) / Arf(3)
         # Test that it works for big numerators and denominators
-        let x = BigInt(typemax(Int)) + 1
+        let x = UInt128(typemax(Int)) + 1
             @test Arblib.set!(T(), x // 2) == Arf(x) / 2
             @test Arblib.set!(T(), 1 // x) == inv(Arf(x))
             @test Arblib.set!(T(), x // (x + 1)) == Arf(x) / Arf(x + 1)
+            @test Arblib.set!(T(), Int128(x) // 2) == Arf(x) / 2
+            @test Arblib.set!(T(), 1 // Int128(x)) == inv(Arf(x))
+            @test Arblib.set!(T(), Int128(x) // (Int128(x) + 1)) == Arf(x) / Arf(x + 1)
+            @test Arblib.set!(T(), BigInt(x) // 2) == Arf(x) / 2
+            @test Arblib.set!(T(), 1 // BigInt(x)) == inv(Arf(x))
+            @test Arblib.set!(T(), BigInt(x) // (BigInt(x) + 1)) == Arf(x) / Arf(x + 1)
         end
     end
 
@@ -51,12 +59,26 @@
 
         # Rational
         @test Arblib.set!(T(), 1 // 2) == one(Arb) / 2
-        @test Arblib.set!(T(), big(1) // 2) == one(Arb) / 2
+        @test Arblib.set!(T(), UInt128(1) // 2) == one(Arb) / 2
+        @test Arblib.set!(T(), Int128(1) // 2) == one(Arb) / 2
+        @test Arblib.set!(T(), BigInt(1) // 2) == one(Arb) / 2
         # Test that it works for big numerators and denominators
-        let x = BigInt(typemax(Int)) + 1
+        let x = UInt128(typemax(Int)) + 1
             @test isequal(Arblib.set!(T(), x // 2), Arb(x) / 2)
             @test isequal(Arblib.set!(T(), 1 // x), inv(Arb(x)))
             @test isequal(Arblib.set!(T(), x // (x + 1)), Arb(x) / Arb(x + 1))
+            @test isequal(Arblib.set!(T(), Int128(x) // 2), Arb(x) / 2)
+            @test isequal(Arblib.set!(T(), 1 // Int128(x)), inv(Arb(x)))
+            @test isequal(
+                Arblib.set!(T(), Int128(x) // (Int128(x) + 1)),
+                Arb(x) / Arb(x + 1),
+            )
+            @test isequal(Arblib.set!(T(), BigInt(x) // 2), Arb(x) / 2)
+            @test isequal(Arblib.set!(T(), 1 // BigInt(x)), inv(Arb(x)))
+            @test isequal(
+                Arblib.set!(T(), BigInt(x) // (BigInt(x) + 1)),
+                Arb(x) / Arb(x + 1),
+            )
         end
 
         # Irrational

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -1,108 +1,95 @@
 @testset "setters" begin
-    @testset "Mag" begin
-        @test π <
-              Float64(Arblib.set!(Mag(), π)) ==
-              Float64(Arblib.set!(Arblib.radref(Arb()), π)) ==
-              Float64(Arblib.set!(Arblib.mag_struct(), π)) <
-              3.15
+    @testset "$name" for (name, T) in [("Mag", Mag), ("MagRef", () -> Arblib.radref(Arb()))]
+        # Integer
+        @test Arblib.set!(T(), 1) == Arblib.set!(T(), UInt(1)) == one(Mag)
 
-        @test Arblib.set!(Mag(), 1) == Arblib.set!(Mag(), UInt(1))
-        @test Arblib.set!(Mag(), 3, 4) == Arblib.set!(Mag(), 3 * 2^4)
+        # π
+        @test Float64(Arblib.set!(T(), π)) ≈ π
+
+        # Integer times power of 2
+        @test Arblib.set!(T(), 3, 4) == Arblib.set!(T(), 3 * 2^4)
     end
 
-    @testset "Arb" begin
-        # MagLike and BigFloat
-        @test Arblib.set!(Arb(), BigInt(1)) == one(Arb)
-        @test Arblib.set!(Arblib.realref(Acb()), BigInt(1)) == one(Arb)
-        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigInt(1)), one(Arb))
-        @test Arblib.set!(Arb(), BigFloat(1.0)) == one(Arb)
-        @test Arblib.set!(Arblib.realref(Acb()), BigFloat(1.0)) == one(Arb)
-        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), BigFloat(1.0)), one(Arb))
-        @test Arblib.set!(Arb(), one(Mag)) == one(Arb)
-        @test Arblib.set!(Arblib.realref(Acb()), one(Mag)) == one(Arb)
-        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), one(Mag).mag), one(Arb))
+    @testset "$name" for (name, T) in [("Arf", Arf), ("ArfRef", () -> Arblib.midref(Arb()))]
+        # UInt128 and Int128
+        let x = Int128(227725055589944414706309)
+            @test Arblib.set!(T(), UInt128(x)) == Arb("227725055589944414706309")
+            @test Arblib.set!(T(), x) == Arb("227725055589944414706309")
+            @test Arblib.set!(T(), -x) == Arb("-227725055589944414706309")
+        end
+
+        # Rational
+        @test Arblib.set!(T(), 2 // 3) == Arf(2) / Arf(3)
+        @test Arblib.set!(T(), big(2) // 3) == Arf(2) / Arf(3)
+        # Test that it works for big numerators and denominators
+        let x = BigInt(typemax(Int)) + 1
+            @test Arblib.set!(T(), x // 2) == Arf(x) / 2
+            @test Arblib.set!(T(), 1 // x) == inv(Arf(x))
+            @test Arblib.set!(T(), x // (x + 1)) == Arf(x) / Arf(x + 1)
+        end
+    end
+
+    @testset "$name" for (name, T) in
+                         [("Arb", Arb), ("ArbRef", () -> Arblib.realref(Acb()))]
+        # MagLike, BigFloat
+        @test Arblib.set!(T(), Mag(2)) == Arb(2)
+        @test Arblib.set!(T(), BigFloat(2)) == Arb(2)
+
         # Check that aliasing works
-        x = Arb()
+        x = T()
         Arblib.set!(Arblib.radref(x), 1)
         @test Arblib.set!(x, Arblib.radref(x)) == one(Arb)
 
-        # Rational
-        @test Arblib.set!(Arb(), 1 // 2) == one(Arb) / 2
-        @test Arblib.set!(Arblib.realref(Acb()), 1 // 2) == one(Arb) / 2
-        @test Arblib.equal(Arblib.set!(Arblib.arb_struct(), 1 // 2), one(Arb) / 2)
-
-        let m = typemax(Int)
-            @test isequal(Arblib.set!(Arb(), 1 // (m + big(1))), inv(Arb(m) + 1))
-            @test isequal(
-                Arblib.set!(Arblib.realref(Acb()), 1 // (m + big(1))),
-                inv(Arb(m) + 1),
-            )
-            @test Arblib.equal(
-                Arblib.set!(Arblib.arb_struct(), 1 // (m + big(1))),
-                inv(Arb(m) + 1),
-            )
+        # UInt128, Int128, BigInt
+        let x = Int128(227725055589944414706309)
+            @test Arblib.set!(T(), UInt128(x)) == Arb("227725055589944414706309")
+            @test Arblib.set!(T(), x) == Arb("227725055589944414706309")
+            @test Arblib.set!(T(), -x) == Arb("-227725055589944414706309")
+            @test Arblib.set!(T(), BigInt(x)) == Arb("227725055589944414706309")
+            @test Arblib.set!(T(), -BigInt(x)) == Arb("-227725055589944414706309")
         end
 
-        # Irrationals
-        @test Arb(3) < Arblib.set!(Arb(), π) < Arb(4)
-        @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.realref(Acb()), π))
-        @test Arblib.equal(Arblib.set!(Arb(), π), Arblib.set!(Arblib.arb_struct(), π))
+        # Rational
+        @test Arblib.set!(T(), 1 // 2) == one(Arb) / 2
+        @test Arblib.set!(T(), big(1) // 2) == one(Arb) / 2
+        # Test that it works for big numerators and denominators
+        let x = BigInt(typemax(Int)) + 1
+            @test isequal(Arblib.set!(T(), x // 2), Arb(x) / 2)
+            @test isequal(Arblib.set!(T(), 1 // x), inv(Arb(x)))
+            @test isequal(Arblib.set!(T(), x // (x + 1)), Arb(x) / Arb(x + 1))
+        end
 
-        @test Arb(2) < Arblib.set!(Arb(), ℯ) < Arb(3)
-        @test Arblib.equal(Arblib.set!(Arb(), ℯ), Arblib.set!(Arblib.realref(Acb()), ℯ))
-        @test Arblib.equal(Arblib.set!(Arb(), ℯ), Arblib.set!(Arblib.arb_struct(), ℯ))
+        # Irrational
+        for irr in [π, ℯ, MathConstants.γ, MathConstants.catalan, MathConstants.φ]
+            @test Arblib.overlaps(Arblib.set!(T(), irr), Arb(BigFloat(irr)))
+        end
 
-        @test Arb(0) < Arblib.set!(Arb(), MathConstants.γ) < Arb(1)
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.γ),
-            Arblib.set!(Arblib.realref(Acb()), MathConstants.γ),
-        )
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.γ),
-            Arblib.set!(Arblib.arb_struct(), MathConstants.γ),
-        )
+        # Intervals
+        let x = Arb(1.5)
+            # Set x to the interval [1, 2]
+            Arblib.set!(Arblib.radref(x), 1, -1)
 
-        @test Arb(0) < Arblib.set!(Arb(), MathConstants.catalan) < Arb(1)
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.catalan),
-            Arblib.set!(Arblib.realref(Acb()), MathConstants.catalan),
-        )
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.catalan),
-            Arblib.set!(Arblib.arb_struct(), MathConstants.catalan),
-        )
+            @test Arblib.contains(Arblib.set!(T(), (Mag(1), Mag(2))), x)
+            @test Arblib.contains(Arblib.set!(T(), (Arf(1), Arf(2))), x)
+            @test Arblib.contains(Arblib.set!(T(), (BigFloat(1), BigFloat(2))), x)
 
-        @test Arblib.overlaps(
-            Arb(BigFloat(MathConstants.φ)),
-            Arblib.set!(Arb(), MathConstants.φ),
-        )
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.φ),
-            Arblib.set!(Arblib.realref(Acb()), MathConstants.φ),
-        )
-        @test Arblib.equal(
-            Arblib.set!(Arb(), MathConstants.φ),
-            Arblib.set!(Arblib.arb_struct(), MathConstants.φ),
-        )
+            @test Arblib.contains(Arblib.set!(T(), (1, 2)), x)
+            @test Arblib.contains(Arblib.set!(T(), (1.0, 2.0)), x)
+            @test Arblib.contains(Arblib.set!(T(), (1, 2.0)), x)
+        end
 
-        # Intervals: MagLike, ArfLike, BigFloat
-        @test Arblib.overlaps(
-            Arblib.set!(Arb(), (Mag(1), Mag(2))),
-            Arblib.set!(Arb(), (Arf(1), Arf(2))),
-        )
+        # Thin interval
+        @test Arblib.set!(T(), (Mag(1), Mag(1))) == one(Arb)
+        @test Arblib.set!(T(), (Arf(1), Arf(1))) == one(Arb)
+        @test Arblib.set!(T(), (BigFloat(1), BigFloat(1))) == one(Arb)
+        @test Arblib.set!(T(), (1, 1)) == one(Arb)
+        @test Arblib.set!(T(), (1.0, 1.0)) == one(Arb)
+        @test Arblib.set!(T(), (1, 1.0)) == one(Arb)
 
-        @test Arblib.equal(
-            Arblib.set!(Arb(), (Arf(1), Arf(2))),
-            Arblib.set!(Arb(), (BigFloat(1), BigFloat(2))),
-        )
-
-        @test Arblib.radref(Arblib.set!(Arb(), (Arf(1), Arf(3)))) >= Mag(1)
-        @test Arblib.midref(Arblib.set!(Arb(), (Arf(1), Arf(3)))) >= Arf(1)
-
-        @test Arblib.radref(Arblib.set!(Arb(prec = 64), (BigFloat(π), BigFloat(π)))) >
-              Mag(0)
+        # Check handling of precision
+        @test !iszero(radius(Arblib.set!(Arb(prec = 64), (BigFloat(π), BigFloat(π)))))
         @test iszero(
-            Arblib.radref(
+            radius(
                 Arblib.set!(
                     Arb(prec = 64),
                     (BigFloat(π), BigFloat(π)),
@@ -110,84 +97,84 @@
                 ),
             ),
         )
-
-        @test_throws ArgumentError Arblib.set!(Arb(), (Arf(2), Arf(1)))
-
-        # Intervals: General
-        @test Arblib.contains(Arblib.set!(Arb(), (1, π)), Arb(π))
-        @test Arblib.contains(Arblib.set!(Arb(), (ℯ, Arb(4))), Arb(π))
-        @test Arblib.equal(
-            Arblib.set!(Arb(), (-2, 2)),
-            Arblib.set!(Arb(), (Arf(-2), Arf(2))),
-        )
-
-        @test Mag(1e-20) < Arblib.radref(Arblib.set!(Arb(prec = 64), (π, π))) < Mag(1e-10)
+        @test Mag(1e-20) < radius(Arblib.set!(Arb(prec = 64), (π, π))) < Mag(1e-10)
         @test Mag(1e-80) <
-              Arblib.radref(Arblib.set!(Arb(prec = 64), (π, π), prec = 256)) <
+              radius(Arblib.set!(Arb(prec = 64), (π, π), prec = 256)) <
               Mag(1e-70)
 
-        @test_throws ArgumentError Arblib.set!(Arb(), (2, 1))
+        # Check enclosure of irrationals
+        @test Arblib.contains(Arblib.set!(T(), (1, π)), Arb(π))
+        @test Arblib.contains(Arblib.set!(T(), (ℯ, Arb(4))), Arb(ℯ))
+
+        @test_throws ArgumentError Arblib.set!(T(), (Mag(2), Mag(1)))
+        @test_throws ArgumentError Arblib.set!(T(), (Arf(2), Arf(1)))
+        @test_throws ArgumentError Arblib.set!(T(), (BigFloat(2), BigFloat(1)))
+        @test_throws ArgumentError Arblib.set!(T(), (2, 1))
+        @test_throws ArgumentError Arblib.set!(T(), (2.0, 1.0))
+        @test_throws ArgumentError Arblib.set!(T(), (2, 1.0))
     end
 
-    @testset "Acb" begin
-        @test Arblib.set!(Acb(), BigInt(typemax(Int)) + 1) ==
-              Acb(BigFloat(typemax(Int)) + 1)
+    @testset "$name" for (name, T) in [
+        ("Acb", Acb),
+        ("AcbRef", (args...) -> AcbRefVector([Acb(args...)])[1]),
+    ]
+        # Setting real part
+        @test Arblib.set!(T(), one(Mag)) == one(Acb)
+        @test Arblib.set!(T(), one(Mag).mag) == one(Acb)
+        @test Arblib.set!(T(), one(Arf)) == one(Acb)
+        @test Arblib.set!(T(), one(Arf).arf) == one(Acb)
+        @test Arblib.set!(T(), one(Arb)) == one(Acb)
+        @test Arblib.set!(T(), one(Arb).arb) == one(Acb)
+        @test Arblib.set!(T(), one(Int)) == one(Acb)
+        @test Arblib.set!(T(), one(Int128)) == one(Acb)
+        @test Arblib.set!(T(), one(Float64)) == one(Acb)
+        @test Arblib.set!(T(), one(BigInt)) == one(Acb)
+        @test Arblib.set!(T(), one(BigFloat)) == one(Acb)
+        @test isequal(Arblib.set!(T(), ℯ), Acb(Arb(ℯ)))
+        @test isequal(Arblib.set!(T(), (1, 2)), Acb(Arb((1, 2))))
 
-        @test Arblib.set!(Acb(), BigFloat(1.0)) == one(Acb)
-        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), BigFloat(1.0)), one(Acb))
-        x = Arblib.set!(Acb(), ℯ)
-        @test isequal(Arblib.realref(x), Arb(ℯ))
-        @test Arblib.imagref(x) == zero(Arb)
-        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), BigFloat(1.0)), one(Acb))
-        @test Arblib.set!(Acb(), one(Arf).arf) == one(Acb)
-        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), one(Arf).arf), one(Acb))
-        @test Arblib.set!(Acb(0, 5), BigFloat(1.0)) == one(Acb)
+        # Test that imaginary part is zeroed out
+        @test Arblib.set!(T(0, 1), one(Mag)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Mag).mag) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Arf)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Arf).arf) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Arb)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Arb).arb) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Int)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Int128)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(BigInt)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(Float64)) == one(Acb)
+        @test Arblib.set!(T(0, 1), one(BigFloat)) == one(Acb)
+        @test isequal(Arblib.set!(T(0, 1), ℯ), Acb(Arb(ℯ)))
+        @test isequal(Arblib.set!(T(0, 1), (1, 2)), Acb(Arb((1, 2))))
 
-        @test Arblib.set!(Acb(), BigFloat(1.0), 2) == Acb(1, 2)
-        x = Arblib.set!(Acb(), π, Arf(4))
-        @test isequal(Arblib.realref(x), Arb(π))
-        @test isequal(Arblib.imagref(x), Arb(4))
-        @test Arblib.set!(Acb(), Arb(1), Arf(2)) == Acb(1, 2)
-        @test Arblib.set!(Acb(), Arb(1).arb, Arf(2).arf) == Acb(1, 2)
+        # Large integer
+        let x = Int128(227725055589944414706309)
+            @test Arblib.set!(T(), UInt128(x)) == Acb(Arb("227725055589944414706309"))
+            @test Arblib.set!(T(), x) == Acb(Arb("227725055589944414706309"))
+            @test Arblib.set!(T(), -x) == Acb(Arb("-227725055589944414706309"))
+            @test Arblib.set!(T(), BigInt(x)) == Acb(Arb("227725055589944414706309"))
+            @test Arblib.set!(T(), -BigInt(x)) == Acb(Arb("-227725055589944414706309"))
+        end
 
-        @test Arblib.set!(Acb(), Complex(1, 2)) == Acb(1, 2)
-        @test Arblib.set!(Acb(), Complex(BigFloat(1), BigFloat(2))) == Acb(1, 2)
-        @test Arblib.equal(Arblib.set!(Arblib.acb_struct(), Complex(1, 2)), Acb(1, 2))
+        # Setting real and imaginary part
+        # Testing with a various mix of arguments
+        @test real(Arblib.set!(T(), 1, 2)) == 1
+        @test imag(Arblib.set!(T(), 1, 2)) == 2
+        @test real(Arblib.set!(T(), Arf(1), Mag(2))) == 1
+        @test imag(Arblib.set!(T(), Arf(1), Mag(2))) == 2
+        @test isequal(real(Arblib.set!(T(), (1, 2), π)), Arb((1, 2)))
+        @test isequal(imag(Arblib.set!(T(), (1, 2), π)), Arb(π))
+        @test real(Arblib.set!(T(), Arf(1).arf, Mag(2).mag)) == 1
+        @test imag(Arblib.set!(T(), Arf(1).arf, Mag(2).mag)) == 2
 
-        x = Arblib.set!(Acb(), π)
-        @test isequal(Arblib.realref(x), Arb(π))
-        @test Arblib.imagref(x) == zero(Arb)
-        x = Arblib.set!(Arblib.acb_struct(), π)
-        @test Arblib.equal(Arblib.realref(x), Arb(π))
-        @test Arblib.equal(Arblib.imagref(x), zero(Arb))
+        # From complex
+        @test Arblib.set!(T(), Complex(1, 2)) == Acb(1, 2)
+        @test Arblib.set!(T(), Complex(BigFloat(1), BigFloat(2))) == Acb(1, 2)
+        @test Arblib.set!(T(), Complex(Arf(1), Arf(2))) == Acb(1, 2)
+        @test Arblib.set!(T(), Complex(Arb(1), Arb(2))) == Acb(1, 2)
 
-        @test Arblib.equal(Arblib.set!(Acb(), (1, 2)), Arblib.set!(Acb(), Arb((1, 2))))
-        @test Arblib.equal(
-            Arblib.set!(Acb(), (1, 2), (3, 4)),
-            Arblib.set!(Acb(), Arb((1, 2)), Arb((3, 4))),
-        )
+        # π
+        @test isequal(Arblib.set!(T(), π), Acb(Arb(π)))
     end
-
-    @testset "Set Rational" begin
-        z = Arb(prec = 64)
-        z[] = 1 // 2
-        @test z == 0.5
-
-        z = Acb(prec = 64)
-        z[] = 1 // 2
-        @test z == 0.5
-
-        z = Acb(prec = 64)
-        z[] = 1 // 2 + 3 // 4 * im
-        @test z == 0.5 + 0.75im
-    end
-
-    @testset "Set Int128" begin
-        x = 227725055589944414706309
-        @test Arb("-227725055589944414706309") == Arb(-x)
-        @test Acb("-227725055589944414706309") == Acb(-x)
-        @test Arb("227725055589944414706309") == Arb(UInt128(x))
-        @test Acb("227725055589944414706309") == Acb(UInt128(x))
-    end
-
 end

--- a/test/types-test.jl
+++ b/test/types-test.jl
@@ -1,6 +1,7 @@
 @testset "types" begin
     @testset "Mag" begin
         @test Mag() isa Mag
+        @test Mag(Arblib.cstruct(Mag())) isa Mag
         @test Mag(Mag()) isa Mag
         @test Mag(Arf()) isa Mag
         x = Mag()


### PR DESCRIPTION
This adds constructors from `BigInt` and also removes the `_mpz` suffix from the Julia function names.

As I mentioned in #136 I realized that we had not been stripping the `_mpz` suffix of the functions names from Arb and setters for `BigInt` did therefore not work properly. In addition to that we have in many places used the `Integer` type when we really need something that can be converted to an `Int`, this made the code cleaner and made it work well with other small integer types. However it lead to problems for `BigInt` since they cannot always be converted to `Int`.

Notice that this would technically be a breaking change since some of the functions change name, e.g. `set_mpz!` now becomes `set!`. You could probably argue that the previous name was a bug though and I would surprised if anyone relies on it.