### PR TITLE
Update the setters for Arb from a tuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -76,15 +76,23 @@ function set!(
     (a, b)::NTuple{2,Union{MagLike,ArfLike,BigFloat}};
     prec::Integer = precision(res),
 )
-    a <= b || throw(ArgumentError("must have a <= b, got a = $a and b = $b"))
+    # Checking a > b instead of a <= b also handles NaN correctly
+    a > b && throw(ArgumentError("must have a <= b, got a = $a and b = $b"))
     return set_interval!(res, a, b, prec = prec)
 end
 
 function set!(res::ArbLike, (a, b)::Tuple{<:Real,<:Real}; prec::Integer = precision(res))
-    # TODO: This is not strictly required to check.
+    # This is not strictly required to check since the union will give
+    # an enclosure anyway. But since thus method is designed for a <=
+    # b adding this check could catch some bugs.
     a > b && throw(ArgumentError("must have a <= b, got a = $a and b = $b"))
-    # TODO: If we really want to we could avoid one allocation by reusing res
-    return union!(res, Arb(a, prec = prec), Arb(b, prec = prec), prec = prec)
+    if !(a isa ArbLike)
+        a = Arb(a, prec = prec)
+    end
+    if !(b isa ArbLike)
+        b = Arb(b, prec = prec)
+    end
+    return union!(res, a, b, prec = prec)
 end
 
 # Acb

--- a/test/setters-test.jl
+++ b/test/setters-test.jl
@@ -95,6 +95,7 @@
             @test Arblib.contains(Arblib.set!(T(), (Arf(1), Arf(2))), x)
             @test Arblib.contains(Arblib.set!(T(), (BigFloat(1), BigFloat(2))), x)
 
+            @test Arblib.contains(Arblib.set!(T(), (Arb(1), Arb(2))), x)
             @test Arblib.contains(Arblib.set!(T(), (1, 2)), x)
             @test Arblib.contains(Arblib.set!(T(), (1.0, 2.0)), x)
             @test Arblib.contains(Arblib.set!(T(), (1, 2.0)), x)
@@ -104,9 +105,20 @@
         @test Arblib.set!(T(), (Mag(1), Mag(1))) == one(Arb)
         @test Arblib.set!(T(), (Arf(1), Arf(1))) == one(Arb)
         @test Arblib.set!(T(), (BigFloat(1), BigFloat(1))) == one(Arb)
+
+        @test Arblib.set!(T(), (Arb(1), Arb(1))) == one(Arb)
         @test Arblib.set!(T(), (1, 1)) == one(Arb)
         @test Arblib.set!(T(), (1.0, 1.0)) == one(Arb)
         @test Arblib.set!(T(), (1, 1.0)) == one(Arb)
+
+        # NaN endpoints
+        @test Arblib.isnan(Arblib.set!(T(), (Arf(NaN), Arf(0))))
+        @test Arblib.isnan(Arblib.set!(T(), (Arf(0), Arf(NaN))))
+        @test Arblib.isnan(Arblib.set!(T(), (Arf(NaN), Arf(NaN))))
+
+        @test Arblib.isnan(Arblib.set!(T(), (NaN, 0)))
+        @test Arblib.isnan(Arblib.set!(T(), (0, NaN)))
+        @test Arblib.isnan(Arblib.set!(T(), (NaN, NaN)))
 
         # Check handling of precision
         @test !iszero(radius(Arblib.set!(Arb(prec = 64), (BigFloat(π), BigFloat(π)))))


### PR DESCRIPTION
This fixes construction with `Arf` and `BigFloat` in case one of the arguments is `NaN` and add tests to check this behavior. It also removes some allocations when the arguments are of type `Arb`.