### PR TITLE
Add deepcopy method for Arb structs

### DIFF
--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -160,6 +160,7 @@ mutable struct acb_mat_struct
 end
 
 const ArbStructTypes = Union{
+    mag_struct,
     arf_struct,
     arb_struct,
     acb_struct,
@@ -170,6 +171,33 @@ const ArbStructTypes = Union{
     arb_mat_struct,
     acb_mat_struct,
 }
+
+function Base.deepcopy_internal(x::T, stackdict::IdDict) where {T<:ArbStructTypes}
+    haskey(stackdict, x) && return stackdict[x]
+    y = set!(T(), x)
+    stackdict[x] = y
+    return y
+end
+
+function Base.deepcopy_internal(
+    x::T,
+    stackdict::IdDict,
+) where {T<:Union{arb_vec_struct,acb_vec_struct}}
+    haskey(stackdict, x) && return stackdict[x]
+    y = set!(T(x.n), x, x.n)
+    stackdict[x] = y
+    return y
+end
+
+function Base.deepcopy_internal(
+    x::T,
+    stackdict::IdDict,
+) where {T<:Union{arb_mat_struct,acb_mat_struct}}
+    haskey(stackdict, x) && return stackdict[x]
+    y = set!(T(x.r, x.c), x)
+    stackdict[x] = y
+    return y
+end
 
 mutable struct calc_integrate_opt_struct
     deg_limit::Int

--- a/test/arb_types-test.jl
+++ b/test/arb_types-test.jl
@@ -11,4 +11,42 @@
         @test precision(typeof(x)) == prec
         @test precision(Ptr{typeof(x)}) == prec
     end
+
+    @testset "deepcopy" begin
+        for x in [
+            Arblib.mag_struct(),
+            Arblib.arf_struct(),
+            Arblib.arb_struct(),
+            Arblib.acb_struct(),
+            Arblib.arb_poly_struct(),
+            Arblib.acb_poly_struct(),
+            Arblib.arb_mat_struct(2, 3),
+            Arblib.acb_mat_struct(2, 3),
+        ]
+            @test !iszero(Arblib.equal(x, deepcopy(x)))
+        end
+
+        # No Arblib.equal method for vectors, just check that the
+        # length is correct.
+        x = Arblib.arb_vec_struct(2)
+        @test deepcopy(x).n == x.n
+        x = Arblib.acb_vec_struct(2), @test deepcopy(x).n == x.n
+
+        # Check that changing the deepcopy doesn't change the
+        # original. We need to make sure to use large enough values so
+        # that the data doesn't get inlined in the struct.
+        x1 = Arblib.set!(Arblib.arb_struct(), π)
+        x2 = Arblib.set!(Arblib.arb_struct(), π)
+        y = deepcopy(x1)
+        Arblib.set!(y, ℯ)
+        @test isequal(x1, x2)
+
+        # Check so that x is only copied once.
+        x = Arblib.set!(Arblib.arb_struct(), π)
+        v = [x, x]
+        w = deepcopy(v)
+        Arblib.set!(w[1], ℯ)
+        @test isequal(x, Arblib.set!(Arblib.arb_struct(), π))
+        @test isequal(w[1], w[2])
+    end
 end


### PR DESCRIPTION
The other week I experienced weird behavior when running some computations. After a long time I managed to track it down to doing a `deepcopy` of some `Arb` values and we have never implemented a proper method for that. It used the default implementation in Julia which meant that the copy would share the same pointer to the limbs as the original. This commit adds proper methods for `deepcopy`.