### PR TITLE
Fix/series constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -196,7 +196,9 @@ for (TSeries, TPoly) in [(:ArbSeries, :ArbPoly), (:AcbSeries, :AcbPoly)]
     )
         p = $TSeries(degree = degree, prec = prec)
         @inbounds p[0] = coeffs[1]
-        @inbounds p[1] = coeffs[2]
+        if degree >= 1
+            @inbounds p[1] = coeffs[2]
+        end
         return p
     end
 

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -202,8 +202,11 @@ for (TSeries, TPoly) in [(:ArbSeries, :ArbPoly), (:AcbSeries, :AcbPoly)]
         return p
     end
 
-    @eval $TSeries(p::Union{$TPoly,$TSeries}; prec::Integer = precision(p)) =
-        set!($TSeries(degree = degree(p), prec = prec), p)
+    @eval $TSeries(
+        p::Union{$TPoly,$TSeries};
+        degree::Integer = degree(p),
+        prec::Integer = precision(p),
+    ) = set_trunc!($TSeries(degree = degree, prec = prec), p, degree + 1)
 end
 function AcbSeries(p::Union{ArbPoly,ArbSeries}; degree = degree(p), prec = precision(p))
     res = AcbSeries(degree = degree, prec = prec)

--- a/test/series.jl
+++ b/test/series.jl
@@ -84,7 +84,11 @@
               TSeries((5.0,)) ==
               TSeries(T[5]) ==
               TSeries(T(5))
-        @test TSeries(TSeries((1, 2))) == TSeries(ArbPoly((1, 2))) == TSeries((1, 2))
+        @test TSeries(TSeries((1, 2))) ==
+              TSeries(ArbPoly((1, 2))) ==
+              TSeries(TSeries((1, 2, 3)), degree = 1) ==
+              TSeries(ArbPoly((1, 2, 3)), degree = 1) ==
+              TSeries((1, 2))
 
         # A previous bug always set both coefficients
         @test Arblib.cstruct(TSeries((2, 1), degree = 0)).length == 1

--- a/test/series.jl
+++ b/test/series.jl
@@ -86,6 +86,9 @@
               TSeries(T(5))
         @test TSeries(TSeries((1, 2))) == TSeries(ArbPoly((1, 2))) == TSeries((1, 2))
 
+        # A previous bug always set both coefficients
+        @test Arblib.cstruct(TSeries((2, 1), degree = 0)).length == 1
+
         @test precision(TSeries(degree = 1, prec = 64)) == 64
         @test precision(TSeries(0, degree = 1, prec = 64)) == 64
         @test precision(TSeries((T(0),), prec = 64)) == 64


### PR DESCRIPTION
This fixes a bug from #142 and also adds support for specifying the degree when constructing a series from a polynomial or a series.