### PR TITLE
Fix minimum and maximum

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,29 +173,15 @@ TODO: Come up with more examples
 ### Implementation details
 In some cases the implementation in Julia implicitly makes certain
 assumptions to improve performance and this can lead to issues. For
-example the `maximum` method in Julia checks for `NaN` results (on
-which is short fuses) using `x == x`, which works for most numerical
-types but not for `Arb` (`x == x` is only true if the radius is zero).
-See <https://github.com/JuliaLang/julia/issues/36287> for some more
-details. Arblib implements its own `maximum` method which gives
-rigorous results, but it only covers the case
-`maximum(AbstractFloat{Arb})`.
-
-``` julia
-julia> f = i -> Arb((i, i + 1));
-
-julia> A = f.(0:1000);
-
-julia> maximum(A)
-[1.00e+3 +/- 1.01]
-
-julia> maximum(A, dims = 1)
-1-element Array{Arb,1}:
- [+/- 1.01]
-
-julia> maximum(f, 0:1000)
-[+/- 1.01]
-```
+example, prior to Julia version 1.8 the `minimum` and `maximum`
+methods in Julia checked for `NaN` results (on which is short fuses)
+using `x == x`, which works for most numerical types but not for `Arb`
+(`x == x` is only true if the radius is zero). See
+<https://github.com/JuliaLang/julia/issues/36287> and in particular
+<https://github.com/JuliaLang/julia/issues/45932> for more details.
+Since Julia version 1.8 the `minimum` and `maximum` methods work
+correctly for `Arb`, for earlier versions of Julia it only works
+correctly in some cases.
 
 These types of problems are the hardest to find since they are not
 clear from the documentation but you have to read the implementation,

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -29,9 +29,6 @@
         @test min(Mag(1), Mag(2)) == Mag(1)
         @test max(Mag(1), Mag(2)) == Mag(2)
         @test minmax(Mag(1), Mag(2)) == minmax(Mag(2), Mag(1)) == (Mag(1), Mag(2))
-        @test minimum(Mag[10:20; 0:9]) == Mag(0)
-        @test maximum(Mag[10:20; 0:9]) == Mag(20)
-        @test extrema(Mag[10:20; 0:9]) == (Mag(0), Mag(20))
     end
 
     @testset "Arf" begin
@@ -74,9 +71,6 @@
         @test min(Arf(1), Arf(2)) == Arf(1)
         @test max(Arf(1), Arf(2)) == Arf(2)
         @test minmax(Arf(1), Arf(2)) == minmax(Arf(2), Arf(1)) == (Arf(1), Arf(2))
-        @test minimum(Arf[10:20; 0:9]) == Arf(0)
-        @test maximum(Arf[10:20; 0:9]) == Arf(20)
-        @test extrema(Arf[10:20; 0:9]) == (Arf(0), Arf(20))
     end
 
     @testset "$T" for T in [Arb, Acb]
@@ -188,21 +182,6 @@
         @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (-1, 0)))
         @test all(Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (2, 3)))
         @test all(.!Arblib.contains.(minmax(Arb((0, 2)), Arb((-1, 3))), (3, -1)))
-        @test minimum(Arb[10:20; 0:9]) == Arb(0)
-        @test maximum(Arb[10:20; 0:9]) == Arb(20)
-        @test extrema(Arb[10:20; 0:9]) == (Arb(0), Arb(20))
-        A = [Arb((i, i + 1)) for i = 0:10]
-        @test Arblib.contains(minimum(A), Arb((0, 1)))
-        @test Arblib.contains(minimum(reverse(A)), Arb((0, 1)))
-        @test Arblib.contains(maximum(A), Arb((10, 11)))
-        @test Arblib.contains(maximum(reverse(A)), Arb((10, 11)))
-        @test all(Arblib.contains.(extrema(A), (Arb((0, 1)), Arb((10, 11)))))
-        # These fails with the default implementation of minimum and maximum
-        @test Arblib.contains(
-            minimum([Arb((-i, -i + 1)) for i = 0:1000]),
-            Arb((-1000, -999)),
-        )
-        @test Arblib.contains(maximum([Arb((i, i + 1)) for i = 0:1000]), Arb((1000, 1001)))
     end
 
     @testset "Acb - specific" begin
@@ -242,5 +221,92 @@
 
         @test abs(Acb(3, 4)) isa Arb
         @test abs(Acb(3, 4)) == Arb(5)
+    end
+
+    @testset "minimum/maximum/extrema" begin
+        # See https://github.com/JuliaLang/julia/issues/45932 for
+        # discussions about the issues with the Base implementation
+
+        # Currently there is no special implementation of extrema, the
+        # default implementation works well. But to help find future
+        # issues we test it here as well.
+
+        A = Arb[10:20; 0:9]
+        @test minimum(A) == 0
+        @test maximum(A) == 20
+        @test extrema(A) == (0, 20)
+
+        A = [Arb((i, i + 1)) for i = 0:20]
+        @test contains(minimum(A), Arb((0, 1)))
+        @test contains(minimum(reverse(A)), Arb((0, 1)))
+        @test contains(maximum(A), Arb((20, 21)))
+        @test contains(maximum(reverse(A)), Arb((20, 21)))
+        @test all(contains.(extrema(A), (Arb((0, 1)), Arb((20, 21)))))
+        @test all(contains.(extrema(reverse(A)), (Arb((0, 1)), Arb((20, 21)))))
+
+        # Fails in Julia version < 1.8 with default implementation due
+        # to short circuiting in Base.mapreduce_impl
+        A = [setball(Arb, 2, 1); zeros(Arb, 257)]
+        @test iszero(minimum(A))
+        @test iszero(maximum(-A))
+        @test iszero(extrema(A)[1])
+        @test iszero(extrema(-A)[2])
+        # Before 1.8.0 these still fails and there is no real way to
+        # overload them
+        if VERSION < v"1.8.0-rc3"
+            @test_broken iszero(minimum(identity, A))
+            @test_broken iszero(maximum(identity, -A))
+        else
+            @test iszero(minimum(identity, A))
+            @test iszero(maximum(identity, -A))
+        end
+        # These work
+        @test iszero(extrema(identity, A)[1])
+        @test iszero(extrema(identity, -A)[2])
+
+        # Fails with default implementation due to Base._fast
+        #A = [Arb(0); [setball(Arb, 0, i) for i in reverse(0:257)]]
+        A = [setball(Arb, 0, i) for i = 0:257]
+        @test contains(minimum(A), -257)
+        @test contains(maximum(A), 257)
+        @test contains(extrema(A)[1], -257)
+        @test contains(extrema(A)[2], 257)
+        @test contains(minimum(identity, A), -257)
+        @test contains(maximum(identity, A), 257)
+        @test contains(extrema(identity, A)[1], -257)
+        @test contains(extrema(identity, A)[2], 257)
+
+        # Fails with default implementation due to both short circuit
+        # and Base._fast
+        A = [setball(Arb, 0, i) for i = 0:1000]
+        @test contains(minimum(A), -1000)
+        @test contains(maximum(A), 1000)
+        @test contains(extrema(A)[1], -1000)
+        @test contains(extrema(A)[2], 1000)
+        if VERSION < v"1.8.0-rc3"
+            @test_broken contains(minimum(identity, A), -1000)
+            @test_broken contains(maximum(identity, A), 1000)
+        else
+            @test contains(minimum(identity, A), -1000)
+            @test contains(maximum(identity, A), 1000)
+        end
+        @test contains(extrema(identity, A)[1], -1000)
+        @test contains(extrema(identity, A)[2], 1000)
+
+        @test !Base.isbadzero(min, zero(Mag))
+        @test !Base.isbadzero(min, zero(Arf))
+        @test !Base.isbadzero(min, zero(Arb))
+
+        @test !Base.isbadzero(max, zero(Mag))
+        @test !Base.isbadzero(max, zero(Arf))
+        @test !Base.isbadzero(max, zero(Arb))
+
+        @test !Base.isgoodzero(min, zero(Mag))
+        @test !Base.isgoodzero(min, zero(Arf))
+        @test !Base.isgoodzero(min, zero(Arb))
+
+        @test !Base.isgoodzero(max, zero(Mag))
+        @test !Base.isgoodzero(max, zero(Arf))
+        @test !Base.isgoodzero(max, zero(Arb))
     end
 end


### PR DESCRIPTION
This is an important fix I have wanted to do for a long time that is finally possible with Julia 1.8. It makes the `minimum` and `maximum` methods work correctly for `Arb` in all cases. Before this we had an implementation which only helped in some cases, it was impossible to overload the general case. Most of the details of the issues can be found in https://github.com/JuliaLang/julia/issues/45932. 

In addition to fixing the issues mentioned above I have removed the specialized implementation of `extrema` as well as the implementations of `minimum` and `maximum` for `Mag` and `Arf`. This does reduce the performance, the earlier version used inplace arithmetic, but I think it is worth the reduced maintenance burden.

This probably has to be rebased once #155 is merged.