### PR TITLE
Update struct for Series

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.7.3"
+version = "0.8.0"
 
 [deps]
 Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -17,6 +17,8 @@ Base.precision(x::ArbTypes) = x.prec
 Base.precision(x::MagLike) = DEFAULT_PRECISION[]
 # disambiguation
 Base.precision(::MagOrRef) = DEFAULT_PRECISION[]
+# ArbSeries and AcbSeries don't store their precision
+Base.precision(x::Union{ArbSeries,AcbSeries}) = precision(x.poly)
 
 @inline _precision(x::Union{ArbTypes,BigFloat}) = precision(x)
 @inline _precision(z::Complex) = max(_precision(real(z)), _precision(imag(z)))
@@ -60,7 +62,7 @@ Base.setprecision(A::T, prec::Integer) where {T<:Union{AcbMatrix,AcbRefMatrix}} 
 
 Base.setprecision(poly::ArbPoly, prec::Integer) = ArbPoly(poly.arb_poly; prec)
 Base.setprecision(series::ArbSeries, prec::Integer) =
-    ArbSeries(series.arb_poly, degree = degree(series); prec)
+    ArbSeries(series, degree = degree(series); prec)
 Base.setprecision(poly::AcbPoly, prec::Integer) = AcbPoly(poly.acb_poly; prec)
 Base.setprecision(series::AcbSeries, prec::Integer) =
-    AcbSeries(series.acb_poly, degree = degree(series); prec)
+    AcbSeries(series, degree = degree(series); prec)

--- a/src/types.jl
+++ b/src/types.jl
@@ -91,14 +91,16 @@ end
 
 """
     ArbSeries <: Number
+
+This type should be considered experimental, the interface for it
+might change in the future.
 """
 struct ArbSeries <: Number
-    arb_poly::arb_poly_struct
+    poly::ArbPoly
     degree::Int
-    prec::Int
 
     ArbSeries(; degree::Integer = 0, prec::Integer = DEFAULT_PRECISION[]) =
-        fit_length!(new(arb_poly_struct(), degree, prec), degree + 1)
+        fit_length!(new(ArbPoly(; prec), degree), degree + 1)
 end
 
 """
@@ -113,14 +115,16 @@ end
 
 """
     AcbSeries <: Number
+
+This type should be considered experimental, the interface for it
+might change in the future.
 """
 struct AcbSeries <: Number
-    acb_poly::acb_poly_struct
+    poly::AcbPoly
     degree::Int
-    prec::Int
 
     AcbSeries(; degree::Integer = 0, prec::Integer = DEFAULT_PRECISION[]) =
-        fit_length!(new(acb_poly_struct(), degree, prec), degree + 1)
+        fit_length!(new(AcbPoly(; prec), degree), degree + 1)
 end
 
 """
@@ -234,6 +238,10 @@ for (T, prefix) in (
         Base.convert(::Type{$arbstruct}, x::$T) = cstruct(x)
     end
 end
+
+# ArbSeries and AcbSeries requires a different cstruct implementation
+cstruct(x::ArbSeries) = cstruct(x.poly)
+cstruct(x::AcbSeries) = cstruct(x.poly)
 
 # handle Ref types
 for prefix in [:mag, :arf, :arb, :acb]


### PR DESCRIPTION
Here comes a more opinionated change where some input could be helpful.

This change originates from a problem I have, but it doesn't solve the problem. The problem is that I want `ArbSeries` (and `AcbSeries`) to satisfy the invariances
```julia
x::ArbSeries + zero(ArbSeries) == x
(x::ArbSeries) * one(ArbSeries) == x
```
At the moment this doesn't work because the type `ArbSeries` doesn't contain any information about the degree of the series. The only way I see to solve this issue is to parameterize the `ArbSeries` type on the degree, so it would become `ArbSeries{N}` where `N` is the degree. However, I'm afraid that would be too costly in terms of compilation since all methods would have to be compiled separately for each degree.

This PR doesn't solve the above problem, but moves one step towards some sort of solution. It changes the Series types so that the polynomial is stored separately from the degree. For methods that don't need the degree, but only act on the underlying polynomial, it is then possible to pass them just the polynomial. If we ever decide to parameterize the type (I'm not sure we'll) this would at least allow for having less of the code needing compilation based on the degree.

More precisely the PR changes the layout of the struct for `ArbSeries` and `AcbSeries`, for `ArbSeries` it changes from
```julia
struct ArbSeries <: Number
    arb_poly::arb_poly_struct
    degree::Int
    prec::Int
end
```
to
```julia
struct ArbSeries <: Number
    poly::ArbPoly
    degree::Int
end
```
It makes it possible to, given an `ArbSeries`, treat it as an `ArbPoly` for some computations, without having to allocate. At the moment there is no non-allocating constructor for `ArbSeries`, this could possibly be added in the future.

I can also note that I don't think there is any performance penalty for this change. The struct is immutable so everything seems to be stored inline anyway.
