### PR TITLE
Make setindex! always use set!

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -45,7 +45,6 @@ Base.@propagate_inbounds function Base.setindex!(
     i::Integer,
     j::Integer,
 )
-    @boundscheck checkbounds(A, i, j)
     ref(A, i, j)[] = x
     return x
 end
@@ -97,7 +96,6 @@ Base.@propagate_inbounds function Base.setindex!(
     i::Integer,
     j::Integer,
 )
-    @boundscheck checkbounds(A, i, j)
     ref(A, i, j)[] = x
     return x
 end

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -1,3 +1,6 @@
+# Use res[] = x as short hand for Arblib.set!(res, x)
+Base.setindex!(res::Union{MagLike,ArfLike,ArbLike,AcbLike}, x) = set!(res, x)
+
 # Mag
 set!(res::MagLike, x::Integer) = set!(res, convert(UInt, x))
 set!(res::MagLike, ::Irrational{:π}) = const_pi!(res)

--- a/src/types.jl
+++ b/src/types.jl
@@ -305,10 +305,3 @@ const ArbTypes = Union{
     AcbPoly,
     AcbSeries,
 }
-
-Base.setindex!(x::Union{Mag,MagRef,Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}, z::Number) =
-    set!(x, z)
-Base.setindex!(x::MagOrRef, z::Ptr{mag_struct}) = set!(x, z)
-Base.setindex!(x::ArfOrRef, z::Ptr{arf_struct}) = set!(x, z)
-Base.setindex!(x::ArbOrRef, z::Ptr{arb_struct}) = set!(x, z)
-Base.setindex!(x::AcbOrRef, z::Ptr{acb_struct}) = set!(x, z)

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -38,7 +38,6 @@ Base.@propagate_inbounds function Base.setindex!(
     x,
     i::Integer,
 )
-    @boundscheck checkbounds(v, i)
     ref(v, i)[] = x
     return x
 end
@@ -84,7 +83,6 @@ Base.@propagate_inbounds function Base.setindex!(
     x,
     i::Integer,
 )
-    @boundscheck checkbounds(v, i)
     ref(v, i)[] = x
     return x
 end


### PR DESCRIPTION
Makes it so that `res[] = x` is a shorthand for `Arblib.set!(res, x)` in all cases, previously it was only implemented for some `x` types. In particular this makes `ArbVector([(1, 2)])` work as expected.