### PR TITLE
Update vector and matrix constructors

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,6 +1,5 @@
-## ArbMatrix AbstractMatrix interface
-Base.size(A::arb_mat_struct) = (A.r, A.c)
-Base.size(A::Union{ArbMatrix,ArbRefMatrix}) = size(A.arb_mat)
+# arb_mat_struct and acb_mat_struct methods
+Base.size(A::Union{arb_mat_struct,acb_mat_struct}) = (A.r, A.c)
 
 function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
     return ccall(
@@ -12,46 +11,6 @@ function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
         j - 1,
     )
 end
-Base.@propagate_inbounds function Base.getindex(A::ArbMatrix, i::Integer, j::Integer)
-    @boundscheck checkbounds(A, i, j)
-    x = Arb(prec = precision(A))
-    x[] = A.arb_mat[i, j]
-    x
-end
-Base.@propagate_inbounds function Base.getindex(A::ArbRefMatrix, i::Integer, j::Integer)
-    @boundscheck checkbounds(A, i, j)
-    return ArbRef(A.arb_mat[i, j], precision(A), cstruct(A))
-end
-
-"""
-    ref(A::ArbMatrix, i, j)
-
-Similar to `A[i,j]` but instead of an `Arb` returns an `ArbRef` which still shares the
-memory with the `(i,j)`-th entry of `A`.
-"""
-Base.@propagate_inbounds function ref(
-    A::Union{ArbMatrix,ArbRefMatrix},
-    i::Integer,
-    j::Integer,
-)
-    @boundscheck checkbounds(A, i, j)
-    return ArbRef(A.arb_mat[i, j], precision(A), cstruct(A))
-end
-
-Base.setindex!(A::arb_mat_struct, x, i::Integer, j::Integer) = (set!(A[i, j], x); x)
-Base.@propagate_inbounds function Base.setindex!(
-    A::Union{ArbMatrix,ArbRefMatrix},
-    x,
-    i::Integer,
-    j::Integer,
-)
-    ref(A, i, j)[] = x
-    return x
-end
-
-## AcbMatrix AbstractMatrix interface
-Base.size(A::acb_mat_struct) = (A.r, A.c)
-Base.size(A::Union{AcbMatrix,AcbRefMatrix}) = size(A.acb_mat)
 
 function Base.getindex(A::acb_mat_struct, i::Integer, j::Integer)
     return ccall(
@@ -63,46 +22,53 @@ function Base.getindex(A::acb_mat_struct, i::Integer, j::Integer)
         j - 1,
     )
 end
-Base.@propagate_inbounds function Base.getindex(A::AcbMatrix, i::Integer, j::Integer)
-    @boundscheck checkbounds(A, i, j)
-    x = Acb(prec = precision(A))
-    x[] = A.acb_mat[i, j]
-    x
-end
-Base.@propagate_inbounds function Base.getindex(A::AcbRefMatrix, i::Integer, j::Integer)
-    @boundscheck checkbounds(A, i, j)
-    return AcbRef(A.acb_mat[i, j], precision(A), cstruct(A))
-end
+
+Base.setindex!(A::Union{arb_mat_struct,acb_mat_struct}, x, i::Integer, j::Integer) =
+    (set!(A[i, j], x); x)
+
+# AbstractMatrix interface
+
+const Matrices = Union{ArbMatrixOrRef,AcbMatrixOrRef}
+
+Base.size(A::Matrices) = size(cstruct(A))
 
 """
-    ref(A::AcbMatrix, i, j)
+    ref(A::Union{ArbMatrixOrRef,AcbMatrixOrRef}, i, j)
 
-Similar to `A[i,j]` but instead of an `Acb` returns an `AcbRef` which still shares the
-memory with the `(i,j)`-th entry of `A`.
+Similar to `A[i,j]` but instead of an `Arb` or `Acb` returns an
+`ArbRef` or `AcbRef` which still shares the memory with the `(i,j)`-th
+entry of `A`.
 """
-Base.@propagate_inbounds function ref(
-    A::Union{AcbMatrix,AcbRefMatrix},
+Base.@propagate_inbounds function ref(A::ArbMatrixOrRef, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
+    return ArbRef(cstruct(A)[i, j], precision(A), cstruct(A))
+end
+Base.@propagate_inbounds function ref(A::AcbMatrixOrRef, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
+    return AcbRef(cstruct(A)[i, j], precision(A), cstruct(A))
+end
+
+Base.@propagate_inbounds function Base.getindex(
+    A::Union{ArbMatrix,AcbMatrix},
     i::Integer,
     j::Integer,
 )
     @boundscheck checkbounds(A, i, j)
-    return AcbRef(A.acb_mat[i, j], precision(A), cstruct(A))
+    return set!(eltype(A)(prec = precision(A)), cstruct(A)[i, j])
 end
-
-Base.setindex!(A::acb_mat_struct, x, i::Integer, j::Integer) = (set!(A[i, j], x); x)
-Base.@propagate_inbounds function Base.setindex!(
-    A::Union{AcbMatrix,AcbRefMatrix},
-    x,
+Base.@propagate_inbounds Base.getindex(
+    A::Union{ArbRefMatrix,AcbRefMatrix},
     i::Integer,
     j::Integer,
-)
+) = ref(A, i, j)
+
+Base.@propagate_inbounds function Base.setindex!(A::Matrices, x, i::Integer, j::Integer)
     ref(A, i, j)[] = x
     return x
 end
 
-## Common methods
+# General constructors
 
-# General constructor
 for (T, TOrRef) in [
     (:ArbMatrix, :ArbMatrixOrRef),
     (:ArbRefMatrix, :ArbMatrixOrRef),
@@ -135,21 +101,14 @@ for (T, TOrRef) in [
     end
 end
 
-const Matrices = Union{ArbMatrix,ArbRefMatrix,AcbMatrix,AcbRefMatrix}
-
-Base.copy(A::T) where {T<:Matrices} = copy!(T(size(A)...; prec = precision(A)), A)
+Base.copy(A::Matrices) = copy!(similar(A), A)
 function Base.copy!(A::T, B::T) where {T<:Matrices}
-    @boundscheck size(A) == size(B) || throw(DimensionMismatch())
-    set!(A, B)
-    A
-end
-function Base.copyto!(A::T, B::T) where {T<:Matrices}
-    @boundscheck size(A) == size(B) || throw(DimensionMismatch())
-    set!(A, B)
-    A
+    size(A) == size(B) || throw(DimensionMismatch())
+    return set!(A, B)
 end
 
-# Basic arithmetic
+# Arithmetic
+
 for (jf, af) in [(:+, :add!), (:-, :sub!)]
     @eval function Base.$jf(A::T, B::T) where {T<:Matrices}
         @boundscheck (
@@ -157,8 +116,7 @@ for (jf, af) in [(:+, :add!), (:-, :sub!)]
             throw(DimensionMismatch("Matrix sizes are not compatible."))
         )
         C = T(size(A, 1), size(B, 2); prec = _precision(A, B))
-        $af(C, A, B)
-        C
+        return $af(C, A, B)
     end
 end
 
@@ -169,49 +127,34 @@ function LinearAlgebra.mul!(C::T, A::T, B::T) where {T<:Matrices}
         (size(C) == (size(A, 1), size(B, 2)) && size(A, 2) == size(B, 1)) ||
         throw(DimensionMismatch("Matrix sizes are not compatible."))
     )
-    Arblib.mul!(C, A, B)
-    C
+    return Arblib.mul!(C, A, B)
 end
 
 function Base.:(*)(A::T, B::T) where {T<:Matrices}
     C = T(size(A, 1), size(B, 2); prec = _precision(A, B))
-    LinearAlgebra.mul!(C, A, B)
+    return LinearAlgebra.mul!(C, A, B)
 end
 
 # scalar multiplication
-function Base.:(*)(c::ArbLike, A::T) where {T<:Matrices}
-    C = similar(A)
-    Arblib.mul!(C, A, c)
-end
-function Base.:(*)(c::AcbLike, A::AcbMatrixLike)
-    C = similar(A)
-    Arblib.mul!(C, A, c)
-end
-function Base.:(*)(c::AcbLike, A::ArbMatrixLike)
+Base.:(*)(c::ArbOrRef, A::T) where {T<:Matrices} = Arblib.mul!(similar(A), A, c)
+Base.:(*)(c::AcbOrRef, A::AcbMatrixOrRef) = Arblib.mul!(similar(A), A, c)
+function Base.:(*)(c::AcbOrRef, A::ArbMatrixOrRef)
     C = AcbMatrix(A)
-    Arblib.mul!(C, C, c)
+    return Arblib.mul!(C, C, c)
 end
-Base.:(*)(A::T, c::AcbLike) where {T<:Matrices} = c * A
-Base.:(*)(A::T, c::ArbLike) where {T<:Matrices} = c * A
+Base.:(*)(A::Matrices, c::Union{ArbOrRef,AcbOrRef}) = c * A
 
 # scalar division
-function Base.:(\)(c::ArbLike, A::T) where {T<:Matrices}
-    C = similar(A)
-    Arblib.div!(C, A, c)
-end
-function Base.:(\)(c::AcbLike, A::AcbMatrixLike)
-    C = similar(A)
-    Arblib.div!(C, A, c)
-end
-function Base.:(\)(c::AcbLike, A::ArbMatrixLike)
+Base.:(\)(c::ArbOrRef, A::T) where {T<:Matrices} = Arblib.div!(similar(A), A, c)
+Base.:(\)(c::AcbOrRef, A::AcbMatrixOrRef) = Arblib.div!(similar(A), A, c)
+function Base.:(\)(c::AcbOrRef, A::ArbMatrixOrRef)
     C = AcbMatrix(A)
-    Arblib.div!(C, C, c)
+    return Arblib.div!(C, C, c)
 end
-Base.:(/)(A::T, c::AcbLike) where {T<:Matrices} = c \ A
-Base.:(/)(A::T, c::ArbLike) where {T<:Matrices} = c \ A
+Base.:(/)(A::Matrices, c::Union{ArbOrRef,AcbOrRef}) = c \ A
 
 # lu factorization
-function LinearAlgebra.lu!(A::T) where {T<:Matrices}
+function LinearAlgebra.lu!(A::Matrices)
     ipiv = zeros(Int, size(A, 2))
     retcode = lu!(ipiv, A, A; prec = precision(A))
     LinearAlgebra.LU(A, ipiv, retcode > 0 ? 0 : 1)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -103,9 +103,21 @@ end
 ## Common methods
 
 # General constructor
-for T in [:ArbMatrix, :ArbRefMatrix, :AcbMatrix, :AcbRefMatrix]
+for (T, TOrRef) in [
+    (:ArbMatrix, :ArbMatrixOrRef),
+    (:ArbRefMatrix, :ArbMatrixOrRef),
+    (:AcbMatrix, :AcbMatrixOrRef),
+    (:AcbRefMatrix, :AcbMatrixOrRef),
+]
+    @eval $T(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
+        $T(cstructtype($T)(r, c), shallow = true; prec)
+
+    @eval $T(v::$TOrRef; shallow::Bool = false, prec::Integer = precision(v)) =
+        $T(cstruct(v); shallow, prec)
+
+
     @eval function $T(A::AbstractMatrix; prec::Integer = _precision(A))
-        B = $T(size(A)...; prec = prec)
+        B = $T(size(A)...; prec)
         # ensure to handle all kind of indices
         ax1, ax2 = axes(A)
         for (i, i′) in enumerate(ax1), (j, j′) in enumerate(ax2)
@@ -115,7 +127,7 @@ for T in [:ArbMatrix, :ArbRefMatrix, :AcbMatrix, :AcbRefMatrix]
     end
 
     @eval function $T(v::AbstractVector; prec::Integer = _precision(v))
-        A = $T(length(v), 1; prec = prec)
+        A = $T(length(v), 1; prec)
         for (i, vᵢ) in enumerate(v)
             A[i, 1] = vᵢ
         end

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -54,13 +54,13 @@ end
 Base.setprecision(x::T, prec::Integer) where {T<:Union{Arf,ArfRef,Arb,ArbRef,Acb,AcbRef}} =
     T(x; prec)
 Base.setprecision(v::T, prec::Integer) where {T<:Union{ArbVector,ArbRefVector}} =
-    T(v.arb_vec, prec)
+    T(v.arb_vec; prec)
 Base.setprecision(v::T, prec::Integer) where {T<:Union{AcbVector,AcbRefVector}} =
-    T(v.acb_vec, prec)
+    T(v.acb_vec; prec)
 Base.setprecision(A::T, prec::Integer) where {T<:Union{ArbMatrix,ArbRefMatrix}} =
-    T(A.arb_mat, prec)
+    T(A.arb_mat; prec)
 Base.setprecision(A::T, prec::Integer) where {T<:Union{AcbMatrix,AcbRefMatrix}} =
-    T(A.acb_mat, prec)
+    T(A.acb_mat; prec)
 
 Base.setprecision(poly::ArbPoly, prec::Integer) = ArbPoly(poly.arb_poly; prec)
 Base.setprecision(series::ArbSeries, prec::Integer) =

--- a/src/types.jl
+++ b/src/types.jl
@@ -129,91 +129,223 @@ end
 
 """
     ArbVector <: DenseVector{Arb}
+    ArbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[])
+    ArbVector(v::ArbVectorLike; shallow::Bool = false, prec::Integer = precision(v))
+    ArbVector(v::AbstractVector; prec::Integer = _precision(v))
+
+The constructor with `n::Integer` returns a vector with `n` elements
+filled with zeros. The other two constructors returns a copy of the
+given vector. If `shallow = true` then the returned vector shares the
+underlying data with the input, mutating one of them mutates both.
+
+See also [`ArbRefVector`](@ref).
 """
 struct ArbVector <: DenseVector{Arb}
     arb_vec::arb_vec_struct
     prec::Int
+
+    function ArbVector(
+        v::arb_vec_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(v, prec)
+        else
+            return set!(new(cstructtype(ArbVector)(v.n), prec), v, v.n)
+        end
+    end
 end
-ArbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    ArbVector(arb_vec_struct(n), prec)
 
 """
     AcbVector <: DenseVector{Acb}
+    AcbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[])
+    AcbVector(v::AcbVectorLike; shallow::Bool = false, prec::Integer = precision(v))
+    AcbVector(v::AbstractVector; prec::Integer = _precision(v))
+
+The constructor with `n::Integer` returns a vector with `n` elements
+filled with zeros. The other two constructors returns a copy of the
+given vector. If `shallow = true` then the returned vector shares the
+underlying data with the input, mutating one of them mutates both.
+
+See also [`AcbRefVector`](@ref).
 """
 struct AcbVector <: DenseVector{Acb}
     acb_vec::acb_vec_struct
     prec::Int
+
+    function AcbVector(
+        v::acb_vec_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(v, prec)
+        else
+            return set!(new(cstructtype(AcbVector)(v.n), prec), v, v.n)
+        end
+    end
 end
-AcbVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    AcbVector(acb_vec_struct(n), prec)
 
 """
     ArbMatrix <: DenseMatrix{Arb}
+    ArbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[])
+    ArbMatrix(A::ArbMatrixLike; shallow::Bool = false, prec::Integer = precision(v))
+    ArbMatrix(A::AbstractMatrix; prec::Integer = _precision(v))
+    ArbMatrix(v::AbstractVector; prec::Integer = _precision(v))
+
+The constructor with `r::Integer, c::Integer` returns a `r × c` filled
+with zeros. The other three constructors returns a copy of the given
+matrix or vector. If `shallow = true` then the returned matrix shares
+the underlying data with the input, mutating one of them mutates both.
+
+See also [`ArbRefMatrix`](@ref).
 """
 struct ArbMatrix <: DenseMatrix{Arb}
     arb_mat::arb_mat_struct
     prec::Int
+
+    function ArbMatrix(
+        A::arb_mat_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(A, prec)
+        else
+            return set!(new(cstructtype(ArbMatrix)(A.r, A.c), prec), A)
+        end
+    end
 end
-ArbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    ArbMatrix(arb_mat_struct(r, c), prec)
 
 """
     AcbMatrix <: DenseMatrix{Acb}
+    AcbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[])
+    AcbMatrix(A::AcbMatrixLike; shallow::Bool = false, prec::Integer = precision(v))
+    AcbMatrix(A::AbstractMatrix; prec::Integer = _precision(v))
+    AcbMatrix(v::AbstractVector; prec::Integer = _precision(v))
+
+The constructor with `r::Integer, c::Integer` returns a `r × c` filled
+with zeros. The other three constructors returns a copy of the given
+matrix or vector. If `shallow = true` then the returned matrix shares
+the underlying data with the input, mutating one of them mutates both.
+
+See also [`AcbRefMatrix`](@ref).
 """
 struct AcbMatrix <: DenseMatrix{Acb}
     acb_mat::acb_mat_struct
     prec::Int
+
+    function AcbMatrix(
+        A::acb_mat_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(A, prec)
+        else
+            return set!(new(cstructtype(AcbMatrix)(A.r, A.c), prec), A)
+        end
+    end
 end
-AcbMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    AcbMatrix(acb_mat_struct(r, c), prec)
 
 """
     ArbRefVector <: DenseMatrix{ArbRef}
+
+Similar to [`ArbVector`](@ref) but indexing elements returns an
+`ArbRef` referencing the corresponding element instead of an `Arb`
+copy of the element. The constructors are the same as for
+`ArbVector`
 """
 struct ArbRefVector <: DenseVector{ArbRef}
     arb_vec::arb_vec_struct
     prec::Int
+
+    function ArbRefVector(
+        arb_vec::arb_vec_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(arb_vec, prec)
+        else
+            return set!(new(arb_vec_struct(arb_vec.n), prec), arb_vec, arb_vec.n)
+        end
+    end
 end
-ArbRefVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    ArbRefVector(arb_vec_struct(n), prec)
 
 """
     AcbRefVector <: DenseMatrix{AcbRef}
+
+Similar to [`AcbVector`](@ref) but indexing elements returns an
+`AcbRef` referencing the corresponding element instead of an `Acb`
+copy of the element. The constructors are the same as for
+`AcbVector`
 """
 struct AcbRefVector <: DenseVector{AcbRef}
     acb_vec::acb_vec_struct
     prec::Int
+
+    function AcbRefVector(
+        acb_vec::acb_vec_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(acb_vec, prec)
+        else
+            return set!(new(acb_vec_struct(acb_vec.n), prec), acb_vec, acb_vec.n)
+        end
+    end
 end
-AcbRefVector(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    AcbRefVector(acb_vec_struct(n), prec)
 
 """
     ArbRefMatrix <: DenseMatrix{ArbRef}
+
+Similar to [`ArbMatrix`](@ref) but indexing elements returns an
+`ArbRef` referencing the corresponding element instead of an `Arb`
+copy of the element. The constructors are the same as for
+`ArbMatrix`
 """
 struct ArbRefMatrix <: DenseMatrix{ArbRef}
     arb_mat::arb_mat_struct
     prec::Int
+
+    function ArbRefMatrix(
+        A::arb_mat_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(A, prec)
+        else
+            return set!(new(cstructtype(ArbRefMatrix)(A.r, A.c), prec), A)
+        end
+    end
 end
-ArbRefMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    ArbRefMatrix(arb_mat_struct(r, c), prec)
 
 """
     AcbRefMatrix <: DenseMatrix{AcbRef}
+
+Similar to [`AcbMatrix`](@ref) but indexing elements returns an
+`AcbRef` referencing the corresponding element instead of an `Acb`
+copy of the element. The constructors are the same as for
+`AcbMatrix
 """
 struct AcbRefMatrix <: DenseMatrix{AcbRef}
     acb_mat::acb_mat_struct
     prec::Int
-end
-AcbRefMatrix(r::Integer, c::Integer; prec::Integer = DEFAULT_PRECISION[]) =
-    AcbRefMatrix(acb_mat_struct(r, c), prec)
 
-# conversion between ref and non-ref arrays.
-for T in [:Arb, :Acb], A in [:Vector, :Matrix]
-    TA = Symbol(T, A)
-    TRefA = Symbol(T, :Ref, A)
-    @eval begin
-        $TRefA(M::$TA) = $TRefA(cstruct(M), precision(M))
-        $TA(M::$TRefA) = $TA(cstruct(M), precision(M))
+    function AcbRefMatrix(
+        A::acb_mat_struct;
+        shallow::Bool = false,
+        prec::Integer = DEFAULT_PRECISION[],
+    )
+        if shallow
+            return new(A, prec)
+        else
+            return set!(new(cstructtype(AcbRefMatrix)(A.r, A.c), prec), A)
+        end
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -273,6 +273,10 @@ const MagOrRef = Union{Mag,MagRef}
 const ArfOrRef = Union{Arf,ArfRef}
 const ArbOrRef = Union{Arb,ArbRef}
 const AcbOrRef = Union{Acb,AcbRef}
+const ArbVectorOrRef = Union{ArbVector,ArbRefVector}
+const AcbVectorOrRef = Union{AcbVector,AcbRefVector}
+const ArbMatrixOrRef = Union{ArbMatrix,ArbRefMatrix}
+const AcbMatrixOrRef = Union{AcbMatrix,AcbRefMatrix}
 
 """
     MagLike = Union{Mag,MagRef,mag_struct,Ptr{mag_struct}}

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -1,96 +1,58 @@
-## ArbVector basic definitions
-function clear!(v::arb_vec_struct)
+# arb_mat_struct and acb_mat_struct methods
+clear!(v::arb_vec_struct) =
     ccall(@libarb(_arb_vec_clear), Cvoid, (Ptr{arb_struct}, Int), v.entries, v.n)
-end
-Base.cconvert(::Type{Ptr{arb_struct}}, v::Union{ArbVector,ArbRefVector}) = v.arb_vec
-Base.unsafe_convert(::Type{Ptr{arb_struct}}, v::arb_vec_struct) = v.entries
-
-# AbstractVector interface for ArbVector
-Base.size(v::arb_vec_struct) = (v.n,)
-Base.size(v::Union{ArbVector,ArbRefVector}) = size(v.arb_vec)
-
-Base.getindex(v::arb_vec_struct, i::Integer) = v.entries + (i - 1) * sizeof(arb_struct)
-Base.@propagate_inbounds function Base.getindex(v::ArbVector, i::Integer)
-    @boundscheck checkbounds(v, i)
-    x = Arb(prec = precision(v))
-    x[] = v.arb_vec[i]
-    x
-end
-Base.@propagate_inbounds function Base.getindex(v::ArbRefVector, i::Integer)
-    @boundscheck checkbounds(v, i)
-    return ArbRef(v.arb_vec[i], precision(v), cstruct(v))
-end
-
-"""
-    ref(v::ArbVector, i)
-
-Similar to `v[i]` but instead of an `Arb` returns an `ArbRef` which still shares the
-memory with the `i`-th entry of `v`.
-"""
-Base.@propagate_inbounds function ref(v::Union{ArbVector,ArbRefVector}, i::Integer)
-    @boundscheck checkbounds(v, i)
-    return ArbRef(v.arb_vec[i], precision(v), cstruct(v))
-end
-
-Base.setindex!(v::arb_vec_struct, x, i::Integer) = (set!(v[i], x); x)
-Base.@propagate_inbounds function Base.setindex!(
-    v::Union{ArbVector,ArbRefVector},
-    x,
-    i::Integer,
-)
-    ref(v, i)[] = x
-    return x
-end
-
-
-## AcbVector basic definitions
-function clear!(v::acb_vec_struct)
+clear!(v::acb_vec_struct) =
     ccall(@libarb(_acb_vec_clear), Cvoid, (Ptr{acb_struct}, Int), v.entries, v.n)
-end
-Base.cconvert(::Type{Ptr{acb_struct}}, v::Union{AcbVector,AcbRefVector}) = v.acb_vec
+
+Base.unsafe_convert(::Type{Ptr{arb_struct}}, v::arb_vec_struct) = v.entries
 Base.unsafe_convert(::Type{Ptr{acb_struct}}, v::acb_vec_struct) = v.entries
 
-# AbstractVector interface for ACbVector
-Base.size(v::acb_vec_struct) = (v.n,)
-Base.size(v::Union{AcbVector,AcbRefVector}) = size(v.acb_vec)
+Base.size(v::Union{arb_vec_struct,acb_vec_struct}) = (v.n,)
 
+Base.getindex(v::arb_vec_struct, i::Integer) = v.entries + (i - 1) * sizeof(arb_struct)
 Base.getindex(v::acb_vec_struct, i::Integer) = v.entries + (i - 1) * sizeof(acb_struct)
-Base.@propagate_inbounds function Base.getindex(v::AcbVector, i::Integer)
-    @boundscheck checkbounds(v, i)
-    x = Acb(prec = precision(v))
-    x[] = v.acb_vec[i]
-    x
-end
-Base.@propagate_inbounds function Base.getindex(v::AcbRefVector, i::Integer)
-    @boundscheck checkbounds(v, i)
-    return AcbRef(v.acb_vec[i], precision(v), cstruct(v))
-end
+
+Base.setindex!(v::Union{arb_vec_struct,acb_vec_struct}, x, i::Integer) = (set!(v[i], x); x)
+
+Base.cconvert(::Type{Ptr{arb_struct}}, v::ArbVectorOrRef) = cstruct(v)
+Base.cconvert(::Type{Ptr{acb_struct}}, v::AcbVectorOrRef) = cstruct(v)
+
+# AbstractVector interface
+
+const Vectors = Union{ArbVectorOrRef,AcbVectorOrRef}
+
+Base.size(v::Vectors) = size(cstruct(v))
 
 """
-    ref(v::AcbVector, i)
+    ref(v::Union{ArbVectorOrRef,AcbVectorOrRef}, i)
 
-Similar to `v[i]` but instead of an `Acb` returns an `AcbRef` which still shares the
-memory with the `i`-th entry of `v`.
+Similar to `v[i]` but instead of an `Arb` or `Acb` returns an `ArbRef`
+or `AcbRef` which still shares the memory with the `i`-th entry of
+`v`.
 """
-Base.@propagate_inbounds function ref(v::Union{AcbVector,AcbRefVector}, i::Integer)
+Base.@propagate_inbounds function ref(v::ArbVectorOrRef, i::Integer)
     @boundscheck checkbounds(v, i)
-    return AcbRef(v.acb_vec[i], precision(v), cstruct(v))
+    return ArbRef(cstruct(v)[i], precision(v), cstruct(v))
+end
+Base.@propagate_inbounds function ref(v::AcbVectorOrRef, i::Integer)
+    @boundscheck checkbounds(v, i)
+    return AcbRef(cstruct(v)[i], precision(v), cstruct(v))
 end
 
-Base.setindex!(v::acb_vec_struct, x, i::Integer) = (set!(v[i], x); x)
-Base.@propagate_inbounds function Base.setindex!(
-    v::Union{AcbVector,AcbRefVector},
-    x,
-    i::Integer,
-)
+Base.@propagate_inbounds function Base.getindex(v::Union{ArbVector,AcbVector}, i::Integer)
+    @boundscheck checkbounds(v, i)
+    return set!(eltype(v)(prec = precision(v)), cstruct(v)[i])
+end
+
+Base.@propagate_inbounds Base.getindex(v::Union{ArbRefVector,AcbRefVector}, i::Integer) =
+    ref(v, i)
+
+Base.@propagate_inbounds function Base.setindex!(v::Vectors, x, i::Integer)
     ref(v, i)[] = x
     return x
 end
 
-## Common methods
-const Vectors = Union{ArbVector,ArbRefVector,AcbVector,AcbRefVector}
-
-# General constructor
+# General constructors
 
 for (T, TOrRef) in [
     (:ArbVector, :ArbVectorOrRef),
@@ -113,7 +75,18 @@ for (T, TOrRef) in [
     end
 end
 
+Base.copy(v::Vectors) = copy!(similar(v), v)
+function Base.copy!(w::T, v::T) where {T<:Vectors}
+    length(w) == length(v) || throw(DimensionMismatch())
+    return set!(w, v)
+end
+function Base.copyto!(w::T, v::T) where {T<:Vectors}
+    length(w) >= length(v) || throw(DimensionMismatch())
+    return set!(w, v)
+end
+
 # Arithmetic
+
 for (jf, af) in [(:+, :add!), (:-, :sub!)]
     @eval function Base.$jf(
         v::T,
@@ -121,12 +94,8 @@ for (jf, af) in [(:+, :add!), (:-, :sub!)]
     ) where {T<:Union{ArbVector,ArbRefVector,AcbVector,AcbRefVector}}
         @boundscheck (length(v) == length(w) || throw(DimensionMismatch()))
         u = T(length(v); prec = _precision(v, w))
-        $af(u, v, w)
-        u
+        return $af(u, v, w)
     end
 end
-Base.:(-)(v::Vectors) = neg!(similar(v), v)
 
-Base.copy(v::Vectors) = copy!(similar(v), v)
-Base.copy!(w::T, v::T) where {T<:Vectors} = set!(w, v)
-Base.copyto!(w::T, v::T) where {T<:Vectors} = set!(w, v)
+Base.:(-)(v::Vectors) = neg!(similar(v), v)

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -91,9 +91,21 @@ end
 const Vectors = Union{ArbVector,ArbRefVector,AcbVector,AcbRefVector}
 
 # General constructor
-for T in [:ArbVector, :ArbRefVector, :AcbVector, :AcbRefVector]
+
+for (T, TOrRef) in [
+    (:ArbVector, :ArbVectorOrRef),
+    (:ArbRefVector, :ArbVectorOrRef),
+    (:AcbVector, :AcbVectorOrRef),
+    (:AcbRefVector, :AcbVectorOrRef),
+]
+    @eval $T(n::Integer; prec::Integer = DEFAULT_PRECISION[]) =
+        $T(cstructtype($T)(n), shallow = true; prec)
+
+    @eval $T(v::$TOrRef; shallow::Bool = false, prec::Integer = precision(v)) =
+        $T(cstruct(v); shallow, prec)
+
     @eval function $T(v::AbstractVector; prec::Integer = _precision(v))
-        V = $T(length(v); prec = prec)
+        V = $T(length(v); prec)
         @inbounds for (i, vᵢ) in enumerate(v)
             V[i] = vᵢ
         end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -150,6 +150,27 @@
             A[1, 1] = 5 // 8
             @test !iszero(A[1, 1])
         end
+
+        @testset "copy" begin
+            A = TMat([1 2; 3 4])
+            B = copy(A)
+            @test A == B
+            B[1] = 2
+            @test A[1, 1] == 1
+            @test B[1, 1] == 2
+
+            B = similar(A)
+            copy!(B, A)
+            @test A == B
+            B[1] = 2
+            @test A[1] == 1
+            @test B[1] == 2
+
+            @test_throws DimensionMismatch copy!(TMat(1, 2), A)
+            @test_throws DimensionMismatch copy!(TMat(3, 2), A)
+            @test_throws DimensionMismatch copy!(TMat(2, 1), A)
+            @test_throws DimensionMismatch copy!(TMat(3, 3), A)
+        end
     end
 
     @testset "RefMatrix: $T" for (T, TRef) in

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -1,169 +1,176 @@
-@testset "Matrix: $TRef" for (TMat, T, TRef) in [
-    (ArbMatrix, Arb, Arb),
-    (AcbMatrix, Acb, Acb),
-    (ArbRefMatrix, Arb, ArbRef),
-    (AcbRefMatrix, Acb, AcbRef),
-]
-    @testset "Basic" begin
-        @test isempty(TMat([]))
-        @test isempty(TMat([]))
+@testset "Matrices" begin
+    @testset "Matrix: $TMat" for (TMat, T, TRef) in [
+        (ArbMatrix, Arb, Arb),
+        (AcbMatrix, Acb, Acb),
+        (ArbRefMatrix, Arb, ArbRef),
+        (AcbRefMatrix, Acb, AcbRef),
+    ]
+        @testset "Basic" begin
+            @test isempty(TMat([]))
+            @test isempty(TMat([]))
 
-        M = TMat(4, 4, prec = 128)
-        @test size(M) == (4, 4)
-        @test precision(M) == 128
+            M = TMat(4, 4, prec = 128)
+            @test size(M) == (4, 4)
+            @test precision(M) == 128
 
-        x = T(1.5)
-        M[2, 2] = x
-        @test M[2, 2] == x
-        @test M[2, 2] isa TRef
-        @test precision(M[2, 2]) == 128
+            x = T(1.5)
+            M[2, 2] = x
+            @test M[2, 2] == x
+            @test M[2, 2] isa TRef
+            @test precision(M[2, 2]) == 128
 
-        Arblib.add!(M, M, M)
-        M2 = TMat(4, 4, prec = 128)
-        M2[2, 2] = T(3)
-        @test M == M2
+            Arblib.add!(M, M, M)
+            M2 = TMat(4, 4, prec = 128)
+            M2[2, 2] = T(3)
+            @test M == M2
 
-        A = TMat([T(i + j) for i = 1:4, j = 1:4])
-        @test A[4, 4] == T(8)
-        A = TMat([i + j for i = 1:4, j = 1:4]; prec = 96)
-        @test A[4, 4] == T(8)
-        @test precision(A) == precision(T(8; prec = 96)) == 96
+            A = TMat([T(i + j) for i = 1:4, j = 1:4])
+            @test A[4, 4] == T(8)
+            A = TMat([i + j for i = 1:4, j = 1:4]; prec = 96)
+            @test A[4, 4] == T(8)
+            @test precision(A) == precision(T(8; prec = 96)) == 96
 
-        @test ref(A, 3, 3) isa Union{ArbRef,AcbRef}
-    end
+            @test ref(A, 3, 3) isa Union{ArbRef,AcbRef}
+        end
 
-    @testset "arithmetic" begin
-        AInt = [1 2; 3 4]
-        BInt = [5 6; 7 8]
-        A = TMat(AInt; prec = 96)
-        B = TMat(BInt; prec = 96)
-        @test A - B == AInt - BInt
-        @test precision(A - B) == 96
-        @test (A - B) isa TMat
-        @test -B == -BInt
-        @test -B isa TMat
-        @test -B + A == A - B
-        @test precision(-B + A) == 96
-        @test A * B == AInt * BInt
-        @test A * B isa TMat
-    end
+        @testset "arithmetic" begin
+            AInt = [1 2; 3 4]
+            BInt = [5 6; 7 8]
+            A = TMat(AInt; prec = 96)
+            B = TMat(BInt; prec = 96)
+            @test A - B == AInt - BInt
+            @test precision(A - B) == 96
+            @test (A - B) isa TMat
+            @test -B == -BInt
+            @test -B isa TMat
+            @test -B + A == A - B
+            @test precision(-B + A) == 96
+            @test A * B == AInt * BInt
+            @test A * B isa TMat
+        end
 
-    @testset "scalar arithmetic" begin
-        AInt = [2 4; 6 8]
-        A = TMat(AInt; prec = 96)
-        cInt = 2
-        c = T(cInt; prec = 96)
-        @test c * A isa TMat
-        @test c * A == cInt * AInt
-        @test A * c isa TMat
-        @test A * c == AInt * cInt
+        @testset "scalar arithmetic" begin
+            AInt = [2 4; 6 8]
+            A = TMat(AInt; prec = 96)
+            cInt = 2
+            c = T(cInt; prec = 96)
+            @test c * A isa TMat
+            @test c * A == cInt * AInt
+            @test A * c isa TMat
+            @test A * c == AInt * cInt
 
-        @test c \ A isa TMat
-        @test c \ A == cInt \ AInt
-        @test A / c isa TMat
-        @test A / c == AInt / cInt
-        if TRef <: Real
-            @test Acb(c) * A isa AcbMatrix
-            @test Acb(c) * A == c * A
-            @test A * Acb(c) isa AcbMatrix
-            @test A * Acb(c) == A * c
+            @test c \ A isa TMat
+            @test c \ A == cInt \ AInt
+            @test A / c isa TMat
+            @test A / c == AInt / cInt
+            if TRef <: Real
+                @test Acb(c) * A isa AcbMatrix
+                @test Acb(c) * A == c * A
+                @test A * Acb(c) isa AcbMatrix
+                @test A * Acb(c) == A * c
 
-            @test Acb(c) \ A isa AcbMatrix
-            @test Acb(c) \ A == c \ A
-            @test A / Acb(c) isa AcbMatrix
-            @test A / Acb(c) == A / c
+                @test Acb(c) \ A isa AcbMatrix
+                @test Acb(c) \ A == c \ A
+                @test A / Acb(c) isa AcbMatrix
+                @test A / Acb(c) == A / c
+            end
+        end
+
+        @testset "LinearAlgebra" begin
+            A = TMat(rand(3, 3))
+            b = TMat(rand(3))
+            c = TMat(3, 1)
+
+            # lu factorization
+            ldiv!(c, A, b)
+            c′ = A \ b
+            @test Arblib.overlaps(c, c′) == 1
+            ldiv!(c, lu(A), b)
+            @test Arblib.overlaps(c, c′) == 1
+            ldiv!(c, lu!(copy(A)), b)
+            @test Arblib.overlaps(c, c′) == 1
+            d = copy(b)
+            ldiv!(lu(A), d)
+            @test Arblib.overlaps(d, c′) == 1
+
+            # inv
+            id = copy(A)
+            Arblib.one!(id)
+            @test Bool(Arblib.contains(inv(A) * A, id))
+
+            # mul
+            A = TMat(rand(3, 2))
+            B = TMat(rand(2, 4))
+            B_wrong = TMat(rand(3, 4))
+            C = TMat(3, 4)
+            @test_throws DimensionMismatch("Matrix sizes are not compatible.") A * B_wrong
+            LinearAlgebra.mul!(C, A, B)
+            @test C == A * B
+        end
+
+        @testset "indexing" begin
+            A = TMat(3, 1)
+            A[3, 1][] = 4
+            @test A[3] == A[3, 1]
+            B = TMat(reshape(1:15, 3, 5))
+            @test B[1:15] == 1:15
+            C = TMat(reshape(1:15, 5, 3))
+            @test C[1:15] == 1:15
+        end
+
+        @testset "similar:" begin
+            A = TMat(3, 5; prec = 96)
+
+            a = similar(A)
+            @test a isa TMat
+            @test precision(a) == precision(A)
+
+            a = similar(A, TRef, (2, 3))
+            @test a isa TMat
+            @test precision(a) == precision(A)
+
+            for (ElT, VT, MT) in (
+                (Arb, ArbVector, ArbMatrix),
+                (Acb, AcbVector, AcbMatrix),
+                (ArbRef, ArbRefVector, ArbRefMatrix),
+                (AcbRef, AcbRefVector, AcbRefMatrix),
+            )
+                a = similar(A, ElT, 3)
+                @test a isa VT
+                @test precision(a) == precision(A)
+
+                a = similar(A, ElT, (3, 2))
+                @test a isa MT
+                @test precision(a) == precision(A)
+            end
+        end
+
+        @testset "set Rational" begin
+            A = TMat(2, 2)
+            A[1, 1] = 5 // 8
+            @test !iszero(A[1, 1])
         end
     end
 
-    @testset "LinearAlgebra" begin
-        A = TMat(rand(3, 3))
-        b = TMat(rand(3))
-        c = TMat(3, 1)
+    @testset "RefMatrix: $T" for (T, TRef) in
+                                 [(ArbMatrix, ArbRefMatrix), (AcbMatrix, AcbRefMatrix)]
+        A = T(2, 3; prec = 96)
+        A[1, 2] = 3
 
-        # lu factorization
-        ldiv!(c, A, b)
-        c′ = A \ b
-        @test Arblib.overlaps(c, c′) == 1
-        ldiv!(c, lu(A), b)
-        @test Arblib.overlaps(c, c′) == 1
-        ldiv!(c, lu!(copy(A)), b)
-        @test Arblib.overlaps(c, c′) == 1
-        d = copy(b)
-        ldiv!(lu(A), d)
-        @test Arblib.overlaps(d, c′) == 1
+        # shallow = false
+        B = TRef(A)
+        @test B isa TRef
+        @test precision(B) == 96
+        B[1, 2] = 4
+        @test A[1, 2] == 3
+        @test B[1, 2] == 4
 
-        # inv
-        id = copy(A)
-        Arblib.one!(id)
-        @test Bool(Arblib.contains(inv(A) * A, id))
-
-        # mul
-        A = TMat(rand(3, 2))
-        B = TMat(rand(2, 4))
-        B_wrong = TMat(rand(3, 4))
-        C = TMat(3, 4)
-        @test_throws DimensionMismatch("Matrix sizes are not compatible.") A * B_wrong
-        LinearAlgebra.mul!(C, A, B)
-        @test C == A * B
+        # shallow = true
+        B = TRef(A, shallow = true)
+        @test B isa TRef
+        @test precision(B) == 96
+        B[1, 2] = 4
+        @test A[1, 2] == 4
+        @test B[1, 2] == 4
     end
-
-    @testset "indexing" begin
-        A = TMat(3, 1)
-        A[3, 1][] = 4
-        @test A[3] == A[3, 1]
-        B = TMat(reshape(1:15, 3, 5))
-        @test B[1:15] == 1:15
-        C = TMat(reshape(1:15, 5, 3))
-        @test C[1:15] == 1:15
-    end
-
-    @testset "similar:" begin
-        A = TMat(3, 5; prec = 96)
-
-        a = similar(A)
-        @test a isa TMat
-        @test precision(a) == precision(A)
-
-        a = similar(A, TRef, (2, 3))
-        @test a isa TMat
-        @test precision(a) == precision(A)
-
-        for (ElT, VT, MT) in (
-            (Arb, ArbVector, ArbMatrix),
-            (Acb, AcbVector, AcbMatrix),
-            (ArbRef, ArbRefVector, ArbRefMatrix),
-            (AcbRef, AcbRefVector, AcbRefMatrix),
-        )
-            a = similar(A, ElT, 3)
-            @test a isa VT
-            @test precision(a) == precision(A)
-
-            a = similar(A, ElT, (3, 2))
-            @test a isa MT
-            @test precision(a) == precision(A)
-        end
-    end
-
-    @testset "set Rational" begin
-        A = TMat(2, 2)
-        A[1, 1] = 5 // 8
-        @test !iszero(A[1, 1])
-    end
-end
-
-
-@testset "MatrixRef: $T" for (T, TRef) in
-                             [(ArbMatrix, ArbRefMatrix), (AcbMatrix, AcbRefMatrix)]
-    A = T(2, 3; prec = 96)
-    A[1, 2] = 3
-
-    B = TRef(A)
-    @test B isa TRef
-    @test precision(B) == 96
-    B[1, 2] = 4
-    @test A[1, 2] == 4
-    @test B[1, 2] == 4
-    C = T(B)
-    @test C == A
-    @test C[1, 2] == 4
 end

--- a/test/precision.jl
+++ b/test/precision.jl
@@ -64,8 +64,10 @@
         B = setprecision(A, 128)
         @test precision(B) == 128
         @test precision(B[1, 1]) == 128
-        A[1, 1][] = 1
-        @test A[1, 1] == B[1, 1]
+
+        # Check that they are not aliased
+        A[1, 1] = 1
+        @test B[1, 1] == 0
     end
 
     @testset "_precision" begin

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -87,6 +87,34 @@
             A[1, 1] = 5 // 8
             @test !iszero(A[1, 1])
         end
+
+        @testset "copy" begin
+            v = TVec(1:4)
+            w = copy(v)
+            @test v == w
+            w[1] = 2
+            @test v[1] == 1
+            @test w[1] == 2
+
+            w = similar(v)
+            copy!(w, v)
+            @test v == w
+            w[1] = 2
+            @test v[1] == 1
+            @test w[1] == 2
+
+            w = TVec(5)
+            copyto!(w, v)
+            @test w[1:4] == v
+            @test w[5] == 0
+            w[1] = 2
+            @test v[1] == 1
+            @test w[1] == 2
+
+            @test_throws DimensionMismatch copy!(TVec(3), v)
+            @test_throws DimensionMismatch copy!(TVec(5), v)
+            @test_throws DimensionMismatch copyto!(TVec(3), v)
+        end
     end
 
     @testset "VectorRef: $T" for (T, TRef) in

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -1,105 +1,112 @@
-@testset "Vector: $TRef" for (TVec, T, TRef) in [
-    (ArbVector, Arb, Arb),
-    (AcbVector, Acb, Acb),
-    (ArbRefVector, Arb, ArbRef),
-    (AcbRefVector, Acb, AcbRef),
-]
-    @test isempty(TVec([]))
-    @test isempty(TVec([], prec = 80))
+@testset "Vectors" begin
+    @testset "Vector: $TVec" for (TVec, T, TRef) in [
+        (ArbVector, Arb, Arb),
+        (AcbVector, Acb, Acb),
+        (ArbRefVector, Arb, ArbRef),
+        (AcbRefVector, Acb, AcbRef),
+    ]
+        @test isempty(TVec([]))
+        @test isempty(TVec([], prec = 80))
 
-    V = TVec(4, prec = 128)
-    @test size(V) == (4,)
-    @test precision(V) == 128
+        V = TVec(4, prec = 128)
+        @test size(V) == (4,)
+        @test precision(V) == 128
 
-    x = T(1.5)
-    V[3] = x
-    @test V[3] == x
-    @test V[3] isa TRef
-    @test !isempty(sprint(show, V[3]))
-    @test precision(V[3]) == 128
+        x = T(1.5)
+        V[3] = x
+        @test V[3] == x
+        @test V[3] isa TRef
+        @test !isempty(sprint(show, V[3]))
+        @test precision(V[3]) == 128
 
-    Arblib.add!(V, V, V)
-    V2 = TVec(4, prec = 128)
-    V2[3] = T(3)
-    @test V == V2
+        Arblib.add!(V, V, V)
+        V2 = TVec(4, prec = 128)
+        V2[3] = T(3)
+        @test V == V2
 
-    A = TVec([T(i + 1) for i = 2:5])
-    @test A[end] == T(6)
+        A = TVec([T(i + 1) for i = 2:5])
+        @test A[end] == T(6)
 
-    A = TVec([i + j for i = 1:4 for j = 1:4]; prec = 96)
-    @test A[16] == T(8)
-    @test precision(A) == 96
-    @test precision(A[14]) == 96
+        A = TVec([i + j for i = 1:4 for j = 1:4]; prec = 96)
+        @test A[16] == T(8)
+        @test precision(A) == 96
+        @test precision(A[14]) == 96
 
-    @test ref(A, 16) isa Union{ArbRef,AcbRef}
+        @test ref(A, 16) isa Union{ArbRef,AcbRef}
 
-    # arithmetic
-    AInt = [1, 2, 3, 4]
-    BInt = [5, 6, 7, 8]
-    A = TVec(AInt; prec = 96)
-    B = TVec(BInt; prec = 96)
-    @test A - B == AInt - BInt
-    @test precision(A - B) == 96
-    @test (A - B) isa TVec
-    @test -B == -BInt
-    @test -B isa TVec
-    @test -B + A == A - B
-    @test precision(-B + A) == 96
+        # arithmetic
+        AInt = [1, 2, 3, 4]
+        BInt = [5, 6, 7, 8]
+        A = TVec(AInt; prec = 96)
+        B = TVec(BInt; prec = 96)
+        @test A - B == AInt - BInt
+        @test precision(A - B) == 96
+        @test (A - B) isa TVec
+        @test -B == -BInt
+        @test -B isa TVec
+        @test -B + A == A - B
+        @test precision(-B + A) == 96
 
-    C = TVec(length(A); prec = 96)
-    Arblib.add!(C, A, B)
-    @test C == AInt + BInt
-    # test original signature
-    D = TVec(length(A); prec = 96)
-    Arblib.add!(D, A, B, length(AInt), 96)
-    @test D == AInt + BInt
+        C = TVec(length(A); prec = 96)
+        Arblib.add!(C, A, B)
+        @test C == AInt + BInt
+        # test original signature
+        D = TVec(length(A); prec = 96)
+        Arblib.add!(D, A, B, length(AInt), 96)
+        @test D == AInt + BInt
 
-    @testset "similar" begin
-        A = TVec(5; prec = 96)
+        @testset "similar" begin
+            A = TVec(5; prec = 96)
 
-        a = similar(A)
-        @test a isa TVec
-        @test precision(a) == precision(A)
-
-        a = similar(A, TRef, 3)
-        @test a isa TVec
-        @test precision(a) == precision(A)
-
-        for (ElT, VT, MT) in (
-            (Arb, ArbVector, ArbMatrix),
-            (Acb, AcbVector, AcbMatrix),
-            (ArbRef, ArbRefVector, ArbRefMatrix),
-            (AcbRef, AcbRefVector, AcbRefMatrix),
-        )
-            a = similar(A, ElT, 3)
-            @test a isa VT
+            a = similar(A)
+            @test a isa TVec
             @test precision(a) == precision(A)
 
-            a = similar(A, ElT, (3, 2))
-            @test a isa MT
+            a = similar(A, TRef, 3)
+            @test a isa TVec
             @test precision(a) == precision(A)
+
+            for (ElT, VT, MT) in (
+                (Arb, ArbVector, ArbMatrix),
+                (Acb, AcbVector, AcbMatrix),
+                (ArbRef, ArbRefVector, ArbRefMatrix),
+                (AcbRef, AcbRefVector, AcbRefMatrix),
+            )
+                a = similar(A, ElT, 3)
+                @test a isa VT
+                @test precision(a) == precision(A)
+
+                a = similar(A, ElT, (3, 2))
+                @test a isa MT
+                @test precision(a) == precision(A)
+            end
+        end
+
+        @testset "set Rational" begin
+            A = TVec(2)
+            A[1, 1] = 5 // 8
+            @test !iszero(A[1, 1])
         end
     end
 
-    @testset "set Rational" begin
-        A = TVec(2)
-        A[1, 1] = 5 // 8
-        @test !iszero(A[1, 1])
+    @testset "VectorRef: $T" for (T, TRef) in
+                                 [(ArbVector, ArbRefVector), (AcbVector, AcbRefVector)]
+        A = T(5; prec = 96)
+        A[4] = 3
+
+        # shallow = false
+        B = TRef(A)
+        @test B isa TRef
+        @test precision(B) == 96
+        B[4] = 4
+        @test A[4] == 3
+        @test B[4] == 4
+
+        B = TRef(A, shallow = true)
+        @test B isa TRef
+        @test precision(B) == 96
+        B[4] = 4
+        @test A[4] == 4
+        @test B[4] == 4
     end
-end
-
-@testset "VectorRef: $T" for (T, TRef) in
-                             [(ArbVector, ArbRefVector), (AcbVector, AcbRefVector)]
-    A = T(5; prec = 96)
-    A[4] = 3
-
-    B = TRef(A)
-    @test B isa TRef
-    @test precision(B) == 96
-    B[4] = 4
-    @test A[4] == 4
-    @test B[4] == 4
-    C = T(B)
-    @test C == A
-    @test C[4] == 4
 end


### PR DESCRIPTION
This updates the code for vectors and matrices. The main change is for the constructors, but there are a few others as well. It depends on #166.
 
It removes the default constructor for the types, i.e. `ArbVector(arb_vec::arb_vec_struct, prec::Int)` in favor for ones which take the precision as a keyword argument, i.e. `ArbVector(v::arb_vec_struct; shallow::Bool = false, prec::Integer = DEFAULT_PRECISION[])` (for the `shallow` keyword see below). This is a breaking change, but hopefully not very important.

It adds the shallow keyword for constructors from `ArbVectorLike`, `AcbVectorLike`, `ArbMatrixLike` and `AcbMatrixLike` types which allows for shallow copies where they share the underlying Arb-struct. Previously it always made a shallow copy with no option of making a non-shallow copy. As a consequence the `setprecision` methods now copy the input. The tests have been updated to reflect that it defaults to a shallow copy. This change should not be breaking, it only affects the performance. 

I think non-shallow constructors is the reasonable default to have. It is similar to how Julia handles for example `Vector([1, 2, 3])`. The main reason for having the shallow constructors is for non-allocating conversions between the ref and non-ref versions.

It also removes most occurrences of XLike types in the high level interface. It now only defines the most basic methods directly on the structs.

It also refactors `src/vector.jl` and `src/matrix.jl` the code for better reuse of code and clearer distinction of struct types. Several style changes as well. This is a breaking change in that a lot of methods are no longer available for the struct types.

Finally it removes the `copyto!` method for matrices. It should not be commonly used for matrices since it just threats them as vectors anyway. Added dimension checks for `copy!` and `copyto!` as well as tests. This is not breaking since it will just fall back to the slower default implementation.

