### PR TITLE
Avoid use of `XLike`

### DIFF
--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -36,7 +36,9 @@ mutable struct mag_struct
         return res
     end
 
-    function mag_struct(x::Union{mag_struct,arf_struct,Ptr{arf_struct}})
+    # Argument type should be Union{MagLike,ArfLike} but those are not
+    # defined yet
+    function mag_struct(x::Union{mag_struct,Ptr{mag_struct},arf_struct,Ptr{arf_struct}})
         res = new()
         init_set!(res, x)
         finalizer(clear!, res)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -2,7 +2,9 @@ export setball
 
 # Mag
 Mag(x) = set!(Mag(), x)
-Mag(x::Union{MagRef,ArfRef}) = Mag(mag_struct(cstruct(x)))
+# Can't be defined inside Mag due to MagRef and ArfRef being defined
+# later.
+Mag(x::Union{MagRef,ArfRef}) = Mag(cstruct(x))
 Mag(x, y) = set!(Mag(), x, y)
 
 # Arf
@@ -43,17 +45,8 @@ function setball(::Type{Arb}, m, r; prec = _precision(m))
 end
 
 ## Acb
-Acb(
-    x::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}};
-    prec::Integer = _precision(x),
-) = set!(Acb(; prec), x)
-Acb(
-    re::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}},
-    im::Union{Real,arb_struct,arf_struct,Tuple{<:Real,<:Real}};
-    prec::Integer = max(_precision(re), _precision(im)),
-) = set!(Acb(; prec), re, im)
-
-Acb(z::Union{AcbLike,Complex}; prec::Integer = _precision(z)) = set!(Acb(; prec), z)
+Acb(z; prec::Integer = _precision(z)) = set!(Acb(; prec), z)
+Acb(re, im; prec::Integer = max(_precision(re), _precision(im))) = set!(Acb(; prec), re, im)
 # disambiguation
 Acb(x::Acb; prec::Integer = precision(x)) = set!(Acb(; prec), x)
 
@@ -76,18 +69,18 @@ end
 Base.Int(x::ArfOrRef; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) =
     is_int(x) ? get_si(x, rnd) : throw(InexactError(:Int64, Int64, x))
 
-Base.Float64(x::MagLike) = get(x)
-Base.Float64(x::ArfLike; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_d(x, rnd)
-Base.Float64(x::ArbLike) = Float64(midref(x))
+Base.Float64(x::MagOrRef) = get(x)
+Base.Float64(x::ArfOrRef; rnd::Union{arb_rnd,RoundingMode} = RoundNearest) = get_d(x, rnd)
+Base.Float64(x::ArbOrRef) = Float64(midref(x))
 
-Base.ComplexF64(z::AcbLike) = Complex(Float64(realref(z)), Float64(imagref(z)))
+Base.ComplexF64(z::AcbOrRef) = Complex(Float64(realref(z)), Float64(imagref(z)))
 
-function Base.BigFloat(x::Union{Arf,ArfRef})
+function Base.BigFloat(x::ArfOrRef)
     y = BigFloat(; precision = precision(x))
     get!(y, x)
     return y
 end
-Base.BigFloat(x::Union{Arb,ArbRef}) = BigFloat(midref(x))
+Base.BigFloat(x::ArbOrRef) = BigFloat(midref(x))
 
 Base.zero(::Union{Mag,Type{Mag}}) = Mag(UInt64(0))
 Base.one(::Union{Mag,Type{Mag}}) = Mag(UInt64(1))

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -47,45 +47,21 @@ end
 Base.decompose(x::Union{MagOrRef,ArfOrRef}) = Base.decompose(cstruct(x))
 
 # Hashes of structs are computed using the method for the wrapping
-# type and then hashed together with a constant. Compare with
-# Base.h_imag
-if UInt === UInt64
-    const h_mag = 0x5d9b5fdb71940a8e
-    const h_arf = 0x9587d52d253e1dd1
-    const h_arb = 0x5209056683bc3f7a
-    const h_acb = 0x9ca782e3b04fab90
-    const h_arb_vec = 0x25e99ee61f9a8792
-    const h_acb_vec = 0x05f9e7ef121a65fe
-    const h_arb_poly = 0xd821aefd7c0bb7d4
-    const h_acb_poly = 0xed00c6f74947b740
-    const h_arb_mat = 0x1caddefdf435e388
-    const h_acb_mat = 0x68e0fd60c8bdd5d1
-else
-    const h_mag = 0x8fa1c5cc
-    const h_arf = 0x695f4554
-    const h_arb = 0x769d5541
-    const h_acb = 0x5eda1191
-    const h_arb_vec = 0x16f853e7
-    const h_acb_vec = 0x31dc4078
-    const h_arb_poly = 0x67d3910f
-    const h_acb_poly = 0x55bdb518
-    const h_arb_mat = 0xbe4a9fe3
-    const h_acb_mat = 0x04460a47
-end
-Base.hash(x::mag_struct, h::UInt) = hash(Mag(x), hash(h_mag, h))
-Base.hash(x::arf_struct, h::UInt) = hash(Arf(x), hash(h_arf, h))
-Base.hash(x::arb_struct, h::UInt) = hash(Arb(x), hash(h_arb, h))
-Base.hash(x::acb_struct, h::UInt) = hash(Acb(x), hash(h_acb, h))
+# type and then hashed together with their type
+Base.hash(x::mag_struct, h::UInt) = hash(Mag(x), hash(typeof(x), h))
+Base.hash(x::arf_struct, h::UInt) = hash(Arf(x), hash(typeof(x), h))
+Base.hash(x::arb_struct, h::UInt) = hash(Arb(x), hash(typeof(x), h))
+Base.hash(x::acb_struct, h::UInt) = hash(Acb(x), hash(typeof(x), h))
 Base.hash(x::arb_vec_struct, h::UInt) =
-    hash(ArbVector(x, shallow = true), hash(h_arb_vec, h))
+    hash(ArbVector(x, shallow = true), hash(typeof(x), h))
 Base.hash(x::acb_vec_struct, h::UInt) =
-    hash(AcbVector(x, shallow = true), hash(h_acb_vec, h))
-Base.hash(x::arb_poly_struct, h::UInt) = hash(ArbPoly(x), hash(h_arb_poly, h))
-Base.hash(x::acb_poly_struct, h::UInt) = hash(AcbPoly(x), hash(h_acb_poly, h))
+    hash(AcbVector(x, shallow = true), hash(typeof(x), h))
+Base.hash(x::arb_poly_struct, h::UInt) = hash(ArbPoly(x), hash(typeof(x), h))
+Base.hash(x::acb_poly_struct, h::UInt) = hash(AcbPoly(x), hash(typeof(x), h))
 Base.hash(x::arb_mat_struct, h::UInt) =
-    hash(ArbMatrix(x, shallow = true), hash(h_arb_mat, h))
+    hash(ArbMatrix(x, shallow = true), hash(typeof(x), h))
 Base.hash(x::acb_mat_struct, h::UInt) =
-    hash(AcbMatrix(x, shallow = true), hash(h_acb_mat, h))
+    hash(AcbMatrix(x, shallow = true), hash(typeof(x), h))
 
 # Hashes of Mag and Arf are computed using the Base implementation
 # which used Base.decompose defined above.
@@ -111,8 +87,6 @@ if UInt === UInt64
 else
     const h_poly = 0xa0617887
 end
-# arb_poly_struct and acb_poly_struct use default hash implementation,
-# this is okay since they don't implement an isequal method.
 function Base.hash(p::Union{ArbPoly,AcbPoly}, h::UInt)
     h = hash(h_poly, h)
     for i = 0:degree(p)

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -56,7 +56,7 @@ Base.hash(x::acb_struct, h::UInt) = hash(Acb(x), h)
 # Hashes of Mag and Arf are computed using the Base implementation
 # which used Base.decompose defined above.
 
-function Base.hash(x::ArbLike, h::UInt)
+function Base.hash(x::ArbOrRef, h::UInt)
     # If the radius is zero we compute the hash using only the
     # midpoint, so that we get identical hashes as for the
     # corresponding Arf
@@ -66,7 +66,7 @@ function Base.hash(x::ArbLike, h::UInt)
     return hash(Arblib.midref(x), h)
 end
 
-function Base.hash(z::AcbLike, h::UInt)
+function Base.hash(z::AcbOrRef, h::UInt)
     # Same as for Complex{T}
     hash(realref(z), h ⊻ hash(imagref(z), Base.h_imag) ⊻ Base.hash_0_imag)
 end

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -11,7 +11,7 @@ arf_get_fmpz_2exp. For Mag the mantissa is stored directly in the
 struct as a UInt and the exponent as a fmpz.
 =#
 function Base.decompose(x::Union{mag_struct,Ptr{mag_struct}})::Tuple{UInt,BigInt,Int}
-    isinf(x) && return 1, 0, 0
+    Arblib.is_inf(x) && return 1, 0, 0
 
     if x isa Ptr{mag_struct}
         x = unsafe_load(x)
@@ -27,8 +27,8 @@ function Base.decompose(x::Union{mag_struct,Ptr{mag_struct}})::Tuple{UInt,BigInt
 end
 
 function Base.decompose(x::Union{arf_struct,Ptr{arf_struct}})::Tuple{BigInt,BigInt,Int}
-    isnan(x) && return 0, 0, 0
-    isinf(x) && return ifelse(x < 0, -1, 1), 0, 0
+    Arblib.is_nan(x) && return 0, 0, 0
+    Arblib.is_inf(x) && return ifelse(Arblib.cmp(x, 0) < 0, -1, 1), 0, 0
 
     num = fmpz_struct()
     pow = fmpz_struct()

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -47,11 +47,45 @@ end
 Base.decompose(x::Union{MagOrRef,ArfOrRef}) = Base.decompose(cstruct(x))
 
 # Hashes of structs are computed using the method for the wrapping
-# type
-Base.hash(x::mag_struct, h::UInt) = hash(Mag(x), h)
-Base.hash(x::arf_struct, h::UInt) = hash(Arf(x), h)
-Base.hash(x::arb_struct, h::UInt) = hash(Arb(x), h)
-Base.hash(x::acb_struct, h::UInt) = hash(Acb(x), h)
+# type and then hashed together with a constant. Compare with
+# Base.h_imag
+if UInt === UInt64
+    const h_mag = 0x5d9b5fdb71940a8e
+    const h_arf = 0x9587d52d253e1dd1
+    const h_arb = 0x5209056683bc3f7a
+    const h_acb = 0x9ca782e3b04fab90
+    const h_arb_vec = 0x25e99ee61f9a8792
+    const h_acb_vec = 0x05f9e7ef121a65fe
+    const h_arb_poly = 0xd821aefd7c0bb7d4
+    const h_acb_poly = 0xed00c6f74947b740
+    const h_arb_mat = 0x1caddefdf435e388
+    const h_acb_mat = 0x68e0fd60c8bdd5d1
+else
+    const h_mag = 0x8fa1c5cc
+    const h_arf = 0x695f4554
+    const h_arb = 0x769d5541
+    const h_acb = 0x5eda1191
+    const h_arb_vec = 0x16f853e7
+    const h_acb_vec = 0x31dc4078
+    const h_arb_poly = 0x67d3910f
+    const h_acb_poly = 0x55bdb518
+    const h_arb_mat = 0xbe4a9fe3
+    const h_acb_mat = 0x04460a47
+end
+Base.hash(x::mag_struct, h::UInt) = hash(Mag(x), hash(h_mag, h))
+Base.hash(x::arf_struct, h::UInt) = hash(Arf(x), hash(h_arf, h))
+Base.hash(x::arb_struct, h::UInt) = hash(Arb(x), hash(h_arb, h))
+Base.hash(x::acb_struct, h::UInt) = hash(Acb(x), hash(h_acb, h))
+Base.hash(x::arb_vec_struct, h::UInt) =
+    hash(ArbVector(x, shallow = true), hash(h_arb_vec, h))
+Base.hash(x::acb_vec_struct, h::UInt) =
+    hash(AcbVector(x, shallow = true), hash(h_acb_vec, h))
+Base.hash(x::arb_poly_struct, h::UInt) = hash(ArbPoly(x), hash(h_arb_poly, h))
+Base.hash(x::acb_poly_struct, h::UInt) = hash(AcbPoly(x), hash(h_acb_poly, h))
+Base.hash(x::arb_mat_struct, h::UInt) =
+    hash(ArbMatrix(x, shallow = true), hash(h_arb_mat, h))
+Base.hash(x::acb_mat_struct, h::UInt) =
+    hash(AcbMatrix(x, shallow = true), hash(h_acb_mat, h))
 
 # Hashes of Mag and Arf are computed using the Base implementation
 # which used Base.decompose defined above.

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -123,7 +123,7 @@ Returns a tuple `(m::Arf, r::Mag)` where `m` is the midpoint of the
 ball and `r` is the radius. If `T` is given convert both `m` and `r`
 to this type, supports `Arb`.
 
-See also [`setball`](@ref) and [`getinterval`](@ref). #
+See also [`setball`](@ref) and [`getinterval`](@ref).
 """
 getball(x::ArbOrRef) = (Arf(midref(x)), Mag(radref(x)))
 getball(::Type{Arb}, x::ArbOrRef) = (Arb(midref(x)), Arb(radref(x), prec = precision(x)))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -182,4 +182,4 @@ See also [`setball`](@ref).
 """
 add_error(x::Union{ArbOrRef,AcbOrRef}, err::Union{MagOrRef,ArfOrRef,ArbOrRef}) =
     add_error!(copy(x), err)
-add_error(x::Union{ArbMatrixLike,AcbMatrixLike}, err::MagOrRef) = add_error!(copy(x), err)
+add_error(x::Union{ArbMatrixOrRef,AcbMatrixOrRef}, err::MagOrRef) = add_error!(copy(x), err)

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -52,7 +52,7 @@ Base.getindex(p::Union{Poly,Series}, I::AbstractRange{<:Integer}) = [p[i] for i 
 
 Base.@propagate_inbounds function Base.setindex!(
     p::Union{ArbPoly,ArbSeries},
-    x::Union{ArbLike,_BitSigned},
+    x::Union{ArbOrRef,_BitSigned},
     i::Integer,
 )
     @boundscheck checkbounds(p, i)
@@ -62,7 +62,7 @@ end
 
 Base.@propagate_inbounds function Base.setindex!(
     p::Union{AcbPoly,AcbSeries},
-    x::AcbLike,
+    x::AcbOrRef,
     i::Integer,
 )
     @boundscheck checkbounds(p, i)
@@ -362,7 +362,7 @@ end
 ##
 
 for (T, Tel, Tel_inplace) in [
-    (Union{ArbPoly,ArbSeries}, Real, Union{ArbOrRef,ArfLike,Unsigned,Integer}),
+    (Union{ArbPoly,ArbSeries}, Real, Union{ArbOrRef,ArfOrRef,Unsigned,Integer}),
     (Union{AcbPoly,AcbSeries}, Number, Union{AcbOrRef,ArbOrRef,Unsigned,Integer}),
 ]
     # Since we use inplace methods we need to manually normalise the

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -197,3 +197,11 @@ end
 # this for non-number types. Note that in this case we always compare
 # them using Arblib.equal.
 Base.:(==)(x::T, y::T) where {T<:ArbStructTypes} = equal(x, y)
+
+function Base.:(==)(x::T, y::T) where {T<:Union{arb_vec_struct,acb_vec_struct}}
+    x.n == y.n || return false
+    for i = 1:x.n
+        equal(x[i], y[i]) || return false
+    end
+    return true
+end

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -1,6 +1,6 @@
 for (T, funcpairs) in (
     (
-        MagLike,
+        MagOrRef,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isinf), :is_inf),
@@ -9,7 +9,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        ArfLike,
+        ArfOrRef,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isinf), :is_inf),
@@ -24,7 +24,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        ArbLike,
+        ArbOrRef,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -39,7 +39,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        AcbLike,
+        AcbOrRef,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -51,9 +51,9 @@ for (T, funcpairs) in (
             (:containsint, :contains_int),
         ),
     ),
-    (ArbVectorLike, ((:(Base.isfinite), :is_finite), (:(Base.iszero), :is_zero))),
+    (ArbVectorOrRef, ((:(Base.isfinite), :is_finite), (:(Base.iszero), :is_zero))),
     (
-        AcbVectorLike,
+        AcbVectorOrRef,
         (
             (:(Base.isfinite), :is_finite),
             (:(Base.isreal), :is_real),
@@ -81,7 +81,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        ArbMatrixLike,
+        ArbMatrixOrRef,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -90,7 +90,7 @@ for (T, funcpairs) in (
         ),
     ),
     (
-        AcbMatrixLike,
+        AcbMatrixOrRef,
         (
             (:isexact, :is_exact),
             (:(Base.isfinite), :is_finite),
@@ -125,7 +125,7 @@ function Base.isfinite(p::Union{ArbPoly,ArbSeries,AcbPoly,AcbSeries})
     return true
 end
 
-for ArbT in (ArfLike, ArbLike, AcbLike)
+for ArbT in (ArfOrRef, ArbOrRef, AcbOrRef)
     @eval begin
         Base.isequal(y::$ArbT, x::$ArbT) = !iszero(equal(x, y))
         # Comparison of non-floating point values should use ==
@@ -133,28 +133,28 @@ for ArbT in (ArfLike, ArbLike, AcbLike)
         Base.:(==)(x::$ArbT, y::Integer) = !iszero(equal(x, y))
     end
 end
-Base.:(==)(x::MagLike, y::MagLike) = !iszero(equal(x, y))
-Base.isless(x::MagLike, y::MagLike) = cmp(x, y) < 0
-Base.:(<)(x::MagLike, y::MagLike) = cmp(x, y) < 0
-Base.:(<=)(x::MagLike, y::MagLike) = cmp(x, y) <= 0
+Base.:(==)(x::MagOrRef, y::MagOrRef) = !iszero(equal(x, y))
+Base.isless(x::MagOrRef, y::MagOrRef) = cmp(x, y) < 0
+Base.:(<)(x::MagOrRef, y::MagOrRef) = cmp(x, y) < 0
+Base.:(<=)(x::MagOrRef, y::MagOrRef) = cmp(x, y) <= 0
 
-for jltype in (ArfLike, Integer, Unsigned, Base.GMP.CdoubleMax)
+for jltype in (ArfOrRef, Integer, Unsigned, Base.GMP.CdoubleMax)
     @eval begin
-        Base.isless(x::ArfLike, y::$jltype) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
-        Base.:(<)(x::ArfLike, y::$jltype) = !isnan(x) && !isnan(y) && cmp(x, y) < 0
-        Base.:(<=)(x::ArfLike, y::$jltype) = (x < y) || isequal(x, y)
+        Base.isless(x::ArfOrRef, y::$jltype) = (isnan(y) && !isnan(x)) || cmp(x, y) < 0
+        Base.:(<)(x::ArfOrRef, y::$jltype) = !isnan(x) && !isnan(y) && cmp(x, y) < 0
+        Base.:(<=)(x::ArfOrRef, y::$jltype) = (x < y) || isequal(x, y)
     end
 end
 
 for (ArbT, args) in (
-    (ArfLike, ((:(==), :equal),)),
+    (ArfOrRef, ((:(==), :equal),)),
     (
-        ArbLike,
+        ArbOrRef,
         ((:(==), :eq), (:(!=), :ne), (:(<), :lt), (:(<=), :le), (:(>), :gt), (:(>=), :ge)),
     ),
-    (AcbLike, ((:(==), :eq), (:(!=), :ne))),
-    (ArbMatrixLike, ((:(==), :eq), (:(!=), :ne))),
-    (AcbMatrixLike, ((:(==), :eq), (:(!=), :ne))),
+    (AcbOrRef, ((:(==), :eq), (:(!=), :ne))),
+    (ArbMatrixOrRef, ((:(==), :eq), (:(!=), :ne))),
+    (AcbMatrixOrRef, ((:(==), :eq), (:(!=), :ne))),
 )
     for (jlf, arbf) in args
         @eval begin
@@ -166,12 +166,12 @@ end
 # Julia Base defines special methods for comparison between Rational
 # and AbstractFloat which do not work well for Arb. We redefine these
 # methods to just convert the rational number to Arb.
-Base.:<(x::Arb, y::Rational) = x < convert(Arb, y)
-Base.:<(x::Rational, y::Arb) = convert(Arb, x) < y
-Base.:<=(x::Arb, y::Rational) = x <= convert(Arb, y)
-Base.:<=(x::Rational, y::Arb) = convert(Arb, x) <= y
-Base.cmp(x::Arb, y::Rational) = Base.cmp(x, convert(Arb, y))
-Base.cmp(x::Rational, y::Arb) = Base.cmp(convert(Arb, x), y)
+Base.:<(x::ArbOrRef, y::Rational) = x < convert(Arb, y)
+Base.:<(x::Rational, y::ArbOrRef) = convert(Arb, x) < y
+Base.:<=(x::ArbOrRef, y::Rational) = x <= convert(Arb, y)
+Base.:<=(x::Rational, y::ArbOrRef) = convert(Arb, x) <= y
+Base.cmp(x::ArbOrRef, y::Rational) = Base.cmp(x, convert(Arb, y))
+Base.cmp(x::Rational, y::ArbOrRef) = Base.cmp(convert(Arb, x), y)
 
 Base.isequal(x::T, y::T) where {T<:Union{ArbPoly,AcbPoly}} = !iszero(equal(x, y))
 Base.isequal(x::T, y::T) where {T<:Union{ArbSeries,AcbSeries}} =
@@ -192,3 +192,8 @@ end
 function Base.:(!=)(x::T, y::T) where {T<:Union{ArbSeries,AcbSeries}}
     return (degree(x) != degree(y)) || iszero(overlaps(x, y))
 end
+
+# For structs we only have to define == since isequals defaults to
+# this for non-number types. Note that in this case we always compare
+# them using Arblib.equal.
+Base.:(==)(x::T, y::T) where {T<:ArbStructTypes} = equal(x, y)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -99,7 +99,7 @@ function set!(res::ArbLike, (a, b)::Tuple{<:Real,<:Real}; prec::Integer = precis
 end
 
 # Acb
-function set!(res::AcbLike, x::Union{Real,arf_struct,mag_struct,Tuple{<:Real,<:Real}})
+function set!(res::AcbLike, x::Union{Real,MagLike,ArfLike,Tuple{<:Real,<:Real}})
     set!(realref(res), x)
     zero!(imagref(res))
     return res
@@ -115,8 +115,8 @@ end
 # Doesn't support aliasing between realref(res) and im
 function set!(
     res::AcbLike,
-    re::Union{Real,arb_struct,arf_struct,mag_struct,Tuple{<:Real,<:Real}},
-    im::Union{Real,arb_struct,arf_struct,mag_struct,Tuple{<:Real,<:Real}},
+    re::Union{Real,MagLike,ArfLike,ArbLike,Tuple{<:Real,<:Real}},
+    im::Union{Real,MagLike,ArfLike,ArbLike,Tuple{<:Real,<:Real}},
 )
     set!(realref(res), re)
     set!(imagref(res), im)

--- a/src/types.jl
+++ b/src/types.jl
@@ -18,9 +18,14 @@ struct Mag <: Real
 
     Mag() = new(mag_struct())
 
-    Mag(x::mag_struct) = new(mag_struct(x))
-
-    Mag(x::Union{Mag,Arf}) = new(mag_struct(cstruct(x)))
+    # Uses init_set! constructor. Argument type should be
+    # Union{MagLike,ArfLike} but those are only defined further down.
+    Mag(
+        x::Union{
+            Union{Mag,mag_struct,Ptr{mag_struct}},
+            Union{Arf,arf_struct,Ptr{arf_struct}},
+        },
+    ) = new(mag_struct(cstruct(x)))
 end
 
 """

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -15,8 +15,8 @@
             @test precision(Arf(zero(T), prec = 80)) == 80
         end
 
-        @test Arf(zero(Arf).arf) == zero(Arf)
-        @test precision(Arf(zero(Arf).arf, prec = 80)) == 80
+        @test Arf(0) == zero(Arf)
+        @test precision(Arf(zero(Arf), prec = 80)) == 80
 
         @test precision(Arf(Arf(prec = 80))) == 80
         @test precision(Arf(BigFloat(0, precision = 80))) == 80
@@ -36,11 +36,9 @@
         @test Arb((one(Arf), one(Arf))) == one(Arb)
         @test isequal(Arb((Arf(1), Arf(2))), Arb((1, 2)))
 
-        @test Arb(zero(Arb).arb) == Arb("0.0") == zero(Arb)
-        @test Arb(one(Arb).arb) == Arb("1.0") == one(Arb)
-        @test precision(Arb(zero(Arb).arb, prec = 80)) ==
-              precision(Arb("0.0", prec = 80)) ==
-              80
+        @test Arb(0) == Arb("0.0") == zero(Arb)
+        @test Arb(1) == Arb("1.0") == one(Arb)
+        @test precision(Arb(zero(Arb), prec = 80)) == precision(Arb("0.0", prec = 80)) == 80
 
         @test precision(Arb(Arf(prec = 80))) == 80
         @test precision(Arb(Arb(prec = 80))) == 80
@@ -88,14 +86,12 @@
             @test precision(Acb(Complex(zero(T), zero(T)), prec = 80)) == 80
         end
 
-        @test Acb(zero(Acb).acb) == Acb("0.0") == zero(Acb)
-        @test Acb(one(Acb).acb) == Acb("1.0") == one(Acb)
-        @test precision(Acb(zero(Acb).acb, prec = 80)) ==
-              precision(Acb("0.0", prec = 80)) ==
-              80
+        @test Acb(0) == Acb("0.0") == zero(Acb)
+        @test Acb(1) == Acb("1.0") == one(Acb)
+        @test precision(Acb("0.0", prec = 80)) == 80
 
-        @test imag(Acb(zero(Arb).arb, one(Arb).arb)) == imag(Acb("0.0", "1.0")) == one(Arb)
-        @test precision(Acb(zero(Arb).arb, zero(Arb).arb, prec = 80)) ==
+        @test imag(Acb(zero(Arb), one(Arb))) == imag(Acb("0.0", "1.0")) == one(Arb)
+        @test precision(Acb(zero(Arb), zero(Arb), prec = 80)) ==
               precision(Acb("0.0", "0.0", prec = 80)) ==
               80
 

--- a/test/hash.jl
+++ b/test/hash.jl
@@ -30,15 +30,6 @@
         @test hash(Acb(π)) != hash(Acb(0, π))
     end
 
-    @testset "mag_struct, arf_struct, arb_struct, acb_struct" begin
-        # Internally uses the hashing for Mag, Arf, Arb and Acb so we
-        # only test that it calls that correctly
-        @test hash(Arblib.mag_struct()) == hash(zero(Mag))
-        @test hash(Arblib.arf_struct()) == hash(zero(Arf))
-        @test hash(Arblib.arb_struct()) == hash(zero(Arb))
-        @test hash(Arblib.acb_struct()) == hash(zero(Acb))
-    end
-
     @testset "Poly, Series" begin
         # Poly
         for T in (ArbPoly, AcbPoly)
@@ -89,6 +80,48 @@
 
             @test hash(T([1, 2, 3])) != hash(T([1, 2, 4]))
             @test hash(T([0])) != hash(T([1]))
+        end
+    end
+
+    @testset "struct" begin
+        let cstruct = Arblib.cstruct
+            # Test so that hashes for different types don't overlap and
+            # that hashes of same values are same
+            @test hash(cstruct(Mag(1))) == hash(cstruct(Mag(1))) != hash(Mag(1))
+            @test hash(cstruct(Arf(1 // 3))) ==
+                  hash(cstruct(Arf(1 // 3))) !=
+                  hash(Arf(1 // 3))
+            @test hash(cstruct(Arb(1 // 3))) ==
+                  hash(cstruct(Arb(1 // 3))) !=
+                  hash(Arb(1 // 3))
+            @test hash(cstruct(Acb(1 // 3))) ==
+                  hash(cstruct(Acb(1 // 3))) !=
+                  hash(Acb(1 // 3))
+            @test hash(cstruct(ArbVector([1]))) ==
+                  hash(cstruct(ArbVector([1]))) !=
+                  hash(ArbVector([1]))
+            @test hash(cstruct(AcbVector([1]))) ==
+                  hash(cstruct(AcbVector([1]))) !=
+                  hash(AcbVector([1]))
+            @test hash(cstruct(ArbPoly([1]))) ==
+                  hash(cstruct(ArbPoly([1]))) !=
+                  hash(ArbPoly([1]))
+            @test hash(cstruct(AcbPoly([1]))) ==
+                  hash(cstruct(AcbPoly([1]))) !=
+                  hash(AcbPoly([1]))
+            @test hash(cstruct(ArbMatrix([1]))) ==
+                  hash(cstruct(ArbMatrix([1]))) !=
+                  hash(ArbMatrix([1]))
+            @test hash(cstruct(AcbMatrix([1]))) ==
+                  hash(cstruct(AcbMatrix([1]))) !=
+                  hash(AcbMatrix([1]))
+
+            @test hash(cstruct(Mag())) != hash(cstruct(Arf()))
+            @test hash(cstruct(Arf())) != hash(cstruct(Arb()))
+            @test hash(cstruct(Arb())) != hash(cstruct(Acb()))
+            @test hash(cstruct(ArbVector([1]))) != hash(cstruct(AcbVector([1])))
+            @test hash(cstruct(ArbPoly([1]))) != hash(cstruct(AcbPoly([1])))
+            @test hash(cstruct(ArbMatrix([1]))) != hash(cstruct(AcbMatrix([1])))
         end
     end
 end

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -171,4 +171,34 @@
         @test isequal(P3, P3)
     end
 
+    @testset "isequal for structs" begin
+        let cstruct = Arblib.cstruct
+            @test isequal(cstruct(Mag(1)), cstruct(Mag(1)))
+            @test isequal(cstruct(Arf(1)), cstruct(Arf(1)))
+            @test isequal(cstruct(Arb(1)), cstruct(Arb(1)))
+            @test isequal(cstruct(Acb(1)), cstruct(Acb(1)))
+
+            @test isequal(cstruct(ArbVector([1, 2])), cstruct(ArbVector([1, 2])))
+            @test isequal(cstruct(AcbVector([1, 2])), cstruct(AcbVector([1, 2])))
+
+            @test isequal(cstruct(ArbPoly([1, 2])), cstruct(ArbPoly([1, 2])))
+            @test isequal(cstruct(AcbPoly([1, 2])), cstruct(AcbPoly([1, 2])))
+
+            @test isequal(cstruct(ArbMatrix([1, 2])), cstruct(ArbMatrix([1, 2])))
+            @test isequal(cstruct(AcbMatrix([1, 2])), cstruct(AcbMatrix([1, 2])))
+
+            # It should behave like Arblib.equal and not Arblib.eq
+            @test isequal(cstruct(Arb(π)), cstruct(Arb(π)))
+            @test isequal(cstruct(Acb(π)), cstruct(Acb(π)))
+            @test isequal(cstruct(ArbMatrix([π])), cstruct(ArbMatrix([π])))
+            @test isequal(cstruct(AcbMatrix([π])), cstruct(AcbMatrix([π])))
+
+            # Different types should not be equal even if they are
+            # numerically the same
+            @test !isequal(cstruct(Mag(1)), cstruct(Arf(1)))
+            @test !isequal(cstruct(Arb(1)), cstruct(Acb(1)))
+            @test !isequal(cstruct(ArbVector([1])), cstruct(AcbVector([1])))
+            @test !isequal(cstruct(ArbMatrix([1])), cstruct(AcbMatrix([1])))
+        end
+    end
 end


### PR DESCRIPTION
This PR removes the use of `XLike` types in several places. This leads to breaking changes since the methods are no longer defined for structs and pointers. This is in line with making the high level interface more focused on the high level types. It depends on #167.

The most notable change is the change to `isequal` (and `==`) for structs. They no longer compare equal to other types, so an `arb_struct` is never equal to an `Arb` even if the underlying struct is the same. This fixes earlier problems with `isequal` not being transitive. Before we had
```julia
julia> isequal(Mag().mag, Mag())
true

julia> isequal(Mag(), Arb())
true

julia> isequal(Arb(), Arb().arb)
true

julia> isequal(Mag().mag, Arb().arb)
false
```
whereas we now have
```julia
julia> isequal(Mag().mag, Mag())
false

julia> isequal(Mag(), Arb())
true

julia> isequal(Arb(), Arb().arb)
false

julia> isequal(Mag().mag, Arb().arb)
false
```
With this change the `hash` methods for structs have also been reworked. They no longer give the same hash as for the non-struct types.

Other changes are reduced usage of `XLike`  in some constructors a few other methods. Some argument types have also been slightly simplified in the process.