### PR TITLE
Avoid overloading `Base.union`, `Base.intersect` and `Base.contains`

### DIFF
--- a/docs/src/interface-ball.md
+++ b/docs/src/interface-ball.md
@@ -28,10 +28,11 @@ getball
 ```
 
 ## Union and intersection
-The `Base.union` and `Base.intersect` methods are overloaded to
-compute the union and intersection of balls.
+The methods `Arblib.union` and `Arblib.intersection` compute the union
+and intersection of balls. Note that these methods are not exported
+and different from `Base.union` and `Base.intersect`.
 
 ``` @docs
-union(::Arb, ::Arb)
-intersect(::Arb, ::Arb)
+Arblib.union
+Arblib.intersection
 ```

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -5,9 +5,6 @@ import LinearAlgebra
 import Serialization
 import SpecialFunctions
 
-# So that the parsed contains method extends the base function
-import Base: contains
-
 export Mag,
     MagRef,
     Arf,

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -138,28 +138,28 @@ getball(::Type{Arb}, x::ArbOrRef) = (Arb(midref(x)), Arb(radref(x), prec = preci
 `union(x, y, z...)` returns a ball containing the union of all given
 balls.
 """
-Base.union(x::ArbOrRef, y::ArbOrRef) = union!(Arb(prec = _precision(x, y)), x, y)
-Base.union(x::AcbOrRef, y::AcbOrRef) = union!(Acb(prec = _precision(x, y)), x, y)
+union(x::ArbOrRef, y::ArbOrRef) = union!(Arb(prec = _precision(x, y)), x, y)
+union(x::AcbOrRef, y::AcbOrRef) = union!(Acb(prec = _precision(x, y)), x, y)
 # TODO: Could be optimized, both for performance and enclosure
-Base.union(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
+union(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
     foldl(union, xs, init = union(union(x, y), z))
-Base.union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...) =
+union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...) =
     foldl(union, xs, init = union(union(x, y), z))
 
 """
-    intersect(x::ArbOrRef, y::ArbOrRef)
-    intersect(x::AcbOrRef, y::AcbOrRef)
-    intersect(x, y, z...)
+    intersection(x::ArbOrRef, y::ArbOrRef)
+    intersection(x::AcbOrRef, y::AcbOrRef)
+    intersection(x, y, z...)
 
-`intersect(x, y)` returns a ball containing the intersection of `x`
+`intersection(x, y)` returns a ball containing the intersection of `x`
 and `y`. If `x` and `y` do not overlap (as given by `overlaps(a, b)`)
 throws an `ArgumentError`.
 
-`intersect(x, y, z...)` returns a ball containing the intersection of
+`intersection(x, y, z...)` returns a ball containing the intersection of
 all given balls. If all the balls do not overlap throws an
 `ArgumentError`.
 """
-function Base.intersect(x::ArbOrRef, y::ArbOrRef)
+function intersection(x::ArbOrRef, y::ArbOrRef)
     overlaps(x, y) ||
         throw(ArgumentError("intersection of non-intersecting balls not allowed"))
     res = Arb(prec = _precision(x, y))
@@ -167,8 +167,9 @@ function Base.intersect(x::ArbOrRef, y::ArbOrRef)
     return res
 end
 # TODO: Could be optimized, both for performance and enclosure
-Base.intersect(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
-    foldl(intersect, xs, init = intersect(intersect(x, y), z))
+intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
+    foldl(intersection, xs, init = intersection(intersection(x, y), z))
+
 
 """
     add_error(x, err)

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -140,11 +140,14 @@ balls.
 """
 union(x::ArbOrRef, y::ArbOrRef) = union!(Arb(prec = _precision(x, y)), x, y)
 union(x::AcbOrRef, y::AcbOrRef) = union!(Acb(prec = _precision(x, y)), x, y)
-# TODO: Could be optimized, both for performance and enclosure
-union(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
-    foldl(union, xs, init = union(union(x, y), z))
-union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...) =
-    foldl(union, xs, init = union(union(x, y), z))
+function union(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...)
+    res = union(y, z, xs...)
+    return union!(res, res, x)
+end
+function union(x::AcbOrRef, y::AcbOrRef, z::AcbOrRef, xs...)
+    res = union(y, z, xs...)
+    return union!(res, res, x)
+end
 
 """
     intersection(x::ArbOrRef, y::ArbOrRef)
@@ -160,16 +163,19 @@ all given balls. If all the balls do not overlap throws an
 `ArgumentError`.
 """
 function intersection(x::ArbOrRef, y::ArbOrRef)
-    overlaps(x, y) ||
-        throw(ArgumentError("intersection of non-intersecting balls not allowed"))
     res = Arb(prec = _precision(x, y))
-    intersection!(res, x, y)
+    sucess = intersection!(res, x, y)
+    iszero(sucess) &&
+        throw(ArgumentError("intersection of non-intersecting balls not allowed"))
     return res
 end
-# TODO: Could be optimized, both for performance and enclosure
-intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...) =
-    foldl(intersection, xs, init = intersection(intersection(x, y), z))
-
+function intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...)
+    res = intersection(y, z, xs...)
+    sucess = intersection!(res, res, x)
+    iszero(sucess) &&
+        throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+    return res
+end
 
 """
     add_error(x, err)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -66,8 +66,8 @@
         @test isone(Arblib.setball(Arb, 1 // 1, 0))
 
         @test getinterval(Arblib.setball(Arb, 2, 1)) == (1, 3)
-        @test contains(Arblib.setball(Arb, 0.5, 0.5), 0)
-        @test contains(Arblib.setball(Arb, 0.5, 0.5), 1)
+        @test Arblib.contains(Arblib.setball(Arb, 0.5, 0.5), 0)
+        @test Arblib.contains(Arblib.setball(Arb, 0.5, 0.5), 1)
 
         @test precision(Arblib.setball(Arb, Arf(prec = 80), 0)) == 80
         @test precision(Arblib.setball(Arb, Arf(prec = 90), 0, prec = 80)) == 80

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -172,29 +172,29 @@
         xs = [Arb(i) for i in vcat(1:10, 10:-1:1)]
         xsc = Acb.(xs)
 
-        @test Arblib.contains(union(zero(Arb), one(Arb)), Arb(0.5))
-        @test Arblib.contains(union(zero(Acb), Acb(1, 1)), Acb(0.5, 0.5))
-        @test all(i -> Arblib.contains(union(xs...), i), 1:10)
-        @test all(i -> Arblib.contains(union(xsc...), i), Acb.(1:10))
+        @test Arblib.contains(Arblib.union(zero(Arb), one(Arb)), Arb(0.5))
+        @test Arblib.contains(Arblib.union(zero(Acb), Acb(1, 1)), Acb(0.5, 0.5))
+        @test all(i -> Arblib.contains(Arblib.union(xs...), i), 1:10)
+        @test all(i -> Arblib.contains(Arblib.union(xsc...), i), Acb.(1:10))
 
-        @test precision(union(Arb(prec = 80), Arb(prec = 90))) == 90
-        @test precision(union(Acb(prec = 80), Acb(prec = 90))) == 90
-        @test precision(union([Arb(prec = p) for p = 70:10:100]...)) == 100
-        @test precision(union([Acb(prec = p) for p = 70:10:100]...)) == 100
+        @test precision(Arblib.union(Arb(prec = 80), Arb(prec = 90))) == 90
+        @test precision(Arblib.union(Acb(prec = 80), Acb(prec = 90))) == 90
+        @test precision(Arblib.union([Arb(prec = p) for p = 70:10:100]...)) == 100
+        @test precision(Arblib.union([Acb(prec = p) for p = 70:10:100]...)) == 100
     end
 
-    @testset "intersect" begin
+    @testset "Arblib.intersection" begin
         xs = [Arb((0, i)) for i in vcat(1:10, 10:-1:1)]
 
-        @test Arblib.contains(intersect(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
-        @test Arblib.contains(intersect(xs...), Arb((0, 1)))
-        @test !Arblib.contains(intersect(xs...), Arb(2))
+        @test Arblib.contains(Arblib.intersection(Arb((0, 2)), Arb((1, 3))), Arb((1, 2)))
+        @test Arblib.contains(Arblib.intersection(xs...), Arb((0, 1)))
+        @test !Arblib.contains(Arblib.intersection(xs...), Arb(2))
 
-        @test precision(intersect(Arb(prec = 80), Arb(prec = 90))) == 90
-        @test precision(intersect([Arb(prec = p) for p = 70:10:100]...)) == 100
+        @test precision(Arblib.intersection(Arb(prec = 80), Arb(prec = 90))) == 90
+        @test precision(Arblib.intersection([Arb(prec = p) for p = 70:10:100]...)) == 100
 
-        @test_throws ArgumentError intersect(Arb(1), Arb(2))
-        @test_throws ArgumentError intersect([xs; Arb(2)]...)
+        @test_throws ArgumentError Arblib.intersection(Arb(1), Arb(2))
+        @test_throws ArgumentError Arblib.intersection([xs; Arb(2)]...)
     end
 
     @testset "add_error" begin

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -33,12 +33,12 @@
         end
 
         A = [Arb((i, i + 1)) for i = 0:20]
-        @test contains(minimum(A), Arb((0, 1)))
-        @test contains(minimum(reverse(A)), Arb((0, 1)))
-        @test contains(maximum(A), Arb((20, 21)))
-        @test contains(maximum(reverse(A)), Arb((20, 21)))
-        @test all(contains.(extrema(A), (Arb((0, 1)), Arb((20, 21)))))
-        @test all(contains.(extrema(reverse(A)), (Arb((0, 1)), Arb((20, 21)))))
+        @test Arblib.contains(minimum(A), Arb((0, 1)))
+        @test Arblib.contains(minimum(reverse(A)), Arb((0, 1)))
+        @test Arblib.contains(maximum(A), Arb((20, 21)))
+        @test Arblib.contains(maximum(reverse(A)), Arb((20, 21)))
+        @test all(Arblib.contains.(extrema(A), (Arb((0, 1)), Arb((20, 21)))))
+        @test all(Arblib.contains.(extrema(reverse(A)), (Arb((0, 1)), Arb((20, 21)))))
 
         # Fails in Julia version < 1.8 with default implementation due
         # to short circuiting in Base.mapreduce_impl
@@ -63,31 +63,31 @@
         # Fails with default implementation due to Base._fast
         #A = [Arb(0); [setball(Arb, 0, i) for i in reverse(0:257)]]
         A = [setball(Arb, 0, i) for i = 0:257]
-        @test contains(minimum(A), -257)
-        @test contains(maximum(A), 257)
-        @test contains(extrema(A)[1], -257)
-        @test contains(extrema(A)[2], 257)
-        @test contains(minimum(identity, A), -257)
-        @test contains(maximum(identity, A), 257)
-        @test contains(extrema(identity, A)[1], -257)
-        @test contains(extrema(identity, A)[2], 257)
+        @test Arblib.contains(minimum(A), -257)
+        @test Arblib.contains(maximum(A), 257)
+        @test Arblib.contains(extrema(A)[1], -257)
+        @test Arblib.contains(extrema(A)[2], 257)
+        @test Arblib.contains(minimum(identity, A), -257)
+        @test Arblib.contains(maximum(identity, A), 257)
+        @test Arblib.contains(extrema(identity, A)[1], -257)
+        @test Arblib.contains(extrema(identity, A)[2], 257)
 
         # Fails with default implementation due to both short circuit
         # and Base._fast
         A = [setball(Arb, 0, i) for i = 0:1000]
-        @test contains(minimum(A), -1000)
-        @test contains(maximum(A), 1000)
-        @test contains(extrema(A)[1], -1000)
-        @test contains(extrema(A)[2], 1000)
+        @test Arblib.contains(minimum(A), -1000)
+        @test Arblib.contains(maximum(A), 1000)
+        @test Arblib.contains(extrema(A)[1], -1000)
+        @test Arblib.contains(extrema(A)[2], 1000)
         if VERSION < v"1.8.0-rc3"
-            @test_broken contains(minimum(identity, A), -1000)
-            @test_broken contains(maximum(identity, A), 1000)
+            @test_broken Arblib.contains(minimum(identity, A), -1000)
+            @test_broken Arblib.contains(maximum(identity, A), 1000)
         else
-            @test contains(minimum(identity, A), -1000)
-            @test contains(maximum(identity, A), 1000)
+            @test Arblib.contains(minimum(identity, A), -1000)
+            @test Arblib.contains(maximum(identity, A), 1000)
         end
-        @test contains(extrema(identity, A)[1], -1000)
-        @test contains(extrema(identity, A)[2], 1000)
+        @test Arblib.contains(extrema(identity, A)[1], -1000)
+        @test Arblib.contains(extrema(identity, A)[2], 1000)
 
         @test !Base.isbadzero(min, zero(Mag))
         @test !Base.isbadzero(min, zero(Arf))


### PR DESCRIPTION
Apart from Flint 3.0 this is the last change I mention in #165. It avoids overloading `Base.union`, `Base.intersect` and `Base.contains` and instead provides `Arblib.union`, `Arblib.intersection` and `Arblib.contains`. 

For the motivation see #165. In short `Base.union` and `Base.intersect` treats numbers as singleton vectors, which is different from the Arb behaviour. For `contains` the problem is not as severe, but I still think keeping the Arb version separate is a good idea. See also [this PR for IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl/pull/572) where they also opt to not overload the Base methods.

This change is of course not backwards compatible and it is likely code will need to be updated (this is certainly true in my case). For `union` and `intersect` this is slightly annoying because they will now use the Base implementation and return a vector, so the error will only be noticed further down the line. Mentioning it in the release notes will hopefully reduce the issues people encounter.