### PR TITLE
Add midpoint for Acb and union and intersection for polynomials

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -211,15 +211,16 @@ end
 
 """
     intersection(x::ArbOrRef, y::ArbOrRef)
-    intersection(x::AcbOrRef, y::AcbOrRef)
+    intersection(x::T, y::T) where {T<:Union{ArbPoly,ArbSeries}}
     intersection(x, y, z...)
 
 `intersection(x, y)` returns a ball containing the intersection of `x`
 and `y`. If `x` and `y` do not overlap (as given by `overlaps(a, b)`)
-throws an `ArgumentError`.
+throws an `ArgumentError`. For polynomials and series the intersection
+is taken coefficient-wise.
 
-`intersection(x, y, z...)` returns a ball containing the intersection of
-all given balls. If all the balls do not overlap throws an
+`intersection(x, y, z...)` returns a ball containing the intersection
+of all given balls. If all the balls do not overlap throws an
 `ArgumentError`.
 """
 function intersection(x::ArbOrRef, y::ArbOrRef)
@@ -229,11 +230,70 @@ function intersection(x::ArbOrRef, y::ArbOrRef)
         throw(ArgumentError("intersection of non-intersecting balls not allowed"))
     return res
 end
+intersection(x::ArbPoly, y::ArbPoly) =
+    _intersection!(ArbPoly((prec = _precision(x, y))), x, y)
+function intersection(x::ArbSeries, y::ArbSeries)
+    degree(x) == degree(y) ||
+        throw(ArgumentError("intersection of series requires same degree"))
+    res = ArbSeries(degree = degree(x), prec = _precision(x, y))
+    _intersection!(res.poly, x.poly, y.poly)
+    return res
+end
+
 function intersection(x::ArbOrRef, y::ArbOrRef, z::ArbOrRef, xs...)
     res = intersection(y, z, xs...)
     sucess = intersection!(res, res, x)
     iszero(sucess) &&
         throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+    return res
+end
+function intersection(x::ArbPoly, y::ArbPoly, z::ArbPoly, xs...)
+    res = intersection(y, z, xs...)
+    return _intersection!(res, res, x)
+end
+function intersection(x::ArbSeries, y::ArbSeries, z::ArbSeries, xs...)
+    res = intersection(y, z, xs...)
+    degree(res) == degree(x) ||
+        throw(ArgumentError("intersection of series requires same degree"))
+    _intersection!(res.poly, res.poly, x.poly)
+    return res
+end
+
+# User internally by intersection
+function _intersection!(res::ArbPoly, x::ArbPoly, y::ArbPoly)
+    res_length = max(length(x), length(y))
+    common_degree = min(degree(x), degree(y))
+
+    fit_length!(res, res_length)
+
+    for i = 0:common_degree
+        sucess = intersection!(ref(res, i), ref(x, i), ref(y, i))
+        if iszero(sucess)
+            set_length!(res, res_length)
+            normalise!(res)
+            throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+        end
+    end
+
+    if common_degree + 1 < res_length
+        # At most one of the below loops will run
+        for i = common_degree+1:degree(x)
+            xi = ref(x, i)
+            contains_zero(xi) ||
+                throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+            isnan(midref(xi)) && indeterminate!(ref(res, i))
+        end
+        for i = common_degree+1:degree(y)
+            yi = ref(y, i)
+            contains_zero(yi) ||
+                throw(ArgumentError("intersection of non-intersecting balls not allowed"))
+            isnan(midref(yi)) && indeterminate!(ref(res, i))
+        end
+    end
+
+    set_length!(res, res_length)
+    normalise!(res)
+
     return res
 end
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -23,6 +23,18 @@ midpoint(::Type{Arb}, x::ArbOrRef) = Arb(midref(x))
 midpoint(x::ArbOrRef) = midpoint(Arf, x)
 
 """
+    midpoint([T, ] z::AcbOrRef)
+
+Returns the midpoint of `z` as a `Complex{Arf}`. If `T` is given and
+equal to `Arf` or `Arb`, convert to `Complex{T}`. If `T` is `Acb` then
+convert to that.
+"""
+midpoint(::Type{Acb}, z::AcbOrRef) = Acb(midref(realref(z)), midref(imagref(z)))
+midpoint(T::Type{<:Union{Arf,Arb}}, z::AcbOrRef) =
+    Complex(midpoint(T, realref(z)), midpoint(T, imagref(z)))
+midpoint(z::AcbOrRef) = midpoint(Arf, z)
+
+"""
     lbound([T, ] x::ArbOrRef)
 
 Returns a lower bound of `x` as an `Arf`. If `T` is given convert to

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -182,7 +182,7 @@ function union(x::T, y::T, z::T, xs...) where {T<:Union{ArbSeries,AcbSeries}}
     return res
 end
 
-# User internally by union
+# Used internally by union
 function _union!(res::T, x::T, y::T) where {T<:Union{ArbPoly,AcbPoly}}
     res_length = max(length(x), length(y))
     common_degree = min(degree(x), degree(y))
@@ -259,7 +259,7 @@ function intersection(x::ArbSeries, y::ArbSeries, z::ArbSeries, xs...)
     return res
 end
 
-# User internally by intersection
+# Used internally by intersection
 function _intersection!(res::ArbPoly, x::ArbPoly, y::ArbPoly)
     res_length = max(length(x), length(y))
     common_degree = min(degree(x), degree(y))

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -110,22 +110,52 @@ length of the polynomial.
   ```
   where `len` is one higher than (an upper bound of) the new degree.
 
-As an example consider an potential implementation (which currently
-doesn't exist) of
-`Arblib.indeterminate!(x::Union{ArbSeries,AcbSeries})` that sets all
-coefficients of `x` to `NaN`.
+See the extended help for more details.
+
+# Extended help
+Here is an example were the leading coefficient is mutated so that the
+degree is lowered.
+```jldoctest
+julia> p = ArbPoly([1, 2], prec = 64) # Polynomial of degree 1
+1.000000000000000000 + 2.000000000000000000⋅x
+
+julia> Arblib.zero!(Arblib.ref(p, 1)) # Set leading coefficient to 0
+0
+
+julia> Arblib.degree(p) # The degree is still reported as 1
+1
+
+julia> length(p) # And the length as 2
+2
+
+julia> p # Printing gives weird results
+1.000000000000000000 +
+
+julia> Arblib.normalise!(p) # Normalising the polynomial updates the degree
+1.000000000000000000
+
+julia> Arblib.degree(p) # This is now correct
+0
+
+julia> p # And so is printing
+1.000000000000000000
 ```
-function Arblib.indeterminate!(x::Union{ArbSeries,AcbSeries})
-    for i = 0:Arblib.degree(x)
-        # i is less than or equal to the degree so Arblib.ref(x, i) is
-        # always allowed for series
-        Arblib.indeterminate!(Arblib.ref(x, i))
-    end
-    # Since we manually updated the coefficients of the polynomial we
-    # need to also manually update the degree. Note that we don't need
-    # to use Arblib.normalise! since we know the length exactly.
-    return Arblib.set_length!(x, length(x))
-end
+Here is an example when a coefficient above the degree is mutated.
+```jldoctest
+julia> q = ArbSeries([1, 2, 0], prec = 64) # Series of degree 3 with leading coefficient zero
+1.000000000000000000 + 2.000000000000000000⋅x + 𝒪(x^3)
+
+julia> Arblib.one!(Arblib.ref(q, 2)) # Set the leading coefficient to 1
+1.000000000000000000
+
+julia> q # The leading coefficient is not picked up
+1.000000000000000000 + 2.000000000000000000⋅x + 𝒪(x^3)
+
+julia> Arblib.degree(q.poly) # The degree of the underlying polynomial is still 1
+1
+
+julia> Arblib.set_length!(q, 3) # After explicitly setting the length to 3 it is ok
+1.000000000000000000 + 2.000000000000000000⋅x + 1.000000000000000000⋅x^2 + 𝒪(x^3)
 ```
 """
 Base.@propagate_inbounds function ref(p::Union{ArbPoly,ArbSeries}, i::Integer)

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -20,8 +20,8 @@
         x = zero(Arb)
         y = one(Arb)
 
-        @test midpoint(x) == midpoint(Arf, x) == midpoint(Arb, x) == zero(Arf)
-        @test midpoint(y) == midpoint(Arf, y) == midpoint(Arb, y) == one(Arf)
+        @test midpoint(x) == midpoint(Arf, x) == midpoint(Arb, x) == 0
+        @test midpoint(y) == midpoint(Arf, y) == midpoint(Arb, y) == 1
         @test midpoint(x) isa Arf
         @test midpoint(Arf, x) isa Arf
         @test midpoint(Arb, x) isa Arb
@@ -29,6 +29,28 @@
         @test precision(midpoint(Arb(prec = 80))) == 80
         @test precision(midpoint(Arf, Arb(prec = 80))) == 80
         @test precision(midpoint(Arb, Arb(prec = 80))) == 80
+
+        x = zero(Acb)
+        y = Acb(1, 1)
+
+        @test midpoint(x) == midpoint(Arf, x) == midpoint(Arb, x) == midpoint(Acb, x) == 0
+        @test midpoint(y) ==
+              midpoint(Arf, y) ==
+              midpoint(Arb, y) ==
+              midpoint(Acb, y) ==
+              1 + im
+        @test midpoint(x) isa Complex{Arf}
+        @test midpoint(Arf, x) isa Complex{Arf}
+        @test midpoint(Arb, x) isa Complex{Arb}
+        @test midpoint(Acb, x) isa Acb
+
+        @test precision(real(midpoint(Acb(prec = 80)))) == 80
+        @test precision(imag(midpoint(Acb(prec = 80)))) == 80
+        @test precision(real(midpoint(Arf, Acb(prec = 80)))) == 80
+        @test precision(imag(midpoint(Arf, Acb(prec = 80)))) == 80
+        @test precision(real(midpoint(Arb, Acb(prec = 80)))) == 80
+        @test precision(imag(midpoint(Arb, Acb(prec = 80)))) == 80
+        @test precision(midpoint(Acb, Acb(prec = 80))) == 80
     end
 
     @testset "lbound/ubound" begin

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -42,17 +42,30 @@
 
         @test_throws BoundsError p[-1]
 
-        p = TPoly(T[i for i = 0:10])
-        @test all(Arblib.ref(p, i) == p[i] for i = 0:10)
+        @testset "ref" begin
+            p = TPoly(T[i for i = 0:10])
+            @test all(Arblib.ref(p, i) == p[i] for i = 0:10)
 
-        Arblib.set!(Arblib.ref(p, 0), 5)
-        @test p[0] == 5
+            Arblib.set!(Arblib.ref(p, 0), 5)
+            @test p[0] == 5
 
-        @test_throws BoundsError Arblib.ref(p, -1)
-        @test_throws BoundsError Arblib.ref(p, 11)
-        Arblib.zero!(Arblib.ref(p, 10))
-        Arblib.normalise!(p)
-        @test_throws BoundsError Arblib.ref(p, 10)
+            @test_throws BoundsError Arblib.ref(p, -1)
+            @test_throws BoundsError Arblib.ref(p, 11)
+
+            # Change the degree and check that we can still access
+            Arblib.zero!(Arblib.ref(p, 10))
+            Arblib.normalise!(p)
+            @test iszero(Arblib.ref(p, 10))
+            Arblib.ref(p, 10)[] = 1
+            @test iszero(p[10]) # Length not updated
+            Arblib.set_length!(p, 11)
+            @test isone(p[10]) # Length updated
+
+            q = zero(TPoly)
+            Arblib.fit_length!(q, 5)
+            @test all(iszero(Arblib.ref(q, i)) for i = 0:4)
+            @test_throws BoundsError Arblib.ref(q, 5)
+        end
     end
 
     @testset "Constructors" begin

--- a/test/series.jl
+++ b/test/series.jl
@@ -46,14 +46,29 @@
         @test_throws BoundsError p[-1]
         @test_throws BoundsError p[11]
 
-        p = TSeries(T[i for i = 0:10])
-        @test all(Arblib.ref(p, i) == p[i] for i = 0:10)
+        @testset "ref" begin
+            p = TSeries(T[i for i = 0:10])
+            @test all(Arblib.ref(p, i) == p[i] for i = 0:10)
 
-        Arblib.set!(Arblib.ref(p, 0), 5)
-        @test p[0] == 5
+            Arblib.set!(Arblib.ref(p, 0), 5)
+            @test p[0] == 5
 
-        @test_throws BoundsError Arblib.ref(p, -1)
-        @test_throws BoundsError Arblib.ref(p, 11)
+            @test_throws BoundsError Arblib.ref(p, -1)
+            @test_throws BoundsError Arblib.ref(p, 11)
+
+            # Change the degree and check that we can still access
+            Arblib.zero!(Arblib.ref(p, 10))
+            Arblib.normalise!(p)
+            @test iszero(Arblib.ref(p, 10))
+            Arblib.ref(p, 10)[] = 1
+            @test iszero(p[10]) # Length not updated
+            Arblib.set_length!(p, 11)
+            @test isone(p[10]) # Length updated
+
+            q = TSeries(degree = 4)
+            @test all(iszero(Arblib.ref(q, i)) for i = 0:4)
+            @test_throws BoundsError Arblib.ref(q, 5)
+        end
     end
 
     @testset "Constructors" begin


### PR DESCRIPTION
This adds three new methods (plus some variants of them).
- `midpoint` for `Acb` types. It either returns `Compex{Arf}`, `Compex{Arb}` or `Acb`
- `Arblib.union` for polynomials and series
- `Arblib.intersection` for real polynomials and series. I have also removed `Acb` from the documentation of `Arblib.intersection` since that was not actually supported.
It took me some time to get the implementations for polynomials to correctly cover all cases.

For implementing the polynomial methods I also changed `Arblib.ref` to allow for accessing all allocated coefficients of a polynomial, instead of only up to the degree.