### PR TITLE
Release 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "0.8.1"
+version = "1.0"
 
 [deps]
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,12 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Documenter = "1"
 FLINT_jll = "~300.0.0"
-SpecialFunctions = "1.0, 2"
+Random = "1.6"
+Serialization = "1.6"
+SpecialFunctions = "1, 2"
+Test = "1.6"
 julia = "1.6"
 
 [targets]

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ This package is a thin, efficient wrapper around
 [Arb](http://arblib.org) - a C library for arbitrary-precision ball
 arithmetic. Since 2023 Arb is part of [Flint](https://flintlib.org/).
 
-The package is currently in early development. More features and
-documentation will be added. While we try to avoid it there might be
-breaking changes.
-
 ## Installation
 
 ```julia

--- a/src/types.jl
+++ b/src/types.jl
@@ -96,9 +96,6 @@ end
 
 """
     ArbSeries <: Number
-
-This type should be considered experimental, the interface for it
-might change in the future.
 """
 struct ArbSeries <: Number
     poly::ArbPoly
@@ -120,9 +117,6 @@ end
 
 """
     AcbSeries <: Number
-
-This type should be considered experimental, the interface for it
-might change in the future.
 """
 struct AcbSeries <: Number
     poly::AcbPoly


### PR DESCRIPTION
Except for one minor thing, see below, I think we are now ready for a 1.0 release. Everything I mention in #165 has been taken care of. This PR contains three changes
- Update the [compat requirements for standard libraries](https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958)
- Remove some comments about early development in documentation
- Set the version to 1.0

The one remaining thing I had in mind was if we should add a doi identifier for the repository, using e.g. [Zenodo](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content). I have not done this before and I don't know exactly how to think about this. So far I have mentioned Arblib.jl in three separate publications and it seems like it would make sense to have a doi link combined with proper archiving. Do you have any thoughts about this?

Also, do you have anything else you think we should handle before 1.0?

Once we do a release I thought I would send an email about it on the Flint email list and possibly also a post at the Julia discourse. 

Sorry for keeping you so busy 😅