### PR TITLE
Remove the non-existing rounding mode ArbRoundExact

### DIFF
--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -19,7 +19,6 @@ ARF_RND_UP     (1)
     ArbRoundDown, # ARF_RND_FLOOR
     ArbRoundUp, # ARF_RND_CEIL
     ArbRoundNearest, # ARF_RND_NEAR
-    ArbRoundExact # ARF_PREC_EXACT
 )
 
 Base.convert(::Type{arb_rnd}, ::RoundingMode{:ToZero}) = ArbRoundToZero
@@ -27,7 +26,6 @@ Base.convert(::Type{arb_rnd}, ::RoundingMode{:FromZero}) = ArbRoundFromZero
 Base.convert(::Type{arb_rnd}, ::RoundingMode{:Down}) = ArbRoundDown
 Base.convert(::Type{arb_rnd}, ::RoundingMode{:Up}) = ArbRoundUp
 Base.convert(::Type{arb_rnd}, ::RoundingMode{:Nearest}) = ArbRoundNearest
-Base.convert(::Type{arb_rnd}, ::RoundingMode{:Exact}) = ArbRoundExact
 
 function Base.convert(::Type{RoundingMode}, r::arb_rnd)
     if r == ArbRoundToZero
@@ -40,8 +38,6 @@ function Base.convert(::Type{RoundingMode}, r::arb_rnd)
         return RoundUp
     elseif r == ArbRoundNearest
         return RoundNearest
-    elseif r == ArbRoundExact
-        return RoundingMode{:Exact}()
     else
         throw(ArgumentError("invalid Arb rounding mode code: $r"))
     end

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -4,12 +4,10 @@
     @test convert(Arblib.arb_rnd, RoundDown) == Arblib.ArbRoundDown
     @test convert(Arblib.arb_rnd, RoundUp) == Arblib.ArbRoundUp
     @test convert(Arblib.arb_rnd, RoundNearest) == Arblib.ArbRoundNearest
-    @test convert(Arblib.arb_rnd, RoundingMode{:Exact}()) == Arblib.ArbRoundExact
 
     @test convert(RoundingMode, Arblib.ArbRoundToZero) == RoundToZero
     @test convert(RoundingMode, Arblib.ArbRoundFromZero) == RoundFromZero
     @test convert(RoundingMode, Arblib.ArbRoundDown) == RoundDown
     @test convert(RoundingMode, Arblib.ArbRoundUp) == RoundUp
     @test convert(RoundingMode, Arblib.ArbRoundNearest) == RoundNearest
-    @test convert(RoundingMode, Arblib.ArbRoundExact) == RoundingMode{:Exact}()
 end


### PR DESCRIPTION
It doesn't actually exist in Flint, and was probably a misread of [ARF_PREC_EXACT](https://flintlib.org/doc/arf.html#c.ARF_PREC_EXACT).