### PR TITLE
Add Aqua tests and fix unbound type parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+Aqua = "0.8"
 Documenter = "1"
 FLINT_jll = "~300.100.100"
 LinearAlgebra = "1.6"
@@ -21,8 +22,9 @@ Test = "1.6"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "Test"]
+test = ["Aqua", "Documenter", "Test"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10081694.svg)](https://doi.org/10.5281/zenodo.10081694)
 [![ci](https://github.com/kalmarek/Arblib.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/kalmarek/Arblib.jl/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/kalmarek/Arblib.jl/graph/badge.svg?token=i1YYEc2Vht)](https://codecov.io/gh/kalmarek/Arblib.jl)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 This package is a thin, efficient wrapper around
 [Arb](http://arblib.org) - a C library for arbitrary-precision ball

--- a/src/multi-argument.jl
+++ b/src/multi-argument.jl
@@ -30,7 +30,7 @@ for (jf, af) in [(:+, :add!), (:*, :mul!), (:min, :min!), (:max, :max!)]
 end
 
 for T in (ArfOrRef, ArbOrRef, AcbOrRef, ArbPoly, AcbPoly)
-    @eval @inline _precision(x::$T, y::$T, z::$T, rest::Vararg{S}) where {S<:$T} =
+    @eval @inline _precision(x::$T, y::$T, z::$T, rest::Vararg{$T}) =
         max(precision(x), _precision(y, z, rest...))
 
     for (jf, af) in [(:+, :add!), (:*, :mul!), (:min, :min!), (:max, :max!)]
@@ -68,9 +68,9 @@ for T in (ArfOrRef, ArbOrRef, AcbOrRef, ArbPoly, AcbPoly)
 end
 
 for T in (ArbSeries, AcbSeries)
-    @eval @inline _precision(x::$T, y::$T, z::$T, rest::Vararg{S}) where {S<:$T} =
+    @eval @inline _precision(x::$T, y::$T, z::$T, rest::Vararg{$T}) =
         max(precision(x), _precision(y, z, rest...))
-    @eval @inline _degree(x::$T, y::$T, z::$T, rest::Vararg{S}) where {S<:$T} =
+    @eval @inline _degree(x::$T, y::$T, z::$T, rest::Vararg{$T}) =
         min(degree(x), _degree(y, z, rest...))
 
     for (jf, af) in [(:+, :add_series!), (:*, :mullow!)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,13 @@ ENV["NEMO_THREADED"] = 1
 using Arblib, Test, LinearAlgebra, Random, Serialization, SpecialFunctions
 using Documenter
 
+import Aqua
+
 DocMeta.setdocmeta!(Arblib, :DocTestSetup, :(using Arblib); recursive = true)
 
 @testset "Arblib" begin
     doctest(Arblib)
+    Aqua.test_all(Arblib; ambiguities = (; broken = true))
 
     include("ArbCall/runtests.jl")
 


### PR DESCRIPTION
The PR adds [Aqua tests](https://juliatesting.github.io/Aqua.jl/dev/). On master, both the tests for method ambiguities and for unbound type parameters are broken. I fixed the unbound type parameters in this PR but the method ambiguity issues are not resolved.