### PR TITLE
Fix `setprecision` errors on Julia nightly

### DIFF
--- a/src/precision.jl
+++ b/src/precision.jl
@@ -93,7 +93,12 @@ end
 # defined only for `Type{BigFloat}`
 # Ref: https://github.com/JuliaLang/julia/pull/51362
 if VERSION >= v"1.12.0-DEV.78"
-    function Base.setprecision(f::Function, ::Type{T}, prec::Integer; kws...) where {T<:ArbTypes}
+    function Base.setprecision(
+        f::Function,
+        ::Type{T},
+        prec::Integer;
+        kws...,
+    ) where {T<:ArbTypes}
         old_prec = Base.precision(T)
         Base.setprecision(T, prec; kws...)
         try


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/51362 (which switched to ScopeValue for MPFR precision and rounding which, however, seems to cause performance regressions; see also #171) of restricted `Base.setprecision(f::Function, ::Type, ::Integer; kwargs...)` to `Type{BigFloat}` which broke tests of Arblib on Julia nightly. The PR copies the implementation for `ArbTypes`.