### PR TITLE
Fix codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,4 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,5 @@ jobs:
           file: ./lcov.info
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
#188 broke codecov integration: Version 4  of the action does not support tokenless iploads anymore. Thus currently codecov uploads will always fail, see eg https://github.com/kalmarek/Arblib.jl/actions/runs/8724232667/job/23934347761#step:8:34. This error was masked by the `fail_ci_if_error: false`, so you might want to consider changing it to `true` (at the cost of spurious test failures sometimes since codecov servers are not completely reliable in my experience).

To fix codecov integration, in addition to this PR you have to go to the codecov webpage, navigate to the settings for this repo, and copy the token shown there to a Github repo secret named `CODECOV_TOKEN`.