### PR TITLE
Fix ambiguities

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -6,18 +6,22 @@ Mag(x) = set!(Mag(), x)
 # later.
 Mag(x::Union{MagRef,ArfRef}) = Mag(cstruct(x))
 Mag(x, y) = set!(Mag(), x, y)
+# disambiguation
+Mag(x::Complex) = set!(Mag(), x)
 
 # Arf
 Arf(x; prec::Integer = _precision(x)) = set!(Arf(; prec), x)
 # disambiguation
 Arf(x::Arf; prec::Integer = precision(x)) = set!(Arf(; prec), x)
 Arf(x::Rational; prec::Integer = _precision(x)) = set!(Arf(; prec), x)
+Arf(x::Complex; prec::Integer = _precision(x)) = set!(Arf(; prec), x)
 
 #Arb
 Arb(x; prec::Integer = _precision(x)) = set!(Arb(; prec), x)
 # disambiguation
 Arb(x::Arb; prec::Integer = precision(x)) = set!(Arb(; prec), x)
 Arb(x::Rational; prec::Integer = _precision(x)) = set!(Arb(; prec), x)
+Arb(x::Complex; prec::Integer = _precision(x)) = set!(Arb(; prec), x)
 
 function Arb(str::AbstractString; prec::Integer = DEFAULT_PRECISION[])
     res = Arb(; prec)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -65,6 +65,6 @@ Base._fast(::typeof(min), x::AbstractFloat, y::ArbOrRef) = min(x, y)
 Base._fast(::typeof(max), x::ArbOrRef, y::AbstractFloat) = max(x, y)
 Base._fast(::typeof(max), x::AbstractFloat, y::ArbOrRef) = max(x, y)
 
-# Mag, Arf and Arb don't have signed zeros
-Base.isbadzero(::typeof(min), x::Union{Mag,Arf,Arb}) = false
-Base.isbadzero(::typeof(max), x::Union{Mag,Arf,Arb}) = false
+# Arf and Arb don't have signed zeros
+Base.isbadzero(::typeof(min), x::Union{ArfOrRef,ArbOrRef}) = false
+Base.isbadzero(::typeof(max), x::Union{ArfOrRef,ArbOrRef}) = false

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -53,12 +53,17 @@ end
 # doesn't solve the full problem.
 
 # The default implementation in Base is not correct for Arb
-Base._fast(::typeof(min), x::Arb, y::Arb) = min(x, y)
-Base._fast(::typeof(min), x::Arb, y) = min(x, y)
-Base._fast(::typeof(min), x, y::Arb) = min(x, y)
-Base._fast(::typeof(max), x::Arb, y::Arb) = max(x, y)
-Base._fast(::typeof(max), x::Arb, y) = max(x, y)
-Base._fast(::typeof(max), x, y::Arb) = max(x, y)
+Base._fast(::typeof(min), x::ArbOrRef, y::ArbOrRef) = min(x, y)
+Base._fast(::typeof(min), x::ArbOrRef, y) = min(x, y)
+Base._fast(::typeof(min), x, y::ArbOrRef) = min(x, y)
+Base._fast(::typeof(max), x::ArbOrRef, y::ArbOrRef) = max(x, y)
+Base._fast(::typeof(max), x::ArbOrRef, y) = max(x, y)
+Base._fast(::typeof(max), x, y::ArbOrRef) = max(x, y)
+# Handle ambiguous methods
+Base._fast(::typeof(min), x::ArbOrRef, y::AbstractFloat) = min(x, y)
+Base._fast(::typeof(min), x::AbstractFloat, y::ArbOrRef) = min(x, y)
+Base._fast(::typeof(max), x::ArbOrRef, y::AbstractFloat) = max(x, y)
+Base._fast(::typeof(max), x::AbstractFloat, y::ArbOrRef) = max(x, y)
 
 # Mag, Arf and Arb don't have signed zeros
 Base.isbadzero(::typeof(min), x::Union{Mag,Arf,Arb}) = false

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -678,6 +678,8 @@ Base.:^(p::ArbSeries, e::Integer) = pow_arb_series!(zero(p), p, convert(Arb, e),
 Base.:^(p::AcbSeries, e::Integer) = pow_acb_series!(zero(p), p, convert(Acb, e), length(p))
 Base.:^(p::ArbSeries, e::Rational) = pow_arb_series!(zero(p), p, convert(Arb, e), length(p))
 Base.:^(p::AcbSeries, e::Rational) = pow_acb_series!(zero(p), p, convert(Acb, e), length(p))
+Base.:^(::Irrational{:ℯ}, e::ArbSeries) = exp(e)
+Base.:^(::Irrational{:ℯ}, e::AcbSeries) = exp(e)
 
 ##
 ## Series methods

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -652,6 +652,16 @@ function Base.:^(p::AcbSeries, q::AcbSeries)
     deg = _degree(p, q)
     return pow_series!(AcbSeries(degree = deg, prec = _precision(p, q)), p, q, deg + 1)
 end
+function Base.:^(p::ArbSeries, q::AcbSeries)
+    deg = _degree(p, q)
+    res = AcbSeries(p, degree = deg, prec = _precision(p, q))
+    return pow_series!(res, res, q, deg + 1)
+end
+function Base.:^(p::AcbSeries, q::ArbSeries)
+    deg = _degree(p, q)
+    res = AcbSeries(q, degree = deg, prec = _precision(p, q))
+    return pow_series!(res, p, res, deg + 1)
+end
 
 Base.:^(p::ArbSeries, e::Real) = pow_arb_series!(zero(p), p, convert(Arb, e), length(p))
 function Base.:^(p::ArbSeries, e::Number)

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -5,6 +5,8 @@ Base.setindex!(res::Union{MagLike,ArfLike,ArbLike,AcbLike}, x) = set!(res, x)
 set!(res::MagLike, x::Integer) = set!(res, convert(UInt, x))
 set!(res::MagLike, ::Irrational{:π}) = const_pi!(res)
 set!(res::MagLike, x::Integer, y::Integer) = set_ui_2exp!(res, convert(UInt, x), y)
+set!(res::MagLike, x::Complex) =
+    isreal(x) ? set!(res, real(x)) : throw(InexactError(:Mag, Mag, x))
 
 # Arf
 function set!(res::ArfLike, x::UInt128)
@@ -37,6 +39,9 @@ function set!(
     div!(res, res, Arf(denominator(x); prec); prec)
     return res
 end
+
+set!(res::ArfLike, x::Complex) =
+    isreal(x) ? set!(res, real(x)) : throw(InexactError(:Arf, Arf, x))
 
 # Arb
 function set!(res::ArbLike, x::Union{UInt128,Int128,MagLike,BigInt,BigFloat})
@@ -97,6 +102,11 @@ function set!(res::ArbLike, (a, b)::Tuple{<:Real,<:Real}; prec::Integer = precis
     end
     return union!(res, a, b; prec)
 end
+
+set!(res::ArbLike, x::AcbOrRef) =
+    is_real(x) ? set!(res, realref(x)) : throw(InexactError(:Arb, Arb, x))
+set!(res::ArbLike, x::Complex) =
+    isreal(x) ? set!(res, real(x)) : throw(InexactError(:Arb, Arb, x))
 
 # Acb
 function set!(res::AcbLike, x::Union{Real,MagLike,ArfLike,Tuple{<:Real,<:Real}})

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -6,6 +6,10 @@
         @test Mag(UInt64(1)) == Mag(1) == one(Mag) == one(Mag()) <= Mag(1.0)
         @test π < Float64(Mag(π)) < 3.15
         @test Mag(3, 4) == Mag(3 * 2^4)
+
+        # Check for ambiguities
+        @test Mag(1 + 0im) == Mag(1)
+        @test_throws InexactError Mag(1 + im)
     end
 
     @testset "Arf" begin
@@ -23,6 +27,10 @@
 
         @test precision(zero(Arf(prec = 80))) == 80
         @test precision(one(Arf(prec = 80))) == 80
+
+        # Check for ambiguities
+        @test Arf(1 + 0im) == 1
+        @test_throws InexactError Arf(1 + im)
     end
 
     @testset "Arb" begin
@@ -58,6 +66,10 @@
         @test precision(Arb(MathConstants.catalan, prec = 80)) == 80
         @test precision(Arb(MathConstants.φ, prec = 80)) == 80
 
+        @test Arb(Acb(1)) == 1
+        @test precision(Arb(Acb(1, prec = 80))) == 80
+        @test_throws InexactError Arb(Acb(1, 1))
+
         # setball
         @test isone(Arblib.setball(Arb, Arf(1), Mag(0)))
         @test isone(Arblib.setball(Arb, 1, 0))
@@ -71,6 +83,10 @@
 
         @test precision(Arblib.setball(Arb, Arf(prec = 80), 0)) == 80
         @test precision(Arblib.setball(Arb, Arf(prec = 90), 0, prec = 80)) == 80
+
+        # Check for ambiguities
+        @test Arb(1 + 0im) == 1
+        @test_throws InexactError Arb(1 + im)
     end
 
     @testset "Acb" begin

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -61,8 +61,7 @@
         @test iszero(extrema(identity, -A)[2])
 
         # Fails with default implementation due to Base._fast
-        #A = [Arb(0); [setball(Arb, 0, i) for i in reverse(0:257)]]
-        A = [setball(Arb, 0, i) for i = 0:257]
+        A = [Arb(0); [setball(Arb, 0, i) for i in reverse(0:257)]]
         @test Arblib.contains(minimum(A), -257)
         @test Arblib.contains(maximum(A), 257)
         @test Arblib.contains(extrema(A)[1], -257)
@@ -71,6 +70,25 @@
         @test Arblib.contains(maximum(identity, A), 257)
         @test Arblib.contains(extrema(identity, A)[1], -257)
         @test Arblib.contains(extrema(identity, A)[2], 257)
+        # In a previous version of Arblib, Base._fast was not correctly
+        # overloaded for ArbRef.
+        A = [
+            Arblib.realref(Acb(0))
+            [Arblib.realref(Acb(setball(Arb, 0, i))) for i in reverse(0:257)]
+        ]
+        @test Arblib.contains(minimum(A), -257)
+        @test Arblib.contains(maximum(A), 257)
+        @test Arblib.contains(extrema(A)[1], -257)
+        @test Arblib.contains(extrema(A)[2], 257)
+        @test Arblib.contains(minimum(identity, A), -257)
+        @test Arblib.contains(maximum(identity, A), 257)
+        @test Arblib.contains(extrema(identity, A)[1], -257)
+        @test Arblib.contains(extrema(identity, A)[2], 257)
+        # In a previous version of Arblib, Base._fast was not correctly
+        # handling mixture of Arb and AbstractFloat
+        @test minimum(AbstractFloat[Arb(0); fill(1.0, 257)]) == 0
+        @test maximum(AbstractFloat[Arb(0); fill(1.0, 257)]) == 1
+        @test extrema(AbstractFloat[Arb(0); fill(1.0, 257)]) == (0, 1)
 
         # Fails with default implementation due to both short circuit
         # and Base._fast

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -110,17 +110,29 @@
         @test !Base.isbadzero(min, zero(Mag))
         @test !Base.isbadzero(min, zero(Arf))
         @test !Base.isbadzero(min, zero(Arb))
+        @test !Base.isbadzero(min, Arblib.radref(zero(Arb)))
+        @test !Base.isbadzero(min, Arblib.midref(zero(Arb)))
+        @test !Base.isbadzero(min, Arblib.realref(zero(Acb)))
 
         @test !Base.isbadzero(max, zero(Mag))
         @test !Base.isbadzero(max, zero(Arf))
         @test !Base.isbadzero(max, zero(Arb))
+        @test !Base.isbadzero(max, Arblib.radref(zero(Arb)))
+        @test !Base.isbadzero(max, Arblib.midref(zero(Arb)))
+        @test !Base.isbadzero(max, Arblib.realref(zero(Acb)))
 
         @test !Base.isgoodzero(min, zero(Mag))
         @test !Base.isgoodzero(min, zero(Arf))
         @test !Base.isgoodzero(min, zero(Arb))
+        @test !Base.isgoodzero(min, Arblib.radref(zero(Arb)))
+        @test !Base.isgoodzero(min, Arblib.midref(zero(Arb)))
+        @test !Base.isgoodzero(min, Arblib.realref(zero(Acb)))
 
         @test !Base.isgoodzero(max, zero(Mag))
         @test !Base.isgoodzero(max, zero(Arf))
         @test !Base.isgoodzero(max, zero(Arb))
+        @test !Base.isgoodzero(max, Arblib.radref(zero(Arb)))
+        @test !Base.isgoodzero(max, Arblib.midref(zero(Arb)))
+        @test !Base.isgoodzero(max, Arblib.realref(zero(Acb)))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,23 @@ DocMeta.setdocmeta!(Arblib, :DocTestSetup, :(using Arblib); recursive = true)
 
 @testset "Arblib" begin
     doctest(Arblib)
-    Aqua.test_all(Arblib; ambiguities = (; broken = true))
+    # Some methods are excluded from the check for ambiguities. There
+    # are two reasons for these exclusions, methods in Base we don't
+    # care about and false positives from Aqua.
+
+    # The methods in Base that we don't care about are construction
+    # from AbstractChar or Base.TwicePrecision. Both of these have
+    # default constructors for Number types that clash with our catch
+    # all constructors. They do not seem important enough to warrant
+    # extra code for handling them.
+
+    # One set of false positives are for Arf(::Rational) and
+    # Arb(::Rational). The other set is for + and * with mix of
+    # ArbSeries and AcbSeries.
+    Aqua.test_all(
+        Arblib,
+        ambiguities = (exclude = [Mag, Arf, Arb, Acb, ArbSeries, AcbSeries, +, *],),
+    )
 
     include("ArbCall/runtests.jl")
 

--- a/test/series.jl
+++ b/test/series.jl
@@ -306,7 +306,7 @@
         p = TSeries([1, 2, 3])
         q = TSeries([2, 3, 0])
 
-        @test p^q == TSeries([1, 4, 16])
+        @test p^q == ArbSeries([1, 2, 3])^q == p^ArbSeries([2, 3, 0]) == TSeries([1, 4, 16])
 
         @test p^T(2) ==
               p^Int(2) ==

--- a/test/series.jl
+++ b/test/series.jl
@@ -322,6 +322,8 @@
         @test 2^TSeries([1, 0]) == TSeries([2, 0])
         @test (2 + im)^TSeries([1, 0]) == AcbSeries([2 + im, 0])
 
+        @test isequal(ℯ^p, exp(p))
+
         @test precision(setprecision(p, 80)^setprecision(q, 90)) == 90
         @test precision(setprecision(p, 80)^T(2)) == 80
     end

--- a/test/setters.jl
+++ b/test/setters.jl
@@ -8,6 +8,10 @@
 
         # Integer times power of 2
         @test Arblib.set!(T(), 3, 4) == Arblib.set!(T(), 3 * 2^4)
+
+        # Complex
+        @test Arblib.set!(T(), 1 + 0im) == Mag(1)
+        @test_throws InexactError Arblib.set!(T(), 1 + 1im)
     end
 
     @testset "$name" for (name, T) in [("Arf", Arf), ("ArfRef", () -> Arblib.midref(Arb()))]
@@ -35,6 +39,10 @@
             @test Arblib.set!(T(), 1 // BigInt(x)) == inv(Arf(x))
             @test Arblib.set!(T(), BigInt(x) // (BigInt(x) + 1)) == Arf(x) / Arf(x + 1)
         end
+
+        # Complex
+        @test Arblib.set!(T(), 1 + 0im) == 1
+        @test_throws InexactError Arblib.set!(T(), 1 + 1im)
     end
 
     @testset "$name" for (name, T) in
@@ -146,6 +154,12 @@
         @test_throws ArgumentError Arblib.set!(T(), (2, 1))
         @test_throws ArgumentError Arblib.set!(T(), (2.0, 1.0))
         @test_throws ArgumentError Arblib.set!(T(), (2, 1.0))
+
+        # Complex
+        @test Arblib.set!(T(), Acb(1, 0)) == 1
+        @test_throws InexactError Arblib.set!(T(), Acb(1, 1))
+        @test Arblib.set!(T(), 1 + 0im) == 1
+        @test_throws InexactError Arblib.set!(T(), 1 + 1im)
     end
 
     @testset "$name" for (name, T) in [


### PR DESCRIPTION
The goal of this PR is to fix all the ambiguities reported by Aqua, see #186. It is not fully finished, there are still some ambiguities left to handle, hence the tests currently fails.

The remaining ones to handle are:

- (::Type{T})(z::Complex) where T<:Real (3 ambiguities)
- (::Type{T})(x::Rational{S}) where {S, T<:AbstractFloat} (2 ambiguities)
- + and * for ArbSeries and AcbSeries (2 ambiguities)

For the ones related to `Complex` it should be straight forward to add, I just didn't have the time to finish it yet. I will probably add similar methods for `Acb` in that case as well.

For the other ones I have, as mentioned in #186, not been able to trigger them. The reported issues are
```
Ambiguity #1
*(p::Union{Arblib.AcbPoly, Arblib.AcbSeries}, c::Number) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/poly.jl:481
*(c::Number, p::Union{Arblib.AcbPoly, Arblib.AcbSeries, Arblib.ArbPoly, Arblib.ArbSeries}) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/poly.jl:533

Possible fix, define
  *(::Arblib.AcbSeries, ::Union{Arblib.AcbSeries, Arblib.ArbSeries})

Ambiguity #2
+(p::Union{Arblib.AcbPoly, Arblib.AcbSeries}, c::Number) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/poly.jl:455
+(c::Number, p::Union{Arblib.AcbPoly, Arblib.AcbSeries, Arblib.ArbPoly, Arblib.ArbSeries}) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/poly.jl:532

Possible fix, define
  +(::Arblib.AcbSeries, ::Union{Arblib.AcbSeries, Arblib.ArbSeries})

Ambiguity #3
Arblib.Arb(x; prec) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/constructors.jl:22
(::Type{T})(x::Rational{S}) where {S, T<:AbstractFloat} @ Base rational.jl:133

Possible fix, define
  Arblib.Arb(::Rational{S}) where S

Ambiguity #5
Arblib.Arf(x; prec) @ Arblib ~/Syncthing/Work/Code/Arblib.jl/src/constructors.jl:14
(::Type{T})(x::Rational{S}) where {S, T<:AbstractFloat} @ Base rational.jl:133

Possible fix, define
  Arblib.Arf(::Rational{S}) where S
```

But everything seems to work fine
```julia
#1
AcbSeries() * AcbSeries()
AcbSeries() * ArbSeries()

#2
AcbSeries() + AcbSeries()
AcbSeries() + ArbSeries()

#3
Arb(1 // 2)
Arb(Rational{Int32}(1, 2))

#4
Arf(1 // 2)
Arf(Rational{Int32}(1, 2))
```
Am I missing something here?