### PR TITLE
Fix some edge cases in `string` and `show` for `Arb` and `Acb`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -6,14 +6,14 @@ function _remove_trailing_zeros(str::AbstractString)
             # Numbers on the form xxx.yyy0ezzz
             mantissa, exponent = split(str, 'e', limit = 2)
             mantissa = rstrip(mantissa, '0')
-            if endswith(mantissa, '.')
+            if endswith(mantissa, '.') || endswith(mantissa, '}')
                 mantissa *= '0'
             end
             str = mantissa * 'e' * exponent
         else
             # Numbers on the form xxx.yyy0
             str = rstrip(str, '0')
-            if endswith(str, '.')
+            if endswith(str, '.') || endswith(str, '}')
                 str *= '0'
             end
         end
@@ -129,7 +129,20 @@ end
 
 function Base.show(io::IO, x::Union{ArbOrRef,AcbOrRef})
     if Base.get(io, :compact, false) && rel_accuracy_bits(x) > 48
-        print(io, string(x, condense = 2, unicode = true))
+        str = string(x, condense = 2, unicode = true)
+        if isexact(x)
+            # For exact values the shortest output is in some cases
+            # not given by condensing the decimal digits, but by
+            # removing trailing zeros. We try both options and take
+            # the shortest.
+
+            str_alt = string(x)
+
+            if length(str_alt) < length(str)
+                str = str_alt
+            end
+        end
+        print(io, str)
     else
         print(io, string(x))
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -30,6 +30,7 @@
               "1.000000000000000000"
         @test string(Arb(1), digits = 2, remove_trailing_zeros = false) == "1.0"
         @test string(Arb(1), digits = 12, remove_trailing_zeros = false) == "1.00000000000"
+        @test string(Arb(1), condense = 2) == "1.00{...72 digits...}0"
         @test string(Arb(10)^100) == "1.0e+100"
         @test string(Arb(10)^100, remove_trailing_zeros = false) ==
               "1.0000000000000000000000000000000000000000000000000000000000000000000000000000e+100"
@@ -90,10 +91,20 @@
     @testset "show" begin
         @test repr(Mag(1), context = IOContext(stdout, :compact => true)) == "1.0"
         @test repr(Arf(1), context = IOContext(stdout, :compact => true)) == "1.0"
+        @test repr(Arb(1), context = IOContext(stdout, :compact => true)) == "1.0"
+        @test repr(Acb(1, 1), context = IOContext(stdout, :compact => true)) ==
+              "1.0 + 1.0im"
+
         @test repr(Arb(π), context = IOContext(stdout, :compact => true)) ==
               "[3.14{…72 digits…}62 ± 1.93e-77]"
         @test repr(Acb(π, ℯ), context = IOContext(stdout, :compact => true)) ==
               "[3.14{…72 digits…}62 ± 1.93e-77] + [2.71{…72 digits…}35 ± 5.46e-77]im"
+        @test repr(Arb(Float64(π)), context = IOContext(stdout, :compact => true)) ==
+              "3.14{…72 digits…}0"
+        @test repr(
+            Acb(Float64(π), Float64(ℯ)),
+            context = IOContext(stdout, :compact => true),
+        ) == "3.14{…72 digits…}0 + 2.71{…72 digits…}0im"
 
         prec = 32
 


### PR DESCRIPTION
For `compact` output it uses the `condense` option for the string representation. This gives a shorted output in general, but not in all cases. For some exact input, such as integers, you get a much more compact output by not condensing the output and instead just removing the trailing zeros. It is not always clear which option is better however, so now it just computes both and takes the shortest.

With this change the matrix `Arb[1 1]` is now displayed as
```
1×2 Matrix{Arb}:
 1.0  1.0
```
instead of as
```
1×2 Matrix{Arb}:
 1.00{…72 digits…}  1.00{…72 digits…}
```