### PR TITLE
Improve low level interface for series

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 

--- a/docs/src/interface-mutable.md
+++ b/docs/src/interface-mutable.md
@@ -1,6 +1,10 @@
 # Mutable arithmetic
 The high level interface can be combined with the low level wrapper to
-allow for efficient computations using mutable arithmetic.
+allow for efficient computations using mutable arithmetic. Making use
+of mutable arithmetic can in some cases have a significant impact on
+the performance of the code, in particular for multithreaded code
+(where avoiding to run the GC is generally more important) and code
+running many iterations of simple computations.
 
 In the future it would be nice to have an interface to
 [MutableArithmetics.jl](https://github.com/jump-dev/MutableArithmetics.jl),
@@ -38,6 +42,14 @@ end
 @benchmark f($x, $y) samples=10000 evals=500
 @benchmark f!($res, $x, $y) samples=10000 evals=500
 ```
+
+!!! warning "Aliasing between input and output"
+    This implementation of the function `f!` doesn't handle aliasing
+    between `res` and `x`. Most cases of aliasing between two
+    variables can be checked for with `===` (so `res === x` in this
+    case). Using `===` does however not catch all possible cases of
+    aliasing, for example it would not catch the aliasing between
+    `Arblib.realref(z)` and `Arblib.realref(z, prec = 2precision(z))`.
 
 Set the radius of the real part of an `Acb`.
 
@@ -83,3 +95,30 @@ end
 @benchmark eval!($res, $p, $x) samples = 10000 evals = 30
 @benchmark $p($x) samples = 10000 evals = 30 # Arb implementation for reference
 ```
+
+### Mutable arithmetic handling both `Arb/Acb` and `ArbSeries/AcbSeries`
+Since `Arblib.jl` version `1.3.0` adjustments have been made to the
+low level wrapper to make it easier to write code using mutable
+arithmetic that can handle both the scalar types `Arb` and `Acb` as
+well as the series types `ArbSeries` and `AcbSeries`. For example the
+following implementation of `sin(atan(x) / x)` can support all of
+these types.
+
+``` @repl
+using Arblib
+
+function f!(res, x)
+    Arblib.atan!(res, x)
+    Arblib.div!(res, res, x)
+    Arblib.sin!(res, res)
+    return res
+end
+
+f!(Arb(prec = 53), Arb(2))
+f!(Acb(prec = 53), Acb(2, 3))
+f!(ArbSeries(degree = 2, prec = 53), ArbSeries((2, 1)))
+f!(AcbSeries(degree = 2, prec = 53), AcbSeries((2 + 3im, 1)))
+```
+
+To make this possible there is special handling of the series
+functions in Arb, see [Series methods](@ref) for more details.

--- a/docs/src/wrapper-methods.md
+++ b/docs/src/wrapper-methods.md
@@ -102,6 +102,7 @@ For example Arb declares the following functions
 9. `void arb_cos(arb_t c, const arb_t x, slong prec)`
 10. `void arb_sin_cos(arb_t s, arb_t c, const arb_t x, slong prec)`
 11. `int arf_add(arf_t res, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)`
+12. `void arb_poly_sin_series(arb_poly_t s, const arb_poly_t h, slong n, slong prec)`
 
 For which the following methods are generated
 
@@ -116,3 +117,21 @@ For which the following methods are generated
 9. `cos!(c::ArbLike, x::ArbLike; prec::Integer = _precision(c))::ArbLike`
 10. `sin_cos!(s::ArbLike, c::ArbLike, x::ArbLike, prec::Integer = _precision(s))::ArbLike`
 11. `add!(res::ArfLike, x::ArfLike, y::ArfLike; prec::Integer = _precision(res), rnd::Union{Arblib.arb_rnd, RoundingMode} = RoundNearest)::Int32`
+12. `sin_series!(s::ArbPolyLike, h::ArbPolyLike, n::Integer; prec::Integer = _precision(s))::ArbPolyLike`
+
+### Series methods
+Arb has several functions mean for computing truncated Taylor series
+(e.g. `arb_sin_series`). These functions have special handling, to
+make them more convenient to use. In addition to the procedure
+discussed above they generate one more method. This extra method
+removes the "_series" suffix from the method name, restricts the input
+type to only series types (and not polynomial types) and takes the
+default length of the computed series from the first argument. As an
+example the function
+- `void arb_poly_sin_series(arb_poly_t s, const arb_poly_t h, slong n, slong prec)`
+generates the method
+- `sin!(s::ArbSeries, h::ArbSeries, n::Integer = length(s); prec::Integer = _precision(s))::ArbSeries`
+in addition to the usual one (see the examples above).
+
+The main motivation for these extra methods is to make it easier to
+write generic code using mutability, see [Mutable arithmetic](@ref).

--- a/src/ArbCall/ArbFunction.jl
+++ b/src/ArbCall/ArbFunction.jl
@@ -59,6 +59,10 @@ function ispredicate(af::ArbFunction)
     return jlname_starts || jlname_contains || jlname_eq
 end
 
+is_series_method(af::ArbFunction) =
+    endswith(arbfname(af), "_series") &&
+    (jltype(first(arguments(af))) <: Union{Arblib.ArbPolyLike,Arblib.AcbPolyLike})
+
 const jlfname_prefixes = (
     "arf",
     "arb",
@@ -75,9 +79,9 @@ const jlfname_prefixes = (
 const jlfname_suffixes = ("si", "ui", "d", "mag", "arf", "arb", "acb", "mpz", "mpfr", "str")
 
 function jlfname(
-    arbfname::AbstractString,
+    arbfname::AbstractString;
     prefixes = jlfname_prefixes,
-    suffixes = jlfname_suffixes;
+    suffixes = jlfname_suffixes,
     inplace = false,
 )
     strs = filter(!isempty, split(arbfname, "_"))
@@ -88,11 +92,11 @@ function jlfname(
 end
 
 jlfname(
-    af::ArbFunction,
+    af::ArbFunction;
     prefixes = jlfname_prefixes,
-    suffixes = jlfname_suffixes;
+    suffixes = jlfname_suffixes,
     inplace = inplace(af),
-) = jlfname(arbfname(af), prefixes, suffixes; inplace)
+) = jlfname(arbfname(af); prefixes, suffixes, inplace)
 
 function jlargs(af::ArbFunction; argument_detection::Bool = true)
     cargs = arguments(af)
@@ -137,6 +141,38 @@ function jlargs(af::ArbFunction; argument_detection::Bool = true)
 end
 
 """
+    jlargs_series(af::ArbFunction)
+
+Compute `args` and `kwargs` for an Arb function `af` satisfying
+`is_series_method(af)`. The values are similar to those computed by
+[`jlargs`](@ref) with the following adjustements:
+1. The argument giving the length of the result has the default value
+   given by the length of the first argument.
+2. Arguments accepting types `ArbPolyLike` and `AcbPolyLike` are
+   restricted to only accept `ArbSeries` and `AcbSeries` respectively.
+"""
+function jlargs_series(af::ArbFunction)
+    args, kwargs = jlargs(af)
+
+    len_name = args[end].args[1]
+    len_type = args[end].args[2]
+    @assert len_name == :len || len_name == :n || len_name == :trunc
+    @assert len_type == Integer
+    first_name = args[1].args[1]
+    args[end] = Expr(:kw, args[end], :(length($first_name)))
+
+    for arg in args
+        if arg.args[2] == Arblib.ArbPolyLike
+            arg.args[2] = Arblib.ArbSeries
+        elseif arg.args[2] == Arblib.AcbPolyLike
+            arg.args[2] = Arblib.AcbSeries
+        end
+    end
+
+    return args, kwargs
+end
+
+"""
     jlcode(af::ArbFunction, jl_fname = jlfname(af))
 
 Generate the Julia code for calling the Arb function from Julia.
@@ -168,11 +204,30 @@ function jlcode(af::ArbFunction, jl_fname = jlfname(af))
         end
     )
 
+    if is_series_method(af)
+        # Note that this currently doesn't respect any custom function
+        # name given as an argument.
+        jl_fname_series = jlfname(af, suffixes = (jlfname_suffixes..., "series"))
+        jl_args_series, jl_kwargs_series = jlargs_series(af)
+
+        func_series = quote
+            $jl_fname_series($(jl_args_series...); $(jl_kwargs_series...)) =
+                $jl_fname($(name.(cargs)...))
+        end
+
+        code = quote
+            $func_full_args
+            $func_series
+        end
+    else
+        code = func_full_args
+    end
+
     if isempty(jl_kwargs)
-        return func_full_args
+        return code
     else
         return quote
-            $func_full_args
+            $code
             $jl_fname($(jl_args...); $(jl_kwargs...)) = $jl_fname($(name.(cargs)...))
         end
     end

--- a/test/ArbCall/ArbFunction.jl
+++ b/test/ArbCall/ArbFunction.jl
@@ -103,6 +103,35 @@
         end
     end
 
+    @testset "is_series_method" begin
+        for sig in (
+            "void arb_poly_pow_series(arb_poly_t h, const arb_poly_t f, const arb_poly_t g, slong len, slong prec)",
+            "void arb_poly_inv_series(arb_poly_t Q, const arb_poly_t A, slong n, slong prec)",
+            "void arb_poly_add_series(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong len, slong prec)",
+            "void acb_poly_atan_series(acb_poly_t res, const acb_poly_t f, slong n, slong prec)",
+            "void acb_poly_sin_pi_series(acb_poly_t s, const acb_poly_t h, slong n, slong prec)",
+            "void acb_poly_rising_ui_series(acb_poly_t res, const acb_poly_t f, ulong r, slong trunc, slong prec)",
+            "void acb_hypgeom_erf_series(acb_poly_t res, const acb_poly_t z, slong len, slong prec)",
+            "void acb_hypgeom_beta_lower_series(acb_poly_t res, const acb_t a, const acb_t b, const acb_poly_t z, int regularized, slong n, slong prec)",
+        )
+            @test Arblib.ArbCall.is_series_method(Arblib.ArbCall.ArbFunction(sig))
+        end
+
+        for sig in (
+            "void _arb_poly_inv_series(arb_ptr Q, arb_srcptr A, slong Alen, slong len, slong prec)",
+            "void _arb_poly_compose_series(arb_ptr res, arb_srcptr poly1, slong len1, arb_srcptr poly2, slong len2, slong n, slong prec)",
+            "void acb_set_ui(acb_t z, ulong x)",
+            "int acb_mat_lu_recursive(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)",
+            "int acb_mat_lu(slong * perm, acb_mat_t LU, const acb_mat_t A, slong prec)",
+            "int acb_mat_inv(acb_mat_t X, const acb_mat_t A, slong prec)",
+            "int arb_sgn_nonzero(const arb_t x)",
+            "int arf_set_round(arf_t res, const arf_t x, slong prec, arf_rnd_t rnd)",
+            "int arf_cmp(const arf_t x, const arf_t y)",
+        )
+            @test !Arblib.ArbCall.is_series_method(Arblib.ArbCall.ArbFunction(sig))
+        end
+    end
+
     @testset "jlargs" begin
         for (str, args, kwargs, full_args) in (
             (
@@ -167,6 +196,44 @@
                 Arblib.ArbCall.ArbFunction(str),
                 argument_detection = false,
             )
+        end
+    end
+
+    @testset "jlargs_series" begin
+        for (str, args, kwargs) in (
+            (
+                "void arb_poly_atan_series(arb_poly_t res, const arb_poly_t f, slong n, slong prec)",
+                [
+                    :(res::$(Arblib.ArbSeries)),
+                    :(f::$(Arblib.ArbSeries)),
+                    Expr(:kw, :(n::$(Integer)), :(length(res))),
+                ],
+                [Expr(:kw, :(prec::Integer), :(_precision(res)))],
+            ),
+            (
+                "void acb_poly_div_series(acb_poly_t Q, const acb_poly_t A, const acb_poly_t B, slong n, slong prec)",
+                [
+                    :(Q::$(Arblib.AcbSeries)),
+                    :(A::$(Arblib.AcbSeries)),
+                    :(B::$(Arblib.AcbSeries)),
+                    Expr(:kw, :(n::$(Integer)), :(length(Q))),
+                ],
+                [Expr(:kw, :(prec::Integer), :(_precision(Q)))],
+            ),
+            (
+                "void acb_hypgeom_u_1f1_series(acb_poly_t res, const acb_poly_t a, const acb_poly_t b, const acb_poly_t z, slong len, slong prec)",
+                [
+                    :(res::$(Arblib.AcbSeries)),
+                    :(a::$(Arblib.AcbSeries)),
+                    :(b::$(Arblib.AcbSeries)),
+                    :(z::$(Arblib.AcbSeries)),
+                    Expr(:kw, :(len::$(Integer)), :(length(res))),
+                ],
+                [Expr(:kw, :(prec::Integer), :(_precision(res)))],
+            ),
+        )
+            @test (args, kwargs) ==
+                  Arblib.ArbCall.jlargs_series(Arblib.ArbCall.ArbFunction(str))
         end
     end
 

--- a/test/ArbCall/ArbFunction.jl
+++ b/test/ArbCall/ArbFunction.jl
@@ -52,6 +52,19 @@
         end
     end
 
+    @testset "jlfname_series" begin
+        for (arbfname, name) in (
+            ("arb_poly_inv_series", :inv!),
+            ("arb_poly_compose_series", :compose!),
+            ("arb_poly_pow_arb_series", :pow!),
+            # These are special cases
+            ("arb_poly_mullow", :mul!),
+            ("acb_poly_mullow", :mul!),
+        )
+            @test Arblib.ArbCall.jlfname_series(arbfname) == name
+        end
+    end
+
     @testset "returntype" begin
         # Supported return types
         for (str, T) in (
@@ -113,6 +126,9 @@
             "void acb_poly_rising_ui_series(acb_poly_t res, const acb_poly_t f, ulong r, slong trunc, slong prec)",
             "void acb_hypgeom_erf_series(acb_poly_t res, const acb_poly_t z, slong len, slong prec)",
             "void acb_hypgeom_beta_lower_series(acb_poly_t res, const acb_t a, const acb_t b, const acb_poly_t z, int regularized, slong n, slong prec)",
+            # These are special cases
+            "void arb_poly_mullow(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)",
+            "void acb_poly_mullow(acb_poly_t C, const acb_poly_t A, const acb_poly_t B, slong n, slong prec)",
         )
             @test Arblib.ArbCall.is_series_method(Arblib.ArbCall.ArbFunction(sig))
         end
@@ -230,6 +246,16 @@
                     Expr(:kw, :(len::$(Integer)), :(length(res))),
                 ],
                 [Expr(:kw, :(prec::Integer), :(_precision(res)))],
+            ),
+            (
+                "void arb_poly_mullow(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)",
+                [
+                    :(C::$(Arblib.ArbSeries)),
+                    :(A::$(Arblib.ArbSeries)),
+                    :(B::$(Arblib.ArbSeries)),
+                    Expr(:kw, :(n::$(Integer)), :(length(C))),
+                ],
+                [Expr(:kw, :(prec::Integer), :(_precision(C)))],
             ),
         )
             @test (args, kwargs) ==


### PR DESCRIPTION
Flint has a number of functions for computing truncated series expansions, these generally have a name ending in `_series`. This PR adds special handling of the low level wrappers for these functions, something I have wanted for a long time.

In addition to the low level methods that were previously constructed for these functions we now add another method. The new method removes the `_series` suffix from the method name, restricts the input type to only series types (and not polynomial types) and takes the default length of the computed series from the first argument. It also handles `arb_poly_mullow` as a special case, since this is morally the same as the function `arb_poly_mul_series` (same for `acb_poly`).

The main motivation for the new methods is to make it easier to write generic code using mutability. For example now `Arblib.sin!` can be applied to both `Arb` and `ArbSeries`, before one had to use `Arblib.sin!` for `Arb` and `Arblib.sin_series!` for `ArbSeries`. As an example I have in some [old project](https://github.com/Joel-Dahne/HighestCuspedWave.jl/blob/2d6dd92e7a4fe7d995dda6684116224d331730fb/src/BurgersHilbert/evaluation.jl#L559C1-L572C8) code like this
```julia
w!(res::Arb, x::Arb) = begin
    Arblib.inv!(res, x)
    Arblib.add!(res, res, 1)
    Arblib.log!(res, res)
    return Arblib.sqrt!(res, res)
end
w!(res::ArbSeries, x::ArbSeries) = begin
    len = length(x)
    Arblib.inv_series!(res, x, len)
    Arblib.add!(res, res, 1)
    Arblib.log_series!(res, res, len)
    return Arblib.sqrt_series!(res, res, len)
end
```
with this update it would be possible to just do
```julia
w!(res::T, x::T) where {T<:Union{Arb,ArbSeries}} = begin
    Arblib.inv!(res, x)
    Arblib.add!(res, res, 1)
    Arblib.log!(res, res)
    return Arblib.sqrt!(res, res)
end
```

I have added information about all of this to the documentation. In the future we should probably try to expand the section about mutable arithmetic. Quite a lot of the work in Arblib.jl is for making mutable arithmetic convenient, and I think the documentation on how to use this in a good way could be improved. To get the documentation to compile locally I had to add `Arblib` as a dependency to it, not sure what has changed since before (hopefully the build on Github works).