### PR TITLE
Set version to 1.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"


### PR DESCRIPTION
I think this is a reasonable time to release 1.3.0. The `nfloat` wrapping will probably be at least another month, so there is no point in waiting for that. For reference, the new additions since last release are:
- Improvements to low-level series interface #198 
- Wrapping of `Acf` #199
- Update to Fling 3.2.0 #204 