### PR TITLE
Set minimum Julia version to 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Random = "1.6"
 Serialization = "1.6"
 SpecialFunctions = "1, 2"
 Test = "1.6"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -22,35 +22,8 @@ end
 # See https://github.com/JuliaLang/julia/issues/45932.
 # Note that it works fine for Mag and Arf.
 
-# Before 1.8.0 there is no way to fix the implementation in Base.
-# Instead we define a new method. Note that this doesn't fully fix the
-# problem, there is no way to dispatch on for example
-# minimum(x -> Arb(x), [1, 2, 3, 4]) or an array with only some Arb.
-if VERSION < v"1.8.0-rc3"
-    function Base.minimum(A::AbstractArray{<:ArbOrRef})
-        isempty(A) &&
-            throw(ArgumentError("reducing over an empty collection is not allowed"))
-        res = copy(first(A))
-        for x in Iterators.drop(A, 1)
-            Arblib.min!(res, res, x)
-        end
-        return res
-    end
-
-    function Base.maximum(A::AbstractArray{<:ArbOrRef})
-        isempty(A) &&
-            throw(ArgumentError("reducing over an empty collection is not allowed"))
-        res = copy(first(A))
-        for x in Iterators.drop(A, 1)
-            Arblib.max!(res, res, x)
-        end
-        return res
-    end
-end
-
-# Since 1.8.0 it is possible to fix the Base implementation by
-# overloading some internal methods. This also works before 1.8.0 but
-# doesn't solve the full problem.
+# Is is possible to fix the Base implementation by overloading some
+# internal methods.
 
 # The default implementation in Base is not correct for Arb
 Base._fast(::typeof(min), x::ArbOrRef, y::ArbOrRef) = min(x, y)

--- a/src/precision.jl
+++ b/src/precision.jl
@@ -1,9 +1,7 @@
 const DEFAULT_PRECISION = Ref{Int}(256)
 
 let f
-    f = if VERSION < v"1.8.0-DEV.725"
-        :precision
-    elseif VERSION < v"1.11.0-DEV.1363"
+    f = if VERSION < v"1.11.0-DEV.1363"
         # Since Julia 1.8.0 Base.precision calls Base._precision and by
         # overloading that we automatically support giving base argument.
         # Ref: https://github.com/JuliaLang/julia/pull/42428
@@ -30,20 +28,16 @@ let f
     end
 end
 
-if VERSION >= v"1.8.0-DEV.725"
-    # Base.precision only allows AbstractFloat, we want to be able to use
-    # all ArbLib types.
-    # Hence we have to define `Base.precision` on Julia versions for which
-    # it is not defined above
-    Base.precision(
-        T::Type{<:Union{ArbTypes,ArbStructTypes,Ptr{<:ArbStructTypes}}};
-        base::Integer = 2,
-    ) = Base._precision(T, base)
-    Base.precision(
-        x::Union{ArbTypes,ArbStructTypes,Ptr{<:ArbStructTypes}};
-        base::Integer = 2,
-    ) = Base._precision(x, base)
-end
+# Base.precision only allows AbstractFloat, we want to be able to use
+# all ArbLib types.
+# Hence we have to define `Base.precision` on Julia versions for which
+# it is not defined above
+Base.precision(
+    T::Type{<:Union{ArbTypes,ArbStructTypes,Ptr{<:ArbStructTypes}}};
+    base::Integer = 2,
+) = Base._precision(T, base)
+Base.precision(x::Union{ArbTypes,ArbStructTypes,Ptr{<:ArbStructTypes}}; base::Integer = 2) =
+    Base._precision(x, base)
 
 # Used internally for determining the precision
 @inline _precision(x::Union{ArbTypes,BigFloat}) = precision(x)

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -47,15 +47,9 @@
         @test iszero(maximum(-A))
         @test iszero(extrema(A)[1])
         @test iszero(extrema(-A)[2])
-        # Before 1.8.0 these still fails and there is no real way to
-        # overload them
-        if VERSION < v"1.8.0-rc3"
-            @test_broken iszero(minimum(identity, A))
-            @test_broken iszero(maximum(identity, -A))
-        else
-            @test iszero(minimum(identity, A))
-            @test iszero(maximum(identity, -A))
-        end
+        # Before 1.8.0 these test failed with no way to fix them
+        @test iszero(minimum(identity, A))
+        @test iszero(maximum(identity, -A))
         # These work
         @test iszero(extrema(identity, A)[1])
         @test iszero(extrema(identity, -A)[2])
@@ -97,13 +91,9 @@
         @test Arblib.contains(maximum(A), 1000)
         @test Arblib.contains(extrema(A)[1], -1000)
         @test Arblib.contains(extrema(A)[2], 1000)
-        if VERSION < v"1.8.0-rc3"
-            @test_broken Arblib.contains(minimum(identity, A), -1000)
-            @test_broken Arblib.contains(maximum(identity, A), 1000)
-        else
-            @test Arblib.contains(minimum(identity, A), -1000)
-            @test Arblib.contains(maximum(identity, A), 1000)
-        end
+        # Before 1.8.0 these test failed with no way to fix them
+        @test Arblib.contains(minimum(identity, A), -1000)
+        @test Arblib.contains(maximum(identity, A), 1000)
         @test Arblib.contains(extrema(identity, A)[1], -1000)
         @test Arblib.contains(extrema(identity, A)[2], 1000)
 

--- a/test/precision.jl
+++ b/test/precision.jl
@@ -54,17 +54,15 @@
             @test precision(y[1, 1]) == prec
         end
 
-        if VERSION >= v"1.8.0"
-            @test precision(x, base = 4) == precdefault ÷ 2
-            @test precision(y, base = 4) == prec ÷ 2
+        @test precision(x, base = 4) == precdefault ÷ 2
+        @test precision(y, base = 4) == prec ÷ 2
 
-            @test precision(Arblib.cstruct(x), base = 4) == precdefault ÷ 2
-            @test precision(Arblib.cstruct(y), base = 4) == precdefault ÷ 2
+        @test precision(Arblib.cstruct(x), base = 4) == precdefault ÷ 2
+        @test precision(Arblib.cstruct(y), base = 4) == precdefault ÷ 2
 
-            @test precision(T, base = 4) == precdefault ÷ 2
-            @test precision(Arblib.cstructtype(T), base = 4) == precdefault ÷ 2
-            @test precision(Ptr{Arblib.cstructtype(T)}, base = 4) == precdefault ÷ 2
-        end
+        @test precision(T, base = 4) == precdefault ÷ 2
+        @test precision(Arblib.cstructtype(T), base = 4) == precdefault ÷ 2
+        @test precision(Ptr{Arblib.cstructtype(T)}, base = 4) == precdefault ÷ 2
 
         x2 = setprecision(x, prec)
         @test precision(x2) == prec
@@ -85,11 +83,9 @@
             @test !isequal(x, x2)
         end
 
-        if VERSION >= v"1.8.0"
-            x3 = setprecision(x, prec ÷ 2, base = 4)
-            @test precision(x3) == prec
-            @test isequal(x3, x)
-        end
+        x3 = setprecision(x, prec ÷ 2, base = 4)
+        @test precision(x3) == prec
+        @test isequal(x3, x)
     end
 
     @testset "setprecision do" begin


### PR DESCRIPTION
I was busy with other things, but finally got time to get back to this!

The motivation for dropping support for versions older than Julia 1.10 is #207. The implementation I made doesn't work on Julia 1.6 due to some rounding related functions not existing. For this specific PR the issues could be worked around, but there are some potential future features where this would not be possible. The main thing I have in mind is #171, switching `setprecision` to use `ScopedValue`. The Base implementation of `ScopedValue` was introduced in Julia 1.11 but there is a compatible implementation in [ScopedValues.jl](https://github.com/vchuravy/ScopedValues.jl), that package does however require Julia 1.8. So to implement that feature we would be required to drop support for Julia 1.6.
