### PR TITLE
Update JuliaFormatter to v2.1.2

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install JuliaFormatter and format
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.9"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="2.1.2"))'
           julia  -e 'using JuliaFormatter; format(["./src", "./test"], verbose=true)'
       - name: Format check
         run: |

--- a/src/ArbCall/ArbFPWrapFunction.jl
+++ b/src/ArbCall/ArbFPWrapFunction.jl
@@ -101,7 +101,7 @@ function jlargs(af::ArbFPWrapFunction)
     cargs[end] == Carg{Cint}(:flags, false) ||
         throw(ArgumentError("expected last argument to be flags::Cint, got $(cargs[end])"))
 
-    args = [:($(name(carg))::$(jltype(carg))) for carg in cargs[n+1:end-1]]
+    args = [:($(name(carg))::$(jltype(carg))) for carg in cargs[(n+1):(end-1)]]
 
     if basetype(af) == Float64
         kwargs = [

--- a/src/ArbCall/ArbFunction.jl
+++ b/src/ArbCall/ArbFunction.jl
@@ -89,7 +89,7 @@ function jlfname(
     strs = filter(!isempty, split(arbfname, "_"))
     k = findfirst(s -> s ∉ prefixes, strs)
     l = findfirst(s -> s ∉ suffixes, reverse(strs))
-    fname = join(strs[k:end-l+1], "_")
+    fname = join(strs[k:(end-l+1)], "_")
     return inplace ? Symbol(fname, "!") : Symbol(fname)
 end
 

--- a/src/ArbCall/parse.jl
+++ b/src/ArbCall/parse.jl
@@ -53,7 +53,7 @@ function parse_arbdoc(filename)
         previous_was_function = false
         for line in lines[start:stop]
             if startswith(line, ".. function::")
-                push!(sections[n][2], strip(line[length(".. function::")+1:end]))
+                push!(sections[n][2], strip(line[(length(".. function::")+1):end]))
                 previous_was_function = true
             elseif previous_was_function
                 if !isempty(strip(line))

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -74,7 +74,7 @@ function approx_eig_qr(
 end
 
 for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
-    jlf_allocating = Symbol(string(jlf)[1:end-1])
+    jlf_allocating = Symbol(string(jlf)[1:(end-1)])
     @eval begin
         function $jlf(
             eigvals::AcbVectorLike,

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -204,10 +204,10 @@ function _union!(res::T, x::T, y::T) where {T<:Union{ArbPoly,AcbPoly}}
     if common_degree + 1 < res_length
         z = zero(eltype(T))
         # At most one of the below loops will run
-        for i = common_degree+1:degree(x)
+        for i = (common_degree+1):degree(x)
             union!(ref(res, i), ref(x, i), z)
         end
-        for i = common_degree+1:degree(y)
+        for i = (common_degree+1):degree(y)
             union!(ref(res, i), ref(y, i), z)
         end
     end
@@ -285,13 +285,13 @@ function _intersection!(res::ArbPoly, x::ArbPoly, y::ArbPoly)
 
     if common_degree + 1 < res_length
         # At most one of the below loops will run
-        for i = common_degree+1:degree(x)
+        for i = (common_degree+1):degree(x)
             xi = ref(x, i)
             contains_zero(xi) ||
                 throw(ArgumentError("intersection of non-intersecting balls not allowed"))
             isnan(midref(xi)) && indeterminate!(ref(res, i))
         end
-        for i = common_degree+1:degree(y)
+        for i = (common_degree+1):degree(y)
             yi = ref(y, i)
             contains_zero(yi) ||
                 throw(ArgumentError("intersection of non-intersecting balls not allowed"))

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -47,7 +47,7 @@ function Serialization.serialize(
     Serialization.serialize_type(s, typeof(p))
     Serialization.serialize(s, length(p))
     T = p isa arb_poly_struct ? arb_struct : acb_struct
-    for i = 0:length(p)-1
+    for i = 0:(length(p)-1)
         Serialization.serialize(s, unsafe_load(p.coeffs + i * sizeof(T)))
     end
 end
@@ -64,8 +64,8 @@ function Serialization.deserialize(s::Serialization.AbstractSerializer, T::Type{
     spaces = findall(" ", str)
     @assert length(spaces) == 3
 
-    real_str = str[1:spaces[2].start-1]
-    imag_str = str[spaces[2].stop+1:end]
+    real_str = str[1:(spaces[2].start-1)]
+    imag_str = str[(spaces[2].stop+1):end]
 
     res = acf_struct()
     Arblib.load_string!(Arblib.realref(res), real_str)
@@ -79,8 +79,8 @@ function Serialization.deserialize(s::Serialization.AbstractSerializer, T::Type{
     spaces = findall(" ", str)
     @assert length(spaces) == 7
 
-    real_str = str[1:spaces[4].start-1]
-    imag_str = str[spaces[4].stop+1:end]
+    real_str = str[1:(spaces[4].start-1)]
+    imag_str = str[(spaces[4].stop+1):end]
 
     res = acb_struct()
     Arblib.load_string!(Arblib.realref(res), real_str)
@@ -120,7 +120,7 @@ function Serialization.deserialize(
 )
     n = Serialization.deserialize(s)
     res = T()
-    for i = 0:n-1
+    for i = 0:(n-1)
         set_coeff!(res, i, Serialization.deserialize(s))
     end
     return res


### PR DESCRIPTION
Some of the formatting rules changed in v2.0 so there are a few diffs with the new version.

This is built on top of #209 so once that is merged this needs to be rebased.