### PR TITLE
Implement significand and exponent

### DIFF
--- a/test/float.jl
+++ b/test/float.jl
@@ -81,4 +81,33 @@
         @test precision(ldexp(Arf(1, prec = 80), 1)) == 80
         @test precision(ldexp(Arb(1, prec = 80), 1)) == 80
     end
+
+    @testset "significand/exponent" begin
+        @test significand(Arf(12.3)) == significand(12.3)
+        @test significand(Arf(-12.3)) == significand(-12.3)
+        @test significand(Arf(0)) == significand(0.0)
+        @test significand(Arf(Inf)) == significand(Inf)
+        @test precision(significand(Arf(1, prec = 80))[1]) == 80
+        @test significand(Arf(1)) isa Arf
+
+        @test significand(Arb(12.3)) == significand(12.3)
+        @test significand(Arb(-12.3)) == significand(-12.3)
+        @test significand(Arb(0)) == significand(0.0)
+        @test significand(Arb(Inf)) == significand(Inf)
+        @test isequal(significand(Arb(π))[1], Arblib.mul_2exp!(Arb(), Arb(π), -1))
+        @test precision(significand(Arb(1, prec = 80))[1]) == 80
+        @test significand(Arb(1)) isa Arb
+
+        @test exponent(Arf(12.3)) == exponent(12.3)
+        @test exponent(Arf(-12.3)) == exponent(-12.3)
+        @test_throws DomainError exponent(Arf(0))
+        @test_throws DomainError exponent(Arf(Inf))
+        @test exponent(Arf(1)) isa BigInt
+
+        @test exponent(Arb(12.3)) == exponent(12.3)
+        @test exponent(Arb(-12.3)) == exponent(-12.3)
+        @test_throws DomainError exponent(Arb(0))
+        @test_throws DomainError exponent(Arb(Inf))
+        @test exponent(Arb(1)) isa BigInt
+    end
 end


### PR DESCRIPTION
I was looking through all the open issues and saw #101. We have made significant improvements on the `AbstractFloat` interface and I think it would be reasonable to close this issue. It does however explicitly mention `exponent`, which happens to be something we have not implemented (we have implemented `frexp` which is very similar). So this PR implements `significant` and `exponent`, by computing `frexp` and adjusting by a factor 2. This closes #101.

It is maybe worth mentioning that this implementation of `exponent` for `Arb` technically doesn't satisfy the documentation. It says that it "Returns the largest integer `y` such that `2^y ≤ abs(x)`." For regular, non-subnormal, floating points this is exactly the regular exponent. The reason for this phrasing in the documentation is to also account for subnormal floating point values. `Arb` doesn't have subnormal values, but it does have a radius. This means that `2^y ≤ abs(x)` in general does not hold if the radius is non-zero. I think the implementation is however close enough to the intention of `exponent` that adding a separate doc-string for this is justified.