### PR TITLE
Clean up some implementations in `ref.jl`

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -2,9 +2,8 @@ export setball
 
 # Mag
 Mag(x) = set!(Mag(), x)
-# Can't be defined inside Mag due to MagRef and ArfRef being defined
-# later.
-Mag(x::Union{MagRef,ArfRef}) = Mag(cstruct(x))
+# Uses the init_set! constructor
+Mag(x::Union{Mag,MagRef}) = Mag(cstruct(x))
 Mag(x, y) = set!(Mag(), x, y)
 # disambiguation
 Mag(x::Complex) = set!(Mag(), x)

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -1,8 +1,8 @@
+MagRef() = Mag()
 ArfRef(; prec::Integer = _current_precision()) = Arf(; prec)
 AcfRef(; prec::Integer = _current_precision()) = Acf(; prec)
 ArbRef(; prec::Integer = _current_precision()) = Arb(; prec)
 AcbRef(; prec::Integer = _current_precision()) = Acb(; prec)
-MagRef() = Mag()
 
 function ArfRef(
     ptr::Ptr{arf_struct},
@@ -32,12 +32,6 @@ function AcbRef(
 )
     AcbRef(ptr, prec, parent)
 end
-
-Mag(x::MagRef) = set!(Mag(), x)
-Arf(x::ArfRef; prec::Integer = precision(x)) = set!(Arf(; prec), x)
-Acf(x::AcfRef; prec::Integer = precision(x)) = set!(Acf(; prec), x)
-Arb(x::ArbRef; prec::Integer = precision(x)) = set!(Arb(; prec), x)
-Acb(x::AcbRef; prec::Integer = precision(x)) = set!(Acb(; prec), x)
 
 Base.zero(::Union{Type{MagRef},MagRef}) = zero(Mag)
 Base.one(::Union{Type{MagRef},MagRef}) = one(Mag)
@@ -72,8 +66,8 @@ end
 Return an `ArfRef` referencing the imaginary part of `z`.
 """
 function imagref(z::AcfLike; prec = precision(z))
-    real_ptr = ccall(@libflint(acf_imag_ptr), Ptr{arf_struct}, (Ref{acf_struct},), z)
-    ArfRef(real_ptr, prec, parentstruct(z))
+    imag_ptr = ccall(@libflint(acf_imag_ptr), Ptr{arf_struct}, (Ref{acf_struct},), z)
+    ArfRef(imag_ptr, prec, parentstruct(z))
 end
 
 """
@@ -112,6 +106,6 @@ end
 Return an `ArbRef` referencing the imaginary part of `z`.
 """
 function imagref(z::AcbLike; prec = precision(z))
-    real_ptr = ccall(@libflint(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
-    ArbRef(real_ptr, prec, parentstruct(z))
+    imag_ptr = ccall(@libflint(acb_imag_ptr), Ptr{arb_struct}, (Ref{acb_struct},), z)
+    ArbRef(imag_ptr, prec, parentstruct(z))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,9 +6,8 @@ struct Mag <: Real
 
     Mag() = new(mag_struct())
 
-    # Uses init_set! constructor. Argument type should be MagLike but
-    # that is only defined further down.
-    Mag(x::Union{Mag,mag_struct,Ptr{mag_struct}}) = new(mag_struct(cstruct(x)))
+    # Uses init_set! constructor.
+    Mag(x::Union{mag_struct,Ptr{mag_struct}}) = new(mag_struct(x))
 end
 
 """

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -7,6 +7,9 @@
         @test π < Float64(Mag(π)) < 3.15
         @test Mag(3, 4) == Mag(3 * 2^4)
 
+        # Test init_set! constructor
+        @test Mag(Ptr{Arblib.mag_struct}(pointer_from_objref(Mag().mag))) == Mag()
+
         # Check for ambiguities
         @test Mag(1 + 0im) == Mag(1)
         @test_throws InexactError Mag(1 + im)


### PR DESCRIPTION
This is a minor cleanup of the implementation in `src/ref.jl` coming from my work on the `NFloat` interface. It should not have any effect for users.