### PR TITLE
Make matrix inv and ldiv return indeterminate instead of throwing

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -292,7 +292,19 @@ function LinearAlgebra.ldiv!(Y::T, A::T, B::T) where {T<:Matrices}
     # precision.
     flag = solve!(Y, A, B)
 
-    iszero(flag) && throw(LinearAlgebra.SingularException(0))
+    # The Base version of this throws a
+    # LinearAlgebra.SingularException in case the inversion fails. We
+    # instead opt to return a matrix filled with indeterminate values.
+    # The motivation for this is that failure to invert matrices is
+    # fairly common when working with wide balls and the overhead of
+    # catching an exception adds a lot of extra work.
+    if iszero(flag)
+        for i in axes(Y, 1)
+            for j in axes(Y, 2)
+                @inbounds indeterminate!(ref(Y, i, j))
+            end
+        end
+    end
 
     return Y
 end
@@ -337,7 +349,19 @@ function Base.inv(A::Matrices)
     B = similar(A)
     flag = inv!(B, A)
 
-    iszero(flag) && throw(LinearAlgebra.SingularException(0))
+    # The Base version of this throws a
+    # LinearAlgebra.SingularException in case the inversion fails. We
+    # instead opt to return a matrix filled with indeterminate values.
+    # The motivation for this is that failure to invert matrices is
+    # fairly common when working with wide balls and the overhead of
+    # catching an exception adds a lot of extra work.
+    if iszero(flag)
+        for i in axes(B, 1)
+            for j in axes(B, 2)
+                @inbounds indeterminate!(ref(B, i, j))
+            end
+        end
+    end
 
     return B
 end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -254,8 +254,8 @@
                     ),
                 ) == 96
 
-                @test_throws SingularException(0) TMat(Diagonal([1, 2, 3, 0])) \ B1
-                @test_throws SingularException(0) TMat(Diagonal([1, 2, 3, 0])) \ B2
+                @test all(!isfinite, TMat(Diagonal([1, 2, 3, 0])) \ B1)
+                @test all(!isfinite, TMat(Diagonal([1, 2, 3, 0])) \ B2)
 
                 @test_throws DimensionMismatch(
                     "matrix is not square: dimensions are (2, 3)",
@@ -296,7 +296,7 @@
                 ]) # Some random invertible matrix
                 @test Arblib.overlaps(inv(A) * A, TMat(I(4)))
 
-                @test_throws SingularException(0) inv(TMat(Diagonal([1, 2, 3, 0])))
+                @test all(!isfinite, inv(TMat(Diagonal([1, 2, 3, 0]))))
 
                 @test_throws DimensionMismatch(
                     "matrix is not square: dimensions are (2, 3)",


### PR DESCRIPTION
The Base version of `inv` and `ldiv` for matrices throws a `LinearAlgebra.SingularException` in case of failure. In #228 I implemented the `ArbMatrix` version to do the same. However, I realized shortly after that it is most likely a better idea to return an indeterminate result in this case. This is what I do in more or less all of my use cases for these functions in the end. Failure to invert matrices is also fairly common when working with wide balls and the overhead of catching an exception adds a lot of extra work. Overall I think this is a better design than throwing an error.

Note that I haven't changed `lu`, it still throws an error on failure. But that interface has a `check` argument that can be used to choose if failure should throw or not.

With this I think we should be ready to (finally) release version 1.7.0. The commit that pushes the version number was some time ago now, but I don't think this is any problem in practice. As long as we use the latest commit for the release.