### PR TITLE
Some fixes based on JET.jl report

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arblib"
 uuid = "fb37089c-8514-4489-9461-98f9c8763369"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <Sascha Timme <timme@math.tu-berlin.de>", "Joel Dahne <joel@dahne.eu>"]
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -69,9 +69,9 @@ end
 function Acb(re::AbstractString, im::AbstractString; prec::Integer = _current_precision())
     res = Acb(; prec)
     flag = set!(realref(res), re)
-    iszero(flag) || throw(ArgumentError("could not parse $str as an Arb"))
+    iszero(flag) || throw(ArgumentError("could not parse $re as an Arb"))
     flag = set!(imagref(res), im)
-    iszero(flag) || throw(ArgumentError("could not parse $str as an Arb"))
+    iszero(flag) || throw(ArgumentError("could not parse $im as an Arb"))
     return res
 end
 

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -114,7 +114,7 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
             R_eigvecs_approx::AcbMatrixLike;
             prec = _precision(A),
         )
-            @boundscheck length(eigvals_approx) == size(A, 1) || throw(
+            @boundscheck length(eigvals) == length(eigvals_approx) == size(A, 1) || throw(
                 DimensionMismatch("eigenvalues sizes are not compatible with matrix A"),
             )
             @boundscheck size(R_eigvecs_approx) == size(A) || throw(

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -127,8 +127,8 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
         end
 
         function $jlf(
-            eigvals::AcbVectorLike,
-            eigvecs::AcbMatrixLike,
+            eigvals::AcbVectorOrRef,
+            eigvecs::AcbMatrixOrRef,
             A::AcbMatrixOrRef;
             prec = precision(A),
             side = :right,
@@ -137,7 +137,7 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
             return $jlf(eigvals, eigvecs, A, eigvals_approx, R_eigvecs_approx; prec, side)
         end
 
-        function $jlf(eigvals::AcbVectorLike, A::AcbMatrixOrRef; prec = precision(A))
+        function $jlf(eigvals::AcbVectorOrRef, A::AcbMatrixOrRef; prec = precision(A))
             λ_approx, R_approx = approx_eig_qr(A, prec = prec)
             return $jlf(eigvals, A, λ_approx, R_approx; prec)
         end
@@ -153,8 +153,8 @@ end
 
 function eig_global_enclosure(
     A::AcbMatrixOrRef,
-    eigvals_approx::AcbVectorLike,
-    R_eigvecs_approx::AcbMatrixLike;
+    eigvals_approx::AcbVectorOrRef,
+    R_eigvecs_approx::AcbMatrixOrRef;
     prec = precision(A),
 )
     return eig_global_enclosure!(Mag(), A, eigvals_approx, R_eigvecs_approx, prec)
@@ -162,15 +162,15 @@ end
 
 function eig_enclosure_rump!(
     λ::AcbLike,
-    eigvecs::AcbMatrixOrRef,
-    A::AcbMatrixOrRef,
+    eigvecs::AcbMatrixLike,
+    A::AcbMatrixLike,
     λ_approx::AcbLike,
-    R_eigvecs_approx::AcbMatrixOrRef;
+    R_eigvecs_approx::AcbMatrixLike;
     prec = precision(A),
 )
     @boundscheck size(eigvecs) == size(R_eigvecs_approx) &&
                  size(eigvecs, 1) == size(A, 1) ||
-                 throw(DimensionMismatch("eigenvalues sizes are not compatible"))
+                 throw(DimensionMismatch("eigenvectors sizes are not compatible"))
 
     return eig_enclosure_rump!(λ, C_NULL, eigvecs, A, λ_approx, R_eigvecs_approx; prec)
 end
@@ -185,8 +185,8 @@ for f in (:eig_multiple_rump, :eig_multiple)
 
         function $f(
             A::AcbMatrixOrRef,
-            eigvals_approx::AcbVectorLike,
-            R_eigvecs_approx::AcbMatrixLike;
+            eigvals_approx::AcbVectorOrRef,
+            R_eigvecs_approx::AcbMatrixOrRef;
             prec = precision(A),
         )
             λ = similar(A, size(A, 1))

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -104,7 +104,7 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
                 $jlf(eigvals, C_NULL, eigvecs, A, eigvals_approx, R_eigvecs_approx; prec)
             end
             isone(val) || throw(EigenvalueComputationError())
-            return eigvals, eigvecs
+            return eigvals
         end
 
         function $jlf(

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -190,13 +190,15 @@ for f in (:eig_multiple_rump, :eig_multiple)
             prec = precision(A),
         )
             λ = similar(A, size(A, 1))
-            $f_inplace(λ, A, eigvals_approx, R_eigvecs_approx; prec)
+            flag = $f_inplace(λ, A, eigvals_approx, R_eigvecs_approx; prec)
+            isone(flag) || throw(EigenvalueComputationError())
             return λ
         end
 
         function $f(A::AcbMatrixOrRef; prec = precision(A))
             λ = similar(A, size(A, 1))
-            $f_inplace(λ, A; prec)
+            flag = $f_inplace(λ, A; prec)
+            isone(flag) || throw(EigenvalueComputationError())
             return λ
         end
 

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -17,11 +17,11 @@ function approx_eig_qr!(
     prec = _precision(A),
     side = :right,
 )
-    @boundscheck size(eigvals, 1) == size(A, 1) && size(eigvecs) == size(A) || throw(
+    @boundscheck length(eigvals) == size(A, 1) && size(eigvecs) == size(A) || throw(
         DimensionMismatch("eigvals, eigvecs and A sizes are not compatible."),
     )
     @assert side in (:left, :right) || throw(
-        ArgumentError("In approx_eig_qr!: `side` kwarg must be eithe :left or :right"),
+        ArgumentError("in approx_eig_qr!: `side` kwarg must be eithe :left or :right"),
     )
 
     if iszero(tol)
@@ -48,7 +48,7 @@ function approx_eig_qr!(
     maxiter = 0,
     prec = _precision(A),
 )
-    @boundscheck size(eigvals, 1) == size(A, 1) || throw(
+    @boundscheck length(eigvals) == size(A, 1) || throw(
         DimensionMismatch("eigvals, eigvecs and A sizes are not compatible."),
     )
     if iszero(tol)
@@ -61,7 +61,7 @@ function approx_eig_qr!(
 end
 
 function approx_eig_qr(
-    A::Union{AcbMatrix,AcbRefMatrix};
+    A::AcbMatrixOrRef;
     tol = Mag(),
     maxiter = 0,
     prec = precision(A),
@@ -87,15 +87,15 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
         )
             @assert side in (:left, :right) || throw(
                 ArgumentError(
-                    "In approx_eig_qr!: `side` kwarg must be either :left or :right",
+                    "in approx_eig_qr!: `side` kwarg must be either :left or :right",
                 ),
             )
 
-            @boundscheck size(eigvals, 1) == size(eigvals_approx, 1) == size(A, 1) || throw(
-                DimensionMismatch("Eigenvalues sizes are not compatible with matrix A"),
+            @boundscheck length(eigvals) == length(eigvals_approx) == size(A, 1) || throw(
+                DimensionMismatch("eigenvalues sizes are not compatible with matrix A"),
             )
             @boundscheck size(eigvecs) == size(R_eigvecs_approx) == size(A) || throw(
-                DimensionMismatch("Eigenvectors sizes are not compatible with matrix A"),
+                DimensionMismatch("eigenvectors sizes are not compatible with matrix A"),
             )
 
             val = if side == :left
@@ -114,11 +114,11 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
             R_eigvecs_approx::AcbMatrixLike;
             prec = _precision(A),
         )
-            @boundscheck size(eigvals_approx, 1) == size(A, 1) || throw(
-                DimensionMismatch("Eigenvalues sizes are not compatible with matrix A"),
+            @boundscheck length(eigvals_approx) == size(A, 1) || throw(
+                DimensionMismatch("eigenvalues sizes are not compatible with matrix A"),
             )
             @boundscheck size(R_eigvecs_approx) == size(A) || throw(
-                DimensionMismatch("Eigenvectors sizes are not compatible with matrix A"),
+                DimensionMismatch("eigenvectors sizes are not compatible with matrix A"),
             )
 
             val = $jlf(eigvals, C_NULL, C_NULL, A, eigvals_approx, R_eigvecs_approx; prec)
@@ -129,7 +129,7 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
         function $jlf(
             eigvals::AcbVectorLike,
             eigvecs::AcbMatrixLike,
-            A::Union{AcbMatrix,AcbRefMatrix};
+            A::AcbMatrixOrRef;
             prec = precision(A),
             side = :right,
         )
@@ -137,20 +137,12 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
             return $jlf(eigvals, eigvecs, A, eigvals_approx, R_eigvecs_approx; prec, side)
         end
 
-        function $jlf(
-            eigvals::AcbVectorLike,
-            A::Union{AcbMatrix,AcbRefMatrix};
-            prec = precision(A),
-        )
+        function $jlf(eigvals::AcbVectorLike, A::AcbMatrixOrRef; prec = precision(A))
             λ_approx, R_approx = approx_eig_qr(A, prec = prec)
             return $jlf(eigvals, A, λ_approx, R_approx; prec)
         end
 
-        function $jlf_allocating(
-            A::Union{AcbMatrix,AcbRefMatrix};
-            prec = precision(A),
-            side = :right,
-        )
+        function $jlf_allocating(A::AcbMatrixOrRef; prec = precision(A), side = :right)
             eigvals = similar(A, size(A, 1))
             eigvecs = similar(A)
             $jlf(eigvals, eigvecs, A; prec, side)
@@ -160,7 +152,7 @@ for jlf in (:eig_simple_rump!, :eig_simple_vdhoeven_mourrain!, :eig_simple!)
 end
 
 function eig_global_enclosure(
-    A::Union{AcbMatrix,AcbRefMatrix},
+    A::AcbMatrixOrRef,
     eigvals_approx::AcbVectorLike,
     R_eigvecs_approx::AcbMatrixLike;
     prec = precision(A),
@@ -170,15 +162,15 @@ end
 
 function eig_enclosure_rump!(
     λ::AcbLike,
-    eigvecs::Union{AcbMatrix,AcbRefMatrix},
-    A::Union{AcbMatrix,AcbRefMatrix},
+    eigvecs::AcbMatrixOrRef,
+    A::AcbMatrixOrRef,
     λ_approx::AcbLike,
-    R_eigvecs_approx::Union{AcbMatrix,AcbRefMatrix};
+    R_eigvecs_approx::AcbMatrixOrRef;
     prec = precision(A),
 )
     @boundscheck size(eigvecs) == size(R_eigvecs_approx) &&
                  size(eigvecs, 1) == size(A, 1) ||
-                 throw(DimensionMismatch("Eigenvalues sizes are not compatible"))
+                 throw(DimensionMismatch("eigenvalues sizes are not compatible"))
 
     return eig_enclosure_rump!(λ, C_NULL, eigvecs, A, λ_approx, R_eigvecs_approx; prec)
 end
@@ -186,17 +178,13 @@ end
 for f in (:eig_multiple_rump, :eig_multiple)
     f_inplace = Symbol(f, "!")
     @eval begin
-        function $f_inplace(
-            eigvals::Union{AcbVector,AcbRefVector},
-            A::Union{AcbMatrix,AcbRefMatrix};
-            prec = precision(A),
-        )
+        function $f_inplace(eigvals::AcbVectorOrRef, A::AcbMatrixOrRef; prec = precision(A))
             λ_approx, R_approx = approx_eig_qr(A; prec)
             return $f_inplace(eigvals, A, λ_approx, R_approx; prec)
         end
 
         function $f(
-            A::Union{AcbMatrix,AcbRefMatrix},
+            A::AcbMatrixOrRef,
             eigvals_approx::AcbVectorLike,
             R_eigvecs_approx::AcbMatrixLike;
             prec = precision(A),
@@ -206,7 +194,7 @@ for f in (:eig_multiple_rump, :eig_multiple)
             return λ
         end
 
-        function $f(A::Union{AcbMatrix,AcbRefMatrix}; prec = precision(A))
+        function $f(A::AcbMatrixOrRef; prec = precision(A))
             λ = similar(A, size(A, 1))
             $f_inplace(λ, A; prec)
             return λ
@@ -215,4 +203,4 @@ for f in (:eig_multiple_rump, :eig_multiple)
     end
 end
 
-LinearAlgebra.eigvals(A::Union{AcbMatrix,AcbRefMatrix}) = eig_multiple(A)
+LinearAlgebra.eigvals(A::AcbMatrixOrRef) = eig_multiple(A)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,5 +1,6 @@
 # arb_mat_struct and acb_mat_struct methods
 Base.size(A::Union{arb_mat_struct,acb_mat_struct}) = (A.r, A.c)
+Base.size(A::Union{arb_mat_struct,acb_mat_struct}, d::Int) = size(A)[d]
 
 function Base.getindex(A::arb_mat_struct, i::Integer, j::Integer)
     return ccall(

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -632,10 +632,10 @@ function integral(p::T, n::Integer) where {T<:Union{Poly,Series}}
     n == 0 && return copy(p)
     n >= 0 || throw(ArgumentError("n must be non-negative"))
 
-    if T <: Poly
-        res = zero(p)
+    res = if T <: Poly
+        zero(p)
     elseif T <: Series
-        res = T(degree = degree(p) + n, prec = precision(p))
+        T(degree = degree(p) + n, prec = precision(p))
     end
     integral!(res, p)
     for _ = 2:n

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -61,11 +61,11 @@ Serialization.deserialize(
 function Serialization.deserialize(s::Serialization.AbstractSerializer, T::Type{acf_struct})
     str = Serialization.deserialize(s)
     # One spaces in the real part, so we are looking for
-    spaces = findall(" ", str)
-    @assert length(spaces) == 3
+    spaces = findall(' ', str)
+    length(spaces) == 3 || throw(ErrorException("invalid format: $str"))
 
-    real_str = str[1:(spaces[2].start-1)]
-    imag_str = str[(spaces[2].stop+1):end]
+    real_str = str[1:(spaces[2]-1)]
+    imag_str = str[(spaces[2]+1):end]
 
     res = acf_struct()
     Arblib.load_string!(Arblib.realref(res), real_str)
@@ -76,11 +76,11 @@ end
 function Serialization.deserialize(s::Serialization.AbstractSerializer, T::Type{acb_struct})
     str = Serialization.deserialize(s)
     # Three spaces in the real part, so we are looking for
-    spaces = findall(" ", str)
-    @assert length(spaces) == 7
+    spaces = findall(' ', str)
+    length(spaces) == 7 || throw(ErrorException("invalid format: $str"))
 
-    real_str = str[1:(spaces[4].start-1)]
-    imag_str = str[(spaces[4].stop+1):end]
+    real_str = str[1:(spaces[4]-1)]
+    imag_str = str[(spaces[4]+1):end]
 
     res = acb_struct()
     Arblib.load_string!(Arblib.realref(res), real_str)

--- a/src/types.jl
+++ b/src/types.jl
@@ -156,7 +156,7 @@ Type handling references to [`Arb`](@ref) objects.
 struct ArbRef <: AbstractFloat
     arb_ptr::Ptr{arb_struct}
     prec::Int
-    parent::Union{acb_struct,AcbRef,arb_vec_struct,arb_poly_struct,arb_mat_struct}
+    parent::Union{Nothing,acb_struct,AcbRef,arb_vec_struct,arb_poly_struct,arb_mat_struct}
 end
 
 """
@@ -187,7 +187,7 @@ Type handling references to [`Arf`](@ref) objects.
 struct ArfRef <: AbstractFloat
     arf_ptr::Ptr{arf_struct}
     prec::Int
-    parent::Union{acf_struct,AcfRef,arb_struct,ArbRef}
+    parent::Union{Nothing,acf_struct,AcfRef,arb_struct,ArbRef}
 end
 
 """
@@ -201,7 +201,7 @@ Type handling references to [`Mag`](@ref) objects.
 """
 struct MagRef <: Real
     mag_ptr::Ptr{mag_struct}
-    parent::Union{arb_struct,ArbRef}
+    parent::Union{Nothing,arb_struct,ArbRef}
 end
 
 """
@@ -523,6 +523,7 @@ for prefix in [:mag, :arf, :acf, :arb, :acb]
         parentstruct(x::$T) = cstruct(x)
         parentstruct(x::$TRef) = x
         parentstruct(x::$TStruct) = x
+        parentstruct(x::Ptr{$TStruct}) = nothing
     end
 end
 

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -1,4 +1,4 @@
-# arb_mat_struct and acb_mat_struct methods
+# arb_vec_struct and acb_vec_struct methods
 clear!(v::arb_vec_struct) =
     ccall(@libflint(_arb_vec_clear), Cvoid, (Ptr{arb_struct}, Int), v.entries, v.n)
 clear!(v::acb_vec_struct) =

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -8,6 +8,7 @@ Base.unsafe_convert(::Type{Ptr{arb_struct}}, v::arb_vec_struct) = v.entries
 Base.unsafe_convert(::Type{Ptr{acb_struct}}, v::acb_vec_struct) = v.entries
 
 Base.size(v::Union{arb_vec_struct,acb_vec_struct}) = (v.n,)
+Base.length(v::Union{arb_vec_struct,acb_vec_struct}) = v.n
 
 Base.getindex(v::arb_vec_struct, i::Integer) = v.entries + (i - 1) * sizeof(arb_struct)
 Base.getindex(v::acb_vec_struct, i::Integer) = v.entries + (i - 1) * sizeof(acb_struct)

--- a/test/calc_integrate.jl
+++ b/test/calc_integrate.jl
@@ -1,44 +1,66 @@
 @testset "integration" begin
     prec = 64
-    a = Acb(0, prec = prec)
-    b = Acb(1, prec = prec)
+    a = Acb(0; prec)
+    b = Acb(1; prec)
 
     # Test with just a plain method
     f1 = sin
     f1! = Arblib.sin!
     res1 = "[0.459697694131860282 +/- 7.22e-19]"
-    @test string(Arblib.integrate(f1, a, b, prec = prec)) == res1
-    @test string(Arblib.integrate!(f1!, Acb(prec = prec), a, b)) == res1
+    @test string(Arblib.integrate(f1, a, b; prec)) == res1
+    @test string(Arblib.integrate(f1, real(a), real(b); prec)) == res1
+    @test string(Arblib.integrate!(f1!, Acb(; prec), a, b)) == res1
+    @test string(Arblib.integrate!(f1!, Acb(; prec), real(a), real(b))) == res1
 
     # Test with a method that accepts precision as a keyword argument
-    f2 = (x; prec) -> Arblib.sin!(Acb(), x, prec = prec)
+    f2 = (x; prec) -> Arblib.sin!(Acb(), x; prec)
     f2! = Arblib.sin!
     res2 = "[0.459697694131860282 +/- 7.22e-19]"
-    @test string(Arblib.integrate(f2, a, b, take_prec = true, prec = prec)) == res2
-    @test string(Arblib.integrate!(f2!, Acb(prec = prec), a, b, take_prec = true)) == res2
+    @test string(Arblib.integrate(f2, a, b, take_prec = true; prec)) == res2
+    @test string(Arblib.integrate(f2, real(a), real(b), take_prec = true; prec)) == res2
+    @test string(Arblib.integrate!(f2!, Acb(; prec), a, b, take_prec = true)) == res2
+    @test string(Arblib.integrate!(f2!, Acb(; prec), real(a), real(b), take_prec = true)) ==
+          res2
 
     # Test with a method that accepts analytic as a keyword argument
-    f3 = (x; analytic) -> Arblib.real_abs!(Acb(prec = prec), x, analytic)
+    f3 = (x; analytic) -> Arblib.real_abs!(Acb(; prec), x, analytic)
     f3! = (res, x; analytic) -> Arblib.real_abs!(res, x, analytic)
     res3 = "[0.50000000000000000 +/- 2.73e-18]"
-    @test string(Arblib.integrate(f3, a, b, check_analytic = true, prec = prec)) == res3
-    @test string(Arblib.integrate!(f3!, Acb(prec = prec), a, b, check_analytic = true)) ==
+    @test string(Arblib.integrate(f3, a, b, check_analytic = true; prec)) == res3
+    @test string(Arblib.integrate(f3, real(a), real(b), check_analytic = true; prec)) ==
           res3
+    @test string(Arblib.integrate!(f3!, Acb(; prec), a, b, check_analytic = true)) == res3
+    @test string(
+        Arblib.integrate!(f3!, Acb(; prec), real(a), real(b), check_analytic = true),
+    ) == res3
 
     # Test with a method that accepts both precision and analytic as
     # a keyword arguments
-    f4 = (x; analytic, prec) -> Arblib.real_abs!(Acb(), x, analytic, prec = prec)
-    f4! = (res, x; analytic, prec) -> Arblib.real_abs!(res, x, analytic, prec = prec)
+    f4 = (x; analytic, prec) -> Arblib.real_abs!(Acb(), x, analytic; prec)
+    f4! = (res, x; analytic, prec) -> Arblib.real_abs!(res, x, analytic; prec)
     res4 = "[0.50000000000000000 +/- 2.73e-18]"
     @test string(
-        Arblib.integrate(f4, a, b, check_analytic = true, take_prec = true, prec = prec),
+        Arblib.integrate(f4, a, b, check_analytic = true, take_prec = true; prec),
+    ) == res4
+    @test string(
+        Arblib.integrate(
+            f4,
+            real(a),
+            real(b),
+            check_analytic = true,
+            take_prec = true;
+            prec,
+        ),
+    ) == res4
+    @test string(
+        Arblib.integrate!(f4!, Acb(; prec), a, b, check_analytic = true, take_prec = true),
     ) == res4
     @test string(
         Arblib.integrate!(
             f4!,
-            Acb(prec = prec),
-            a,
-            b,
+            Acb(; prec),
+            real(a),
+            real(b),
             check_analytic = true,
             take_prec = true,
         ),
@@ -49,6 +71,34 @@
     f5! = (res, x) -> Arblib.sin!(res, Arblib.exp!(res, x))
     res5 = "[0.8750 +/- 5.14e-5]"
     res5! = "[0.87495720 +/- 2.77e-9]"
-    @test string(Arblib.integrate(f5, a, b, prec = prec, rtol = 1e-4)) == res5
-    @test string(Arblib.integrate!(f5!, Acb(prec = prec), a, b, atol = 1e-8)) == res5!
+    @test string(Arblib.integrate(f5, a, b; prec, rtol = 1e-4)) == res5
+    @test string(Arblib.integrate(f5, real(a), real(b); prec, rtol = 1e-4)) == res5
+    @test string(Arblib.integrate!(f5!, Acb(; prec), a, b, atol = 1e-8)) == res5!
+    @test string(Arblib.integrate!(f5!, Acb(; prec), real(a), real(b), atol = 1e-8)) ==
+          res5!
+
+    # Test with calc_integrate_opt_struct
+    f6 = sin
+    f6! = Arblib.sin!
+    res6 = "[0.459697694131860282 +/- 7.22e-19]"
+    opts = Arblib.calc_integrate_opt_struct()
+    @test string(Arblib.integrate(f6, a, b; prec, opts)) == res6
+    @test string(Arblib.integrate(f6, real(a), real(b); prec, opts)) == res6
+    @test string(Arblib.integrate!(f6!, Acb(; prec), a, b; opts)) == res6
+    @test string(Arblib.integrate!(f6!, Acb(; prec), real(a), real(b); opts)) == res6
+
+    f7 = sin
+    f7! = Arblib.sin!
+    res7 = "[0.46 +/- 4.34e-3]"
+    opts = Arblib.calc_integrate_opt_struct(5, 500, 0, true, 0)
+    warn_on_no_convergence = false
+    @test string(Arblib.integrate(f7, a, b; prec, warn_on_no_convergence, opts)) == res7
+    @test string(
+        Arblib.integrate(f7, real(a), real(b); prec, warn_on_no_convergence, opts),
+    ) == res7
+    @test string(Arblib.integrate!(f7!, Acb(; prec), a, b; warn_on_no_convergence, opts)) ==
+          res7
+    @test string(
+        Arblib.integrate!(f7!, Acb(; prec), real(a), real(b); warn_on_no_convergence, opts),
+    ) == res7
 end

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -1,150 +1,208 @@
-@testset "eigenvalues/eigenvectors: $MatT" for MatT in (AcbMatrix, AcbRefMatrix)
-    A = [
-        0.6873474041954415 0.7282180564881044 0.07360652513458521
-        0.000835810121029068 0.9256166870757694 0.5363310989411239
-        0.07387174694790022 0.4050436025621329 0.20226010388885896
-    ]
-    B = [
-        0.8982563031334123 0.3029712969740874 0.8585014523679579
-        0.7583002736998279 0.8854763478184455 0.3031103325817668
-        0.2319572749472405 0.5769840251057949 0.5119507333628952
-    ]
-    M = MatT(A + B * im, prec = 64)
-    # M = MatT(rand(3, 3) + im * rand(3, 3), prec = 64)
+@testset "eigen" begin
+    @testset "eigenvalues/eigenvectors: $MatT" for MatT in (AcbMatrix, AcbRefMatrix)
+        A = [
+            0.6873474041954415 0.7282180564881044 0.07360652513458521
+            0.000835810121029068 0.9256166870757694 0.5363310989411239
+            0.07387174694790022 0.4050436025621329 0.20226010388885896
+        ]
+        B = [
+            0.8982563031334123 0.3029712969740874 0.8585014523679579
+            0.7583002736998279 0.8854763478184455 0.3031103325817668
+            0.2319572749472405 0.5769840251057949 0.5119507333628952
+        ]
+        M = MatT(A + B * im, prec = 64)
+        # M = MatT(rand(3, 3) + im * rand(3, 3), prec = 64)
 
-    VecT = typeof(similar(M, 3))
+        VecT = typeof(similar(M, 3))
 
-    @testset "approx_eig_qr" begin
-        λs_a_r, revs_a = Arblib.approx_eig_qr(M, side = :right)
-        @test λs_a_r isa VecT
-        @test revs_a isa MatT
+        @testset "approx_eig_qr" begin
+            λs_a_r, revs_a = Arblib.approx_eig_qr(M, side = :right)
+            @test λs_a_r isa VecT
+            @test revs_a isa MatT
 
-        ε = 1e-10
+            ε = 1e-10
 
-        λs_a_l, revs_a = Arblib.approx_eig_qr(M, tol = Arblib.Mag(ε), side = :left)
-        @test λs_a_l isa VecT
-        @test revs_a isa MatT
+            λs_a_l, revs_a = Arblib.approx_eig_qr(M, tol = Arblib.Mag(ε), side = :left)
+            @test λs_a_l isa VecT
+            @test revs_a isa MatT
 
-        @test all(abs.(λs_a_r - λs_a_l) .< ε)
+            @test all(abs.(λs_a_r - λs_a_l) .< ε)
 
-        λs_r = similar(M, size(M, 1))
-        Arblib.approx_eig_qr!(λs_r, M)
-        @test Arblib.is_zero(λs_r - λs_a_r, length(λs_r))
-    end
-
-    @testset "eig_simple" begin
-        λs1, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :right)
-        λs2, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :left)
-
-        @test all(Arblib.containszero, λs1 - λs2)
-
-        λs1, _ = Arblib.eig_simple_rump(M, side = :right)
-        λs2, _ = Arblib.eig_simple_rump(M, side = :left)
-        @test all(Arblib.containszero, λs1 - λs2)
-
-        λs1, _ = Arblib.eig_simple(M, side = :right)
-        λs2, _ = Arblib.eig_simple(M, side = :left)
-        @test all(Arblib.containszero, λs1 - λs2)
-
-        λs = similar(M, size(M, 1))
-        Arblib.eig_simple_vdhoeven_mourrain!(λs, M)
-        @test all(Arblib.containszero, λs - λs1)
-
-        λs = similar(M, size(M, 1))
-        Arblib.eig_simple_rump!(λs, M)
-        @test all(Arblib.containszero, λs - λs1)
-
-        λs = similar(M, size(M, 1))
-        Arblib.eig_simple!(λs, M)
-        @test all(Arblib.containszero, λs - λs1)
-    end
-
-    N = similar(M)
-    evs = [Arb(2.0), Arb(2.0), Arb(rand())]
-    N[1, 1], N[2, 2], N[3, 3] = evs
-
-    N = M * N * M^-1
-
-    @testset "enclosures" begin
-        ε = Arblib.Mag()
-        tol = 1e-12
-        λ_approx, R_approx = Arblib.approx_eig_qr(M, tol = tol)
-
-        @test Arblib.eig_global_enclosure!(
-            ε,
-            M,
-            λ_approx,
-            R_approx;
-            prec = precision(M),
-        ) isa Arblib.Mag
-
-        @test ε <= tol
-
-        λs = similar(M, size(M, 1))
-        Arblib.eig_simple!(λs, M, λ_approx, R_approx)
-
-        for λa in λ_approx
-            a_real = let x = real(λa)
-                m = Arblib.midref(x)
-                r = Arblib.radref(x)
-                Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
-            end
-
-            a_imag = let x = imag(λa)
-                m = Arblib.midref(x)
-                r = Arblib.radref(x)
-                Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
-            end
-
-            a = Acb(a_real, a_imag)
-            @test any(Arblib.containszero(a - λ) for λ in λs)
+            λs_r = similar(M, size(M, 1))
+            Arblib.approx_eig_qr!(λs_r, M)
+            @test Arblib.is_zero(λs_r - λs_a_r, length(λs_r))
         end
 
+        @testset "eig_simple" begin
+            λs1, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :right)
+            λs2, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :left)
 
-        @test_throws Arblib.EigenvalueComputationError Arblib.eig_simple(N)
+            @test all(Arblib.containszero, λs1 - λs2)
 
-        λ_approx, R_approx = Arblib.approx_eig_qr(N)
-        v = sortperm(λ_approx, by = abs, rev = true)
+            λs1, _ = Arblib.eig_simple_rump(M, side = :right)
+            λs2, _ = Arblib.eig_simple_rump(M, side = :left)
+            @test all(Arblib.containszero, λs1 - λs2)
 
-        λ = Acb(prec = precision(N))
-        R = similar(N, (3, 1))
-        Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:1]])
-        @test !isfinite(λ)
+            λs1, _ = Arblib.eig_simple(M, side = :right)
+            λs2, _ = Arblib.eig_simple(M, side = :left)
+            @test all(Arblib.containszero, λs1 - λs2)
 
-        λ = Acb(prec = precision(N))
-        R = similar(N, (3, 1))
-        Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[3]], R_approx[:, v[3:3]])
-        @test isfinite(λ)
-        @test Arblib.contains_zero(λ - evs[3])
+            λs = similar(M, size(M, 1))
+            Arblib.eig_simple_vdhoeven_mourrain!(λs, M)
+            @test all(Arblib.containszero, λs - λs1)
 
-        λ = Acb(prec = precision(N))
-        R = similar(N, (3, 2))
-        Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:2]])
-        @test isfinite(λ)
-        @test Arblib.contains_zero(λ - 2)
-        @test all(Arblib.contains_zero.(N * R - R * λ))
+            λs = similar(M, size(M, 1))
+            Arblib.eig_simple_rump!(λs, M)
+            @test all(Arblib.containszero, λs - λs1)
 
-        λ = Acb(prec = precision(N))
-        R = similar(N, (3, 2))
-        J = similar(N, (2, 2))
+            λs = similar(M, size(M, 1))
+            Arblib.eig_simple!(λs, M)
+            @test all(Arblib.containszero, λs - λs1)
+        end
 
-        Arblib.eig_enclosure_rump!(λ, J, R, N, λ_approx[v[2]], R_approx[:, v[1:2]])
-        @test Arblib.contains_zero(λ - 2)
-        @test all(Arblib.contains_zero.(N * R - R * J))
+        N = similar(M)
+        evs = [Arb(2.0), Arb(2.0), Arb(rand())]
+        N[1, 1], N[2, 2], N[3, 3] = evs
+
+        N = M * N * M^-1
+
+        @testset "enclosures" begin
+            ε = Arblib.Mag()
+            tol = 1e-12
+            λ_approx, R_approx = Arblib.approx_eig_qr(M, tol = tol)
+
+            @test Arblib.eig_global_enclosure!(
+                ε,
+                M,
+                λ_approx,
+                R_approx;
+                prec = precision(M),
+            ) isa Arblib.Mag
+
+            @test ε <= tol
+
+            λs = similar(M, size(M, 1))
+            Arblib.eig_simple!(λs, M, λ_approx, R_approx)
+
+            for λa in λ_approx
+                a_real = let x = real(λa)
+                    m = Arblib.midref(x)
+                    r = Arblib.radref(x)
+                    Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
+                end
+
+                a_imag = let x = imag(λa)
+                    m = Arblib.midref(x)
+                    r = Arblib.radref(x)
+                    Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
+                end
+
+                a = Acb(a_real, a_imag)
+                @test any(Arblib.containszero(a - λ) for λ in λs)
+            end
+
+
+            @test_throws Arblib.EigenvalueComputationError Arblib.eig_simple(N)
+
+            λ_approx, R_approx = Arblib.approx_eig_qr(N)
+            v = sortperm(λ_approx, by = abs, rev = true)
+
+            λ = Acb(prec = precision(N))
+            R = similar(N, (3, 1))
+            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:1]])
+            @test !isfinite(λ)
+
+            λ = Acb(prec = precision(N))
+            R = similar(N, (3, 1))
+            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[3]], R_approx[:, v[3:3]])
+            @test isfinite(λ)
+            @test Arblib.contains_zero(λ - evs[3])
+
+            λ = Acb(prec = precision(N))
+            R = similar(N, (3, 2))
+            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:2]])
+            @test isfinite(λ)
+            @test Arblib.contains_zero(λ - 2)
+            @test all(Arblib.contains_zero.(N * R - R * λ))
+
+            λ = Acb(prec = precision(N))
+            R = similar(N, (3, 2))
+            J = similar(N, (2, 2))
+
+            Arblib.eig_enclosure_rump!(λ, J, R, N, λ_approx[v[2]], R_approx[:, v[1:2]])
+            @test Arblib.contains_zero(λ - 2)
+            @test all(Arblib.contains_zero.(N * R - R * J))
+        end
+
+        @testset "eig_multiple" begin
+            λs = similar(N, 3)
+            @test Arblib.eig_multiple_rump(N) isa VecT
+            Arblib.eig_multiple_rump!(λs, N)
+
+            v = sortperm(λs, by = abs, rev = true)
+            @test all(Arblib.contains_zero.(λs[v] - evs))
+
+            @test Arblib.eig_multiple(N) isa VecT
+            Arblib.eig_multiple!(λs, N)
+
+            v = sortperm(λs, by = abs, rev = true)
+            @test all(Arblib.contains_zero.(λs[v] - evs))
+        end
     end
 
-    @testset "eig_multiple" begin
-        λs = similar(N, 3)
-        @test Arblib.eig_multiple_rump(N) isa VecT
-        Arblib.eig_multiple_rump!(λs, N)
+    @testset "eigenvalues/eigenvectors: acb_mat_struct" begin
+        # We only run very limited tests for this type to see that the
+        # functions run. We don't actually check the return values,
+        # just that the functions run.
+        A = [
+            0.6873474041954415 0.7282180564881044 0.07360652513458521
+            0.000835810121029068 0.9256166870757694 0.5363310989411239
+            0.07387174694790022 0.4050436025621329 0.20226010388885896
+        ]
+        B = [
+            0.8982563031334123 0.3029712969740874 0.8585014523679579
+            0.7583002736998279 0.8854763478184455 0.3031103325817668
+            0.2319572749472405 0.5769840251057949 0.5119507333628952
+        ]
+        M = AcbMatrix(A + B * im, prec = 64).acb_mat
+        eigvals_approx = AcbVector(3).acb_vec
+        eigvecs_approx = AcbMatrix(3, 3).acb_mat
+        eigvals = AcbVector(3).acb_vec
+        eigvecs = AcbMatrix(3, 3).acb_mat
 
-        v = sortperm(λs, by = abs, rev = true)
-        @test all(Arblib.contains_zero.(λs[v] - evs))
+        @test Arblib.approx_eig_qr!(eigvals_approx, eigvecs_approx, M, side = :left) isa
+              Arblib.acb_vec_struct
+        @test Arblib.approx_eig_qr!(eigvals_approx, eigvecs_approx, M, side = :right) isa
+              Arblib.acb_vec_struct
+        @test Arblib.approx_eig_qr!(eigvals_approx, M) isa Arblib.acb_vec_struct
 
-        @test Arblib.eig_multiple(N) isa VecT
-        Arblib.eig_multiple!(λs, N)
+        @test Arblib.eig_simple!(
+            eigvals,
+            eigvecs,
+            M,
+            eigvals_approx,
+            eigvecs_approx,
+            side = :right,
+        ) isa Arblib.acb_vec_struct
+        @test Arblib.eig_simple!(
+            eigvals,
+            eigvecs,
+            M,
+            eigvals_approx,
+            eigvecs_approx,
+            side = :left,
+        ) isa Arblib.acb_vec_struct
+        @test Arblib.eig_simple!(eigvals, M, eigvals_approx, eigvecs_approx) isa
+              Arblib.acb_vec_struct
+        @test Arblib.eig_simple!(eigvals, M, eigvals_approx, eigvecs_approx) isa
+              Arblib.acb_vec_struct
 
-        v = sortperm(λs, by = abs, rev = true)
-        @test all(Arblib.contains_zero.(λs[v] - evs))
+        @test Arblib.eig_enclosure_rump!(
+            Acb().acb,
+            AcbMatrix(3, 1).acb_mat,
+            M,
+            eigvals[1],
+            AcbMatrix(eigvecs_approx)[:, 1:1].acb_mat,
+        ) isa Arblib.acb_struct
     end
 end

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -155,6 +155,15 @@
 
             @test Arblib.contains(sort(LinearAlgebra.eigvals(N), by = abs), AcbVector(evs))
 
+            @test_throws Arblib.EigenvalueComputationError Arblib.eig_multiple_rump(
+                AcbMatrix(fill(NaN, 3, 3)),
+            )
+            @test_throws Arblib.EigenvalueComputationError Arblib.eig_multiple(
+                AcbMatrix(fill(NaN, 3, 3)),
+            )
+            @test_throws Arblib.EigenvalueComputationError LinearAlgebra.eigvals(
+                AcbMatrix(fill(NaN, 3, 3)),
+            )
         end
     end
 

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -1,17 +1,18 @@
 @testset "eigen" begin
+    # Gives an invertible matrix A + B * im used for testing
+    A = [
+        0.68 0.72 0.07
+        0.01 0.92 0.53
+        0.07 0.40 0.20
+    ]
+    B = [
+        0.89 0.30 0.85
+        0.75 0.88 0.30
+        0.23 0.57 0.51
+    ]
+
     @testset "eigenvalues/eigenvectors: $MatT" for MatT in (AcbMatrix, AcbRefMatrix)
-        A = [
-            0.6873474041954415 0.7282180564881044 0.07360652513458521
-            0.000835810121029068 0.9256166870757694 0.5363310989411239
-            0.07387174694790022 0.4050436025621329 0.20226010388885896
-        ]
-        B = [
-            0.8982563031334123 0.3029712969740874 0.8585014523679579
-            0.7583002736998279 0.8854763478184455 0.3031103325817668
-            0.2319572749472405 0.5769840251057949 0.5119507333628952
-        ]
         M = MatT(A + B * im, prec = 64)
-        # M = MatT(rand(3, 3) + im * rand(3, 3), prec = 64)
 
         VecT = typeof(similar(M, 3))
 
@@ -20,9 +21,9 @@
             @test λs_a_r isa VecT
             @test revs_a isa MatT
 
-            ε = 1e-10
+            ε = Mag(1e-10)
 
-            λs_a_l, revs_a = Arblib.approx_eig_qr(M, tol = Arblib.Mag(ε), side = :left)
+            λs_a_l, revs_a = Arblib.approx_eig_qr(M, tol = ε, side = :left)
             @test λs_a_l isa VecT
             @test revs_a isa MatT
 
@@ -30,44 +31,42 @@
 
             λs_r = similar(M, size(M, 1))
             Arblib.approx_eig_qr!(λs_r, M)
-            @test Arblib.is_zero(λs_r - λs_a_r, length(λs_r))
+            @test isequal(λs_r, λs_a_r)
+
+            λs_l = similar(M, size(M, 1))
+            Arblib.approx_eig_qr!(λs_l, M, tol = ε)
+            @test isequal(λs_l, λs_a_l)
         end
 
         @testset "eig_simple" begin
             λs1, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :right)
             λs2, _ = Arblib.eig_simple_vdhoeven_mourrain(M, side = :left)
 
-            @test all(Arblib.containszero, λs1 - λs2)
+            @test Arblib.overlaps(λs1, λs2)
 
             λs1, _ = Arblib.eig_simple_rump(M, side = :right)
             λs2, _ = Arblib.eig_simple_rump(M, side = :left)
-            @test all(Arblib.containszero, λs1 - λs2)
+            @test Arblib.overlaps(λs1, λs2)
 
             λs1, _ = Arblib.eig_simple(M, side = :right)
             λs2, _ = Arblib.eig_simple(M, side = :left)
-            @test all(Arblib.containszero, λs1 - λs2)
+            @test Arblib.overlaps(λs1, λs2)
 
             λs = similar(M, size(M, 1))
             Arblib.eig_simple_vdhoeven_mourrain!(λs, M)
-            @test all(Arblib.containszero, λs - λs1)
+            @test Arblib.overlaps(λs, λs1)
 
             λs = similar(M, size(M, 1))
             Arblib.eig_simple_rump!(λs, M)
-            @test all(Arblib.containszero, λs - λs1)
+            @test Arblib.overlaps(λs, λs1)
 
             λs = similar(M, size(M, 1))
             Arblib.eig_simple!(λs, M)
-            @test all(Arblib.containszero, λs - λs1)
+            @test Arblib.overlaps(λs, λs1)
         end
 
-        N = similar(M)
-        evs = [Arb(2.0), Arb(2.0), Arb(rand())]
-        N[1, 1], N[2, 2], N[3, 3] = evs
-
-        N = M * N * M^-1
-
-        @testset "enclosures" begin
-            ε = Arblib.Mag()
+        @testset "enclosures - simple" begin
+            ε = Mag()
             tol = 1e-12
             λ_approx, R_approx = Arblib.approx_eig_qr(M, tol = tol)
 
@@ -81,72 +80,81 @@
 
             @test ε <= tol
 
+            @test Arblib.eig_global_enclosure(M, λ_approx, R_approx) <= tol
+
             λs = similar(M, size(M, 1))
             Arblib.eig_simple!(λs, M, λ_approx, R_approx)
 
-            for λa in λ_approx
-                a_real = let x = real(λa)
-                    m = Arblib.midref(x)
-                    r = Arblib.radref(x)
-                    Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
-                end
+            @test all(
+                any(Arblib.overlaps(add_error(Acb(λa), ε), λ) for λ in λs) for
+                λa in λ_approx
+            )
+        end
 
-                a_imag = let x = imag(λa)
-                    m = Arblib.midref(x)
-                    r = Arblib.radref(x)
-                    Arblib.set_interval!(x, m - (r + ε), m + (r + ε))
-                end
+        # Take N to be a matrix with an eigenvalue of multiplicity 2,
+        # specifically the eigenvalues [0.3, 2, 2]. Used to test the
+        # multiple eigenvalue code.
+        evs = Acb[0.3, 2, 2]
+        N = M * MatT(Diagonal(evs), prec = precision(M)) * inv(M)
 
-                a = Acb(a_real, a_imag)
-                @test any(Arblib.containszero(a - λ) for λ in λs)
-            end
-
-
+        @testset "enclosures - multiple" begin
             @test_throws Arblib.EigenvalueComputationError Arblib.eig_simple(N)
+            @test_throws "Failed to separate eigenvalues" Arblib.eig_simple(N)
 
             λ_approx, R_approx = Arblib.approx_eig_qr(N)
-            v = sortperm(λ_approx, by = abs, rev = true)
+            v = sortperm(λ_approx, by = abs)
 
             λ = Acb(prec = precision(N))
-            R = similar(N, (3, 1))
-            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:1]])
+            R1 = similar(N, (3, 1))
+            R2 = similar(N, (3, 2))
+            J2 = similar(N, (2, 2))
+
+            # Simple eigenvalue
+            Arblib.eig_enclosure_rump!(λ, R1, N, λ_approx[v[1]], R_approx[:, v[1:1]])
+            @test isfinite(λ)
+            @test Arblib.contains(λ, evs[1])
+
+            # Double eigenvalue with one dimensional basis
+            Arblib.eig_enclosure_rump!(λ, R1, N, λ_approx[v[2]], R_approx[:, v[2:2]])
             @test !isfinite(λ)
 
-            λ = Acb(prec = precision(N))
-            R = similar(N, (3, 1))
-            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[3]], R_approx[:, v[3:3]])
+            # Double eigenvalue with two dimensional basis
+            Arblib.eig_enclosure_rump!(λ, R2, N, λ_approx[v[2]], R_approx[:, v[2:3]])
             @test isfinite(λ)
-            @test Arblib.contains_zero(λ - evs[3])
+            @test Arblib.contains(λ, evs[2])
+            @test Arblib.overlaps(N * R2, R2 * λ)
 
-            λ = Acb(prec = precision(N))
-            R = similar(N, (3, 2))
-            Arblib.eig_enclosure_rump!(λ, R, N, λ_approx[v[1]], R_approx[:, v[1:2]])
-            @test isfinite(λ)
-            @test Arblib.contains_zero(λ - 2)
-            @test all(Arblib.contains_zero.(N * R - R * λ))
-
-            λ = Acb(prec = precision(N))
-            R = similar(N, (3, 2))
-            J = similar(N, (2, 2))
-
-            Arblib.eig_enclosure_rump!(λ, J, R, N, λ_approx[v[2]], R_approx[:, v[1:2]])
-            @test Arblib.contains_zero(λ - 2)
-            @test all(Arblib.contains_zero.(N * R - R * J))
+            Arblib.eig_enclosure_rump!(λ, J2, R2, N, λ_approx[v[2]], R_approx[:, v[2:3]])
+            @test Arblib.contains(λ, evs[2])
+            @test Arblib.overlaps(N * R2, R2 * J2)
         end
 
         @testset "eig_multiple" begin
-            λs = similar(N, 3)
-            @test Arblib.eig_multiple_rump(N) isa VecT
-            Arblib.eig_multiple_rump!(λs, N)
+            λ_approx, R_approx = Arblib.approx_eig_qr(N)
 
-            v = sortperm(λs, by = abs, rev = true)
-            @test all(Arblib.contains_zero.(λs[v] - evs))
+            λs1 = Arblib.eig_multiple_rump(N)
+            λs2 = Arblib.eig_multiple_rump(N, λ_approx, R_approx)
+            λs3 = similar(N, 3)
+            Arblib.eig_multiple_rump!(λs3, N)
+            @test λs1 isa VecT
+            @test λs2 isa VecT
+            @test λs3 isa VecT
+            @test allequal((λs1, λs2, λs3))
+            @test Arblib.contains(sort(λs1, by = abs), AcbVector(evs))
 
-            @test Arblib.eig_multiple(N) isa VecT
-            Arblib.eig_multiple!(λs, N)
 
-            v = sortperm(λs, by = abs, rev = true)
-            @test all(Arblib.contains_zero.(λs[v] - evs))
+            λs1 = Arblib.eig_multiple(N)
+            λs2 = Arblib.eig_multiple(N, λ_approx, R_approx)
+            λs3 = similar(N, 3)
+            Arblib.eig_multiple!(λs3, N)
+            @test λs1 isa VecT
+            @test λs2 isa VecT
+            @test λs3 isa VecT
+            @test allequal((λs1, λs2, λs3))
+            @test Arblib.contains(sort(λs1, by = abs), AcbVector(evs))
+
+            @test Arblib.contains(sort(LinearAlgebra.eigvals(N), by = abs), AcbVector(evs))
+
         end
     end
 
@@ -154,16 +162,6 @@
         # We only run very limited tests for this type to see that the
         # functions run. We don't actually check the return values,
         # just that the functions run.
-        A = [
-            0.6873474041954415 0.7282180564881044 0.07360652513458521
-            0.000835810121029068 0.9256166870757694 0.5363310989411239
-            0.07387174694790022 0.4050436025621329 0.20226010388885896
-        ]
-        B = [
-            0.8982563031334123 0.3029712969740874 0.8585014523679579
-            0.7583002736998279 0.8854763478184455 0.3031103325817668
-            0.2319572749472405 0.5769840251057949 0.5119507333628952
-        ]
         M = AcbMatrix(A + B * im, prec = 64).acb_mat
         eigvals_approx = AcbVector(3).acb_vec
         eigvecs_approx = AcbMatrix(3, 3).acb_mat
@@ -176,26 +174,25 @@
               Arblib.acb_vec_struct
         @test Arblib.approx_eig_qr!(eigvals_approx, M) isa Arblib.acb_vec_struct
 
-        @test Arblib.eig_simple!(
-            eigvals,
-            eigvecs,
+        @testset "$f" for f in (
+            Arblib.eig_simple!,
+            Arblib.eig_simple_rump!,
+            Arblib.eig_simple_vdhoeven_mourrain!,
+        )
+            @test f(eigvals, eigvecs, M, eigvals_approx, eigvecs_approx, side = :right) isa
+                  Arblib.acb_vec_struct
+            @test f(eigvals, eigvecs, M, eigvals_approx, eigvecs_approx, side = :left) isa
+                  Arblib.acb_vec_struct
+            @test f(eigvals, M, eigvals_approx, eigvecs_approx) isa Arblib.acb_vec_struct
+        end
+
+        @test Arblib.eig_global_enclosure!(
+            Mag().mag,
             M,
             eigvals_approx,
             eigvecs_approx,
-            side = :right,
-        ) isa Arblib.acb_vec_struct
-        @test Arblib.eig_simple!(
-            eigvals,
-            eigvecs,
-            M,
-            eigvals_approx,
-            eigvecs_approx,
-            side = :left,
-        ) isa Arblib.acb_vec_struct
-        @test Arblib.eig_simple!(eigvals, M, eigvals_approx, eigvecs_approx) isa
-              Arblib.acb_vec_struct
-        @test Arblib.eig_simple!(eigvals, M, eigvals_approx, eigvecs_approx) isa
-              Arblib.acb_vec_struct
+            prec = 64,
+        ) isa Arblib.mag_struct
 
         @test Arblib.eig_enclosure_rump!(
             Acb().acb,
@@ -203,6 +200,14 @@
             M,
             eigvals[1],
             AcbMatrix(eigvecs_approx)[:, 1:1].acb_mat,
+        ) isa Arblib.acb_struct
+        @test Arblib.eig_enclosure_rump!(
+            Acb().acb,
+            AcbMatrix(2, 2).acb_mat,
+            AcbMatrix(3, 2).acb_mat,
+            M,
+            eigvals[1],
+            AcbMatrix(eigvecs_approx)[:, 1:2].acb_mat,
         ) isa Arblib.acb_struct
     end
 end

--- a/test/ref.jl
+++ b/test/ref.jl
@@ -1,4 +1,5 @@
 @testset "MagRef" begin
+    @test MagRef() isa Mag
     @test isequal(MagRef(), Mag())
 
     x = Arb()
@@ -12,6 +13,11 @@
     z = Arblib.radref(x)[]
     Arblib.set!(z, 4)
     @test Arblib.radref(x) == Mag(2)
+
+    # Ptr input
+    @test isnothing(
+        Arblib.radref(Ptr{Arblib.arb_struct}(pointer_from_objref(Arb().arb))).parent,
+    )
 
     @test isequal(zero(MagRef), zero(Mag))
     @test isequal(zero(Arblib.radref(x)), zero(Mag))
@@ -50,6 +56,17 @@ end
     Arblib.set!(Arblib.imagref(w), 3)
     @test w == Acf(2, 3)
     @test Arblib.imagref(w) == Arf(3)
+
+    # Ptr input
+    @test isnothing(
+        Arblib.midref(Ptr{Arblib.arb_struct}(pointer_from_objref(Arb().arb))).parent,
+    )
+    @test isnothing(
+        Arblib.realref(Ptr{Arblib.acf_struct}(pointer_from_objref(Acf().acf))).parent,
+    )
+    @test isnothing(
+        Arblib.imagref(Ptr{Arblib.acf_struct}(pointer_from_objref(Acf().acf))).parent,
+    )
 
     @test isequal(zero(ArfRef), zero(Arf))
     @test isequal(zero(Arblib.midref(x)), zero(Arf))
@@ -113,6 +130,14 @@ end
     z = Arblib.realref(x)[]
     Arblib.set!(z, 4)
     @test Arblib.realref(x) == Arf(2)
+
+    # Ptr input
+    @test isnothing(
+        Arblib.realref(Ptr{Arblib.acb_struct}(pointer_from_objref(Acb().acb))).parent,
+    )
+    @test isnothing(
+        Arblib.imagref(Ptr{Arblib.acb_struct}(pointer_from_objref(Acb().acb))).parent,
+    )
 
     @test isequal(zero(ArbRef), zero(Arb))
     @test isequal(zero(Arblib.realref(x)), zero(Arb))


### PR DESCRIPTION
I ran the `report_package` function from [JET.jl](https://github.com/aviatesk/JET.jl). It have a lot of false positives (mostly related to pessimistic union splitting), but also surfaced some real issues that I fixed. While fixing them I made some other minor adjustments as well. None of the fixes are particularly important, most of them are related to the low level struct types not implementing some functionality. The most relevant fixes are:

- Define `length` for vector structs and `size(A, d)` for matrix structs. Also update the eigenvalue functions to use length for vectors. While updating the eigenvalue functions I also made some minor adjustments to error messages and a bit of cleanup.
- I added `Nothing` as a possible parent type for all Ref types. Previously only `AcbRef` and `AcfRef` supported it. What made me add it to the other ones as well was that `parentstruct` was previously not defined for pointers to structs. This was a problem since e.g. `ArbLike` is given by `Union{Arb,ArbRef,cstructtype(Arb),Ptr{cstructtype(Arb)}}` and hence all functions using `parentstruct` and accepting `ArbLike` would not work for `Ptr{cstructtype(Arb)}`. In practice this is probably not very common and we basically do not have any tests for this. Nevertheless it felt like a reasonable fix to do.
- Some other minor fixes that should not be visible to users.

I set the version to 1.8.1 and will make a patch release with the fixes.