### PR TITLE
Add high level interface for FFT

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(
             "Types" => "interface-types.md",
             "Ball methods" => "interface-ball.md",
             "Integration" => "interface-integration.md",
+            "FFT" => "interface-fft.md",
             "Series" => "interface-series.md",
             "Mutable arithmetic" => "interface-mutable.md",
             "Precision" => "precision.md",

--- a/docs/src/interface-fft.md
+++ b/docs/src/interface-fft.md
@@ -1,0 +1,7 @@
+``` @docs
+Arblib.fft
+Arblib.ifft
+Arblib.fft!
+Arblib.ifft!
+Arblib.AcbFFTPlan
+```

--- a/src/ArbCall/ArbArgTypes.jl
+++ b/src/ArbCall/ArbArgTypes.jl
@@ -60,6 +60,8 @@ const arbargtypes = ArbArgTypes(
         "arb_poly_t" => ArbPoly,
         # acb_poly.h
         "acb_poly_t" => AcbPoly,
+        # acb_dft.h
+        "acb_dft_pre_t" => acb_dft_pre_struct,
         # arb_mat.h
         "arb_mat_t" => ArbMatrix,
         # acb_mat.h
@@ -102,6 +104,8 @@ const arbargtypes = ArbArgTypes(
         ArbPoly => "arb_poly_t",
         # acb_poly.h
         AcbPoly => "acb_poly_t",
+        # acb_dft.h
+        acb_dft_pre_struct => "acb_dft_pre_t",
         # arb_mat.h
         ArbMatrix => "arb_mat_t",
         # acb_mat.h

--- a/src/ArbCall/ArbCall.jl
+++ b/src/ArbCall/ArbCall.jl
@@ -22,6 +22,7 @@ import ..Arblib:
     acb_poly_struct,
     arb_mat_struct,
     acb_mat_struct,
+    acb_dft_pre_struct,
     MagLike,
     ArfLike,
     AcfLike,

--- a/src/ArbCall/Carg.jl
+++ b/src/ArbCall/Carg.jl
@@ -103,7 +103,7 @@ The type that should be used for the argument when passed to C code.
 """
 ctype(ca::Carg) = rawtype(ca)
 ctype(::Carg{Vector{T}}) where {T} = Ref{T}
-ctype(::Carg{T}) where {T<:Union{BigFloat,BigInt}} = Ref{T}
+ctype(::Carg{T}) where {T<:Union{BigFloat,BigInt,acb_dft_pre_struct}} = Ref{T}
 ctype(::Carg{T}) where {T<:Union{Mag,Arf,Acf,Arb,Acb,ArbPoly,AcbPoly,ArbMatrix,AcbMatrix}} =
     Ref{cstructtype(T)}
 ctype(::Carg{T}) where {T<:Union{ArbVector,arb_vec_struct}} = Ptr{arb_struct}

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -48,6 +48,7 @@ function flint_set_num_threads(a::Integer)
     end
 end
 
+include("gr_types.jl")
 include("arb_types.jl")
 include("fmpz.jl")
 include("rounding_types.jl")

--- a/src/Arblib.jl
+++ b/src/Arblib.jl
@@ -85,6 +85,7 @@ include("eigen.jl")
 include("poly.jl")
 include("calc_integrate.jl")
 include("special-functions.jl")
+include("fft.jl")
 
 include("arbcalls/mag.jl")
 include("arbcalls/arf.jl")

--- a/src/arb_types.jl
+++ b/src/arb_types.jl
@@ -256,6 +256,9 @@ function Base.deepcopy_internal(
     return y
 end
 
+# In Flint acb_dft_pre_t is an alias for gr_dft_acb_pre_t
+const acb_dft_pre_struct = gr_dft_acb_pre_struct
+
 """
     calc_integrate_opt_struct
 """

--- a/src/arbcalls/acb_dft.jl
+++ b/src/arbcalls/acb_dft.jl
@@ -5,10 +5,10 @@
 ### Main DFT functions
 arbcall"void acb_dft(acb_ptr w, acb_srcptr v, slong len, slong prec)"
 arbcall"void acb_dft_inverse(acb_ptr w, acb_srcptr v, slong len, slong prec)"
-#ni arbcall"void acb_dft_precomp_init(acb_dft_pre_t pre, slong len, slong prec)"
-#ni arbcall"void acb_dft_precomp_clear(acb_dft_pre_t pre)"
-#ni arbcall"void acb_dft_precomp(acb_ptr w, acb_srcptr v, const acb_dft_pre_t pre, slong prec)"
-#ni arbcall"void acb_dft_inverse_precomp(acb_ptr w, acb_srcptr v, const acb_dft_pre_t pre, slong prec)"
+arbcall"void acb_dft_precomp_init(acb_dft_pre_t pre, slong len, slong prec)"
+arbcall"void acb_dft_precomp_clear(acb_dft_pre_t pre)"
+arbcall"void acb_dft_precomp(acb_ptr w, acb_srcptr v, const acb_dft_pre_t pre, slong prec)"
+arbcall"void acb_dft_inverse_precomp(acb_ptr w, acb_srcptr v, const acb_dft_pre_t pre, slong prec)"
 
 ### DFT on products
 arbcall"void acb_dft_prod(acb_ptr w, acb_srcptr v, slong * cyc, slong num, slong prec)"

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -1,0 +1,108 @@
+"""
+    AcbFFTPlan(len::Integer; prec::Integer = _current_precision())
+
+Precomputed FFT plan for use with [`fft`](@ref) and [`fft!`](@ref), as
+well as their inverse counterparts.
+
+Precomputing a plan can speed up computations when multiple FFTs of
+the same size are computed.
+
+An optimal plan is automatically determined based on the given
+arguments.
+"""
+struct AcbFFTPlan
+    plan::acb_dft_pre_struct
+
+    function AcbFFTPlan(len::Integer; prec::Integer = _current_precision())
+        return new(acb_dft_pre_struct(len; prec))
+    end
+end
+
+fft_plan_size(plan::AcbFFTPlan) = plan.plan.n
+
+_precision_with_base_2(plan::AcbFFTPlan) = plan.plan.prec
+Base.precision(plan::AcbFFTPlan; base::Integer = 2) = _precision_in_base(plan, base)
+
+function Base.show(io::IO, plan::AcbFFTPlan)
+    print(io, "AcbFFTPlan($(fft_plan_size(plan)); prec = $(precision(plan)))")
+end
+
+"""
+    fft!(w::AcbVectorOrRef, v::AcbVectorOrRef[, plan::AcbFFTPlan])
+
+Compute the FFT of `v`, storing the result inplace in `w`. It
+optionally takes a precomputed [`AcbFFTPlan`](@ref).
+
+The input and output are allowed to alias.
+
+See also [`fft`](@ref) and [`ifft!`](@ref)
+"""
+function fft!(w::AcbVectorOrRef, v::AcbVectorOrRef)
+    @boundscheck (
+        length(v) == length(w) ||
+        throw(DimensionMismatch("v has size $(length(v)), w has size $(length(w))"))
+    )
+    return dft!(w, v)
+end
+
+function fft!(w::AcbVectorOrRef, v::AcbVectorOrRef, plan::AcbFFTPlan)
+    @boundscheck (
+        length(v) == length(w) ||
+        throw(DimensionMismatch("v has size $(length(v)), w has size $(length(w))"))
+    )
+    @boundscheck length(v) == fft_plan_size(plan) || throw(
+        DimensionMismatch("v has size $(length(v)), plan has size $(fft_plan_size(plan))"),
+    )
+    return dft_precomp!(w, v, plan.plan)
+end
+
+"""
+    fft(v::AcbVectorOrRef[, plan::AcbFFTPlan])
+
+Compute the FFT of `v`. It optionally takes a precomputed
+[`AcbFFTPlan`](@ref).
+
+See also [`fft!`](@ref) and [`ifft`](@ref)
+"""
+fft(v::AcbVectorOrRef) = fft!(similar(v), v)
+fft(v::AcbVectorOrRef, plan::AcbFFTPlan) = fft!(similar(v), v, plan)
+
+"""
+    ifft!(w::AcbVectorOrRef, v::AcbVectorOrRef[, plan::AcbFFTPlan])
+
+Compute the inverse FFT of `v`, storing the result inplace in `w`. It
+optionally takes a precomputed [`AcbFFTPlan`](@ref).
+
+The input and output are allowed to alias.
+
+See also [`ifft`](@ref) and [`fft!`](@ref)
+"""
+function ifft!(w::AcbVectorOrRef, v::AcbVectorOrRef)
+    @boundscheck (
+        length(v) == length(w) ||
+        throw(DimensionMismatch("v has size $(length(v)), w has size $(length(w))"))
+    )
+    return dft_inverse!(w, v)
+end
+
+function ifft!(w::AcbVectorOrRef, v::AcbVectorOrRef, plan::AcbFFTPlan)
+    @boundscheck (
+        length(v) == length(w) ||
+        throw(DimensionMismatch("v has size $(length(v)), w has size $(length(w))"))
+    )
+    @boundscheck length(v) == fft_plan_size(plan) || throw(
+        DimensionMismatch("v has size $(length(v)), plan has size $(fft_plan_size(plan))"),
+    )
+    return dft_inverse_precomp!(w, v, plan.plan)
+end
+
+"""
+    ifft(v::AcbVectorOrRef[, plan::AcbFFTPlan])
+
+Compute the inverse FFT of `v`. It optionally takes a precomputed
+[`AcbFFTPlan`](@ref)
+
+See also [`ifft!`](@ref) and [`fft`](@ref)
+"""
+ifft(v::AcbVectorOrRef) = ifft!(similar(v), v)
+ifft(v::AcbVectorOrRef, plan::AcbFFTPlan) = ifft!(similar(v), v, plan)

--- a/src/gr_types.jl
+++ b/src/gr_types.jl
@@ -1,0 +1,158 @@
+"""
+    GRDomainError()
+
+Used to throw an error corresponding to the `GR_DOMAIN` flag in Flint.
+
+The Flint documentation gives the following description of this flag.
+
+> The result does not have a value in the domain of the target ring or
+> type, i.e. the result is mathematically undefined. This occurs, for
+> example, on division by zero or when attempting to compute the
+> square root of a non-square. It also occurs when attempting to
+> convert a too large value to a bounded type (example: `get_ui()`
+> with input ``n \\geq 2^64``).
+
+See also [`GRUnableError`](@ref).
+"""
+struct GRDomainError <: Exception end
+
+"""
+    GRUnableError()
+
+Used to throw an error corresponding to the `GR_UNABLE` flag in Flint.
+
+The Flint documentation gives the following description of this flag.
+
+> The operation could not be performed because of limitations of the
+> implementation or the data representation, i.e. the result is
+> unknown. Typical reasons:
+> - The result would be too large to fit in memory
+> - The inputs are inexact and an exact comparison is needed
+> - The computation would take too long
+> - An algorithm is not yet implemented for this case
+> If this flag is set, there is also potentially a domain error (but
+>  this is unknown).
+
+See also [`GRDomainError`](@ref).
+"""
+struct GRUnableError <: Exception end
+
+"""
+    gr_handle_flag(flag::Cint)
+
+Handle a GR return flag returned from a Flint function. If the flag is
+zero it returns `nothing`, otherwise it throws an error depending on
+the flag.
+
+It first checks if the `GR_UNABLE` flag is set, in which case it
+throws a [`GRUnableError`](@ref), it then checks if the `GR_DOMAIN`
+flag is set, in which case it throws a [`GRDomainError`](@ref). If
+none of these flags are set (and the result is non-zero) it throws an
+[`ErrorException`](@ref) for an unknown GR return flag.
+"""
+function gr_handle_flag(flag::Cint)
+    if iszero(flag)
+        return nothing
+    elseif !iszero(flag & Cint(2))
+        throw(GRUnableError())
+    elseif !iszero(flag & Cint(1))
+        throw(GRDomainError())
+    else
+        throw(ErrorException("unknown GR return flag $flag"))
+    end
+end
+
+const GR_CTX_STRUCT_DATA_BYTES = 6 * sizeof(UInt)
+# This type is currently unused. At the moment it only serves to
+# determine the size of gr_dft_acb_pre_struct. A proper wrapper of the
+# generic ring interface is future work.
+mutable struct gr_ctx_struct
+    data::NTuple{GR_CTX_STRUCT_DATA_BYTES,UInt8}
+    which_ring::UInt
+    sizeof_elem::Int
+    methods::Ptr{Cvoid}
+    size_limit::UInt
+
+    global _gr_ctx_struct() = new()
+end
+
+# This type is currently unused. At the moment it only serves to
+# determine the size of gr_dft_acb_pre_struct. A proper wrapper of the
+# generic ring interface is future work.
+mutable struct gr_dft_pre_struct
+    n::UInt
+    depth::Cint
+    alg::Cint
+    flags::Cint
+    ctx::Ptr{Cvoid}
+    real_ctx::Ptr{Cvoid}
+    roots::Ptr{Cvoid}
+    stage_tab::Ptr{Cvoid}
+    stage_len::Int
+    wtab::Ptr{Cvoid}
+    wclass::Ptr{UInt8}
+    n1::UInt
+    n2::UInt
+    pfa_a::UInt
+    pfa_b::UInt
+    radices::Ptr{UInt}
+    num_radices::Int
+    conv_len::UInt
+    bl_kern::Ptr{Cvoid}
+    bl_wtab::Ptr{Cvoid}
+    P1::Ptr{gr_dft_pre_struct}
+    P2::Ptr{gr_dft_pre_struct}
+    threads::Ptr{Cint}
+    num_threads::Int
+    serial_block::Int
+    nfixed_root_err::Cdouble
+    bl_shifted::Cint
+
+    global _gr_dft_pre_struct() = new()
+end
+
+"""
+    gr_dft_acb_pre_struct(len::Integer; prec::Integer = _current_precision())
+
+Precomputed plan for discrete Fourier transforms of length `len` on
+`acb` at precision `prec`.
+
+The plan is created by Flint, which also owns the memory it points to.
+For this reason the fields should be considered opaque, only `n` and
+`prec` are read directly.
+
+See [`AcbFFTPlan`](@ref) for the high level interface.
+"""
+mutable struct gr_dft_acb_pre_struct
+    n::Int
+    prec::Int
+    which::Cint
+    nl::Int
+    p1e::Int
+    in_mag::Float64
+    errulps::Float64
+    rctx::NTuple{sizeof(gr_ctx_struct),UInt8} # gr_ctx_struct
+    cctx::NTuple{sizeof(gr_ctx_struct),UInt8} # gr_ctx_struct
+    P::NTuple{sizeof(gr_dft_pre_struct),UInt8} # gr_dft_pre_struct
+
+    function gr_dft_acb_pre_struct(len::Integer; prec::Integer = _current_precision())
+        res = new()
+        flag = @ccall libflint.gr_dft_acb_precomp_init(
+            res::Ref{gr_dft_acb_pre_struct},
+            len::Int,
+            prec::Int,
+        )::Cint
+        gr_handle_flag(flag)
+        finalizer(res) do Q
+            @ccall libflint.gr_dft_acb_precomp_clear(Q::Ref{gr_dft_acb_pre_struct})::Cvoid
+        end
+        return res
+    end
+end
+
+function Base.deepcopy_internal(x::gr_dft_acb_pre_struct, stackdict::IdDict)
+    haskey(stackdict, x) && return stackdict[x]
+    y = gr_dft_acb_pre_struct(x.n; prec = x.prec)
+    stackdict[x] = y
+    return y
+end

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -1,0 +1,95 @@
+@testset "fft" begin
+    AcbFFTPlan = Arblib.AcbFFTPlan
+
+    @testset "AcbFFTPlan" begin
+        @test Arblib.fft_plan_size(AcbFFTPlan(1)) == 1
+        @test Arblib.fft_plan_size(AcbFFTPlan(8)) == 8
+        @test Arblib.fft_plan_size(AcbFFTPlan(64)) == 64
+
+        @test precision(AcbFFTPlan(1)) == precision(Arb)
+        @test precision(AcbFFTPlan(1, prec = 80)) == 80
+        @test precision(AcbFFTPlan(1, prec = 80), base = 4) == 40
+
+        @test_throws Arblib.GRDomainError AcbFFTPlan(0)
+        @test_throws Arblib.GRDomainError AcbFFTPlan(-1)
+
+        let plan = AcbFFTPlan(8, prec = 80), plan_copy = deepcopy(plan)
+            # The copy owns its own Flint data
+            @test plan_copy.plan !== plan.plan
+            @test Arblib.fft_plan_size(plan_copy) == 8
+            @test precision(plan_copy) == 80
+
+            v = AcbVector(1:8, prec = 80)
+            @test isequal(Arblib.fft(v, plan_copy), Arblib.fft(v, plan))
+        end
+    end
+
+    # Test good path
+    n = 128
+    v = AcbVector(1:n)
+
+    plan = AcbFFTPlan(n)
+
+    w1 = Arblib.fft(v)
+    w2 = Arblib.fft(v, plan)
+    w3 = Arblib.fft!(similar(v), v)
+    w4 = Arblib.fft!(similar(v), v, plan)
+    w5, w6 = copy(v), copy(v)
+    Arblib.fft!(w5, w5)
+    Arblib.fft!(w6, w6, plan)
+
+    @test allequal((w1, w2, w3, w4, w5, w6))
+
+    v1 = Arblib.ifft(w1)
+    v2 = Arblib.ifft(w2, plan)
+    v3 = Arblib.ifft!(similar(w3), w3)
+    v4 = Arblib.ifft!(similar(w4), w4, plan)
+    v5, v6 = copy(w5), copy(w6)
+    Arblib.ifft!(v5, v5)
+    Arblib.ifft!(v6, v6, plan)
+
+    @test allequal((v1, v2, v3, v4, v5, v6))
+    @test Arblib.overlaps(v, v1)
+
+    # Check the normalization. The forward transform is unnormalized
+    # and the inverse transform has a factor 1 / m. For a constant
+    # input this gives
+    # fft([c, c, ..., c]) == [m * c, 0, ..., 0] and
+    # ifft([c, c, ..., c]) == [c, 0, ..., 0].
+    let m = 8, c = 3
+        u = AcbVector(fill(c, m))
+
+        w = Arblib.fft(u)
+        @test Arblib.contains(w[1], Acb(m * c))
+        @test all(i -> Arblib.contains_zero(w[i]), 2:m)
+
+        z = Arblib.ifft(u)
+        @test Arblib.contains(z[1], Acb(c))
+        @test all(i -> Arblib.contains_zero(z[i]), 2:m)
+    end
+
+    # Special cases
+    @test isempty(Arblib.fft(AcbVector(0)))
+    @test isempty(Arblib.fft!(AcbVector(0), AcbVector(0)))
+    @test isempty(Arblib.ifft(AcbVector(0)))
+    @test isempty(Arblib.ifft!(AcbVector(0), AcbVector(0)))
+
+    @test precision(Arblib.fft(AcbVector(8, prec = 80))) == 80
+    @test precision(Arblib.ifft(AcbVector(8, prec = 80))) == 80
+    # It uses the precision from the vector, rather than the plan
+    @test precision(Arblib.fft(AcbVector(8, prec = 80), AcbFFTPlan(8, prec = 90))) == 80
+    @test precision(Arblib.ifft(AcbVector(8, prec = 80), AcbFFTPlan(8, prec = 90))) == 80
+
+    # Test errors
+    @test_throws DimensionMismatch Arblib.fft!(AcbVector(1), AcbVector(2))
+    @test_throws DimensionMismatch Arblib.fft!(AcbVector(1), AcbVector(1), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.fft!(AcbVector(1), AcbVector(2), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.fft!(AcbVector(2), AcbVector(1), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.fft!(AcbVector(1), AcbVector(2), AcbFFTPlan(3))
+
+    @test_throws DimensionMismatch Arblib.ifft!(AcbVector(1), AcbVector(2))
+    @test_throws DimensionMismatch Arblib.ifft!(AcbVector(1), AcbVector(1), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.ifft!(AcbVector(1), AcbVector(2), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.ifft!(AcbVector(2), AcbVector(1), AcbFFTPlan(2))
+    @test_throws DimensionMismatch Arblib.ifft!(AcbVector(1), AcbVector(2), AcbFFTPlan(3))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ DocMeta.setdocmeta!(Arblib, :DocTestSetup, :(using Arblib); recursive = true)
     include("poly.jl")
     include("series.jl")
     include("special-functions.jl")
+    include("fft.jl")
     include("threading.jl")
     include("forward_diff.jl")
 end


### PR DESCRIPTION
This adds a high level interface to the FFT code of Flint. It depends on the currently unreleased version of Flint, more precisely the changes in [#2774](https://github.com/flintlib/flint/pull/2774), so the tests will not pass here. It currently includes a temporary commit related to reparsing the Flint documentation, once the next version of Flint is released this should be regenerated.

Note that Flint refers to FFTs as DFT. We here follow the Julia standard of referring to them as FFT. This could possibly be mentioned in the documentation.